### PR TITLE
Fix #1: Add jboss-deployment-structure.xml file

### DIFF
--- a/docs/Deploying-Enrollment-Server.md
+++ b/docs/Deploying-Enrollment-Server.md
@@ -1,0 +1,36 @@
+# Deploying Enrollment Server
+
+This chapter explains how to deploy Enrollment Server.
+
+## Downloading Enrollment Server
+
+You can download the latest `enrollment-server.war` from the [Enrollment Server releases page](https://github.com/wultra/enrollment-server/releases).
+
+## Configuring Enrollment Server
+
+The default implementation of a Enrollment Server has only one compulsory configuration parameter `powerauth.service.url` that configures the SOAP endpoint location of a PowerAuth Server. The default value for this property points to `localhost`:
+
+```bash
+powerauth.service.url=http://localhost:8080/powerauth-java-server/soap
+```
+
+## Setting Up SOAP Service Credentials
+
+_(optional)_ In case Enrollment Server uses a [restricted access flag in the server configuration](https://github.com/wultra/powerauth-server/blob/develop/docs/Deploying-PowerAuth-Server.md#enabling-powerauth-server-security), you need to configure credentials for the Enrollment Server so that it can connect to the SOAP service:
+
+```sh
+powerauth.service.security.clientToken=
+powerauth.service.security.clientSecret=
+```
+
+## Deploying Enrollment Server
+
+You can deploy Enrollment Server into any Java EE container.
+
+The default configuration works best with Apache Tomcat server running on default port 8080. In this case, the deployed server is accessible on `http://localhost:8080/enrollment-server/`.
+
+To deploy Enrollment Server to Apache Tomcat, simply copy the WAR file in your `webapps` folder or deploy it using the "Tomcat Web Application Manager" application (usually deployed on default Tomcat address `http://localhost:8080/manager`).
+
+## Deploying Enrollment Server On JBoss / Wildfly
+
+Follow the extra instructions in chapter [Deploying Enrollment Server on JBoss / Wildfly](./Deploying-Wildfly.md).

--- a/docs/Deploying-Wildfly.md
+++ b/docs/Deploying-Wildfly.md
@@ -1,0 +1,94 @@
+# Deploying Enrollment Server on JBoss / Wildfly
+
+## JBoss Deployment Descriptor 
+
+Enrollment Server contains the following configuration in `jboss-deployment-structure.xml` file for JBoss:
+
+```
+<?xml version="1.0"?>
+<jboss-deployment-structure xmlns="urn:jboss:deployment-structure:1.2">
+	<deployment>
+		<exclude-subsystems>
+			<!-- disable the logging subsystem because the application manages its own logging independently -->
+			<subsystem name="logging" />
+		</exclude-subsystems>
+
+		<dependencies>
+			<module name="com.wultra.powerauth.enrollment-server.conf" />
+		</dependencies>
+		<local-last value="true" />
+	</deployment>
+</jboss-deployment-structure>
+```
+
+The deployment descriptor requires configuration of the `com.wultra.powerauth.enrollment-server.conf` module.
+
+## JBoss Module for Enrollment Server Configuration
+
+Create a new module in `PATH_TO_JBOSS/modules/system/layers/base/com/wultra/powerauth/enrollment-server/conf/main`.
+
+The files described below should be added into this folder.
+
+### Main Module Configuration
+
+The `module.xml` configuration is used for module registration. It also adds resources from the module folder to classpath:
+```
+<?xml version="1.0" encoding="UTF-8"?>
+<module xmlns="urn:jboss:module:1.3" name="com.wultra.powerauth.enrollment-server.conf">
+    <resources>
+        <resource-root path="." />
+    </resources>
+</module>
+```
+
+### Logging Configuration
+
+Use the `logback.xml` file to configure logging, for example:
+```
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration scan="true" scanPeriod="30 seconds">
+
+        <property name="LOG_FILE_DIR" value="/var/log/powerauth" />
+        <property name="LOG_FILE_NAME" value="enrollment-server" />
+        <property name="INSTANCE_ID" value="${jboss.server.name}" />
+
+        <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+                <file>${LOG_FILE_DIR}/${LOG_FILE_NAME}-${INSTANCE_ID}.log</file>
+                <immediateFlush>true</immediateFlush>
+                <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+                        <fileNamePattern>${LOG_FILE_DIR}/${LOG_FILE_NAME}-${INSTANCE_ID}-%d{yyyy-MM-dd}-%i.log</fileNamePattern>
+                        <maxFileSize>10MB</maxFileSize>
+                        <maxHistory>5</maxHistory>
+                        <totalSizeCap>100MB</totalSizeCap>
+                </rollingPolicy>
+                <encoder>
+                        <charset>UTF-8</charset>
+                        <pattern>%d{ISO8601} [%thread] %-5level %logger{36} - %msg%n</pattern>
+                </encoder>
+        </appender>
+
+        <logger name="com.wultra" level="INFO" />
+        <logger name="io.getlime" level="INFO" />
+
+        <root level="INFO">
+                <appender-ref ref="FILE" />
+        </root>
+</configuration>
+```
+
+### Application Configuration
+
+The `application-ext.properties` file is used to override default configuration properties, for example:
+```
+# PowerAuth 2.0 Client configuration
+powerauth.service.url=http://[host]:[port]/powerauth-java-server/soap
+```
+
+Enrollment Server Spring application uses the `ext` Spring profile which activates overriding of default properties by `application-ext.properties`.
+
+### Bouncy Castle Installation
+
+The Bouncy Castle module for JBoss / Wildfly needs to be enabled as a global module for Enrollment Server.
+
+Follow the instructions in the [Installing Bouncy Castle](https://github.com/wultra/powerauth-server/blob/develop/docs/Installing-Bouncy-Castle.md) chapter of PowerAuth Server documentation. 
+Note that the instructions differ based on Java version and application server type.

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -1,0 +1,8 @@
+# PowerAuth Enrollment Server Documentation
+
+PowerAuth Enrollment Server is an easy to deploy backend service used for bootstrapping PowerAuth integration.
+
+## Deployment Tutorials
+
+- [Deploying Enrollment Server](./Deploying-Enrollment-Server.md)
+- [Deploying Enrollment Server on JBoss/Wildfly](./Deploying-Wildfly.md)

--- a/docs/_Sidebar.md
+++ b/docs/_Sidebar.md
@@ -1,0 +1,4 @@
+**Deployment Tutorials**
+
+- [Deploying Enrollment Server](./Deploying-Enrollment-Server.md)
+- [Deploying Enrollment Server on JBoss/Wildfly](./Deploying-Wildfly.md)

--- a/src/main/java/com/wultra/app/enrollmentserver/configuration/PowerAuthWebServiceConfiguration.java
+++ b/src/main/java/com/wultra/app/enrollmentserver/configuration/PowerAuthWebServiceConfiguration.java
@@ -21,6 +21,7 @@ package com.wultra.app.enrollmentserver.configuration;
 import io.getlime.security.powerauth.soap.spring.client.PowerAuthServiceClient;
 import org.apache.wss4j.dom.WSConstants;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -34,6 +35,7 @@ import org.springframework.ws.soap.security.wss4j2.Wss4jSecurityInterceptor;
  * @author Petr Dvorak, petr@wultra.com
  */
 @Configuration
+@ConfigurationProperties("ext")
 @ComponentScan(basePackages = {"io.getlime.security.powerauth"})
 public class PowerAuthWebServiceConfiguration {
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,6 +16,10 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+# Allow externalization of properties using application-ext.properties
+spring.profiles.active=ext
+
+# PowerAuth service configuration
 powerauth.service.url=http://localhost:8080/powerauth-java-server/soap
 powerauth.service.security.clientToken=
 powerauth.service.security.clientSecret=


### PR DESCRIPTION
This pull request adds the deployment descriptor for JBoss / Wildfly and activates the `ext` profile to allow overriding of `application.properties`. It also includes documentation updates especially about deploying on JBoss / Wildfly.