### PR TITLE
Optional sample activation code handler

### DIFF
--- a/enrollment-server/pom.xml
+++ b/enrollment-server/pom.xml
@@ -25,13 +25,13 @@
     <description>Base implementation of the enrollment server.</description>
 
     <artifactId>enrollment-server</artifactId>
-    <version>1.1.0</version>
+    <version>1.2.0-SNAPSHOT</version>
     <packaging>war</packaging>
 
     <parent>
         <groupId>com.wultra.security</groupId>
         <artifactId>enrollment-server-parent</artifactId>
-        <version>1.1.0</version>
+        <version>1.2.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -41,17 +41,17 @@
         <dependency>
             <groupId>com.wultra.security</groupId>
             <artifactId>mtoken-model</artifactId>
-            <version>1.1.0</version>
+            <version>1.2.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.getlime.security</groupId>
             <artifactId>powerauth-restful-security-spring</artifactId>
-            <version>1.1.0</version>
+            <version>1.2.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.getlime.security</groupId>
             <artifactId>powerauth-push-client</artifactId>
-            <version>1.1.0</version>
+            <version>1.2.0-SNAPSHOT</version>
         </dependency>
 
         <!-- Bouncy Castle -->

--- a/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/demo/DelegatingActivationCodeHandlerDemo.java
+++ b/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/demo/DelegatingActivationCodeHandlerDemo.java
@@ -1,0 +1,77 @@
+/*
+ * PowerAuth Enrollment Server
+ * Copyright (C) 2021 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.wultra.app.enrollmentserver.demo;
+
+import com.wultra.app.enrollmentserver.impl.service.DelegatingActivationCodeHandler;
+import com.wultra.security.powerauth.client.PowerAuthClient;
+import com.wultra.security.powerauth.client.model.error.PowerAuthClientException;
+import com.wultra.security.powerauth.client.v3.GetApplicationListResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * Delegating activation code handler demo.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+@Component
+public class DelegatingActivationCodeHandlerDemo implements DelegatingActivationCodeHandler {
+
+    private static final Logger logger = LoggerFactory.getLogger(DelegatingActivationCodeHandlerDemo.class);
+
+    private final PowerAuthClient powerAuthClient;
+
+    @Autowired
+    public DelegatingActivationCodeHandlerDemo(PowerAuthClient powerAuthClient) {
+        this.powerAuthClient = powerAuthClient;
+    }
+
+    @Override
+    public Long fetchDestinationApplicationId(String applicationId, Long sourceAppId, List<String> activationFlags, List<String> applicationRoles) {
+        logger.info("Destination application ID requested in activation code handler for application: {}, source application ID: {}", applicationId, sourceAppId);
+        try {
+            List<GetApplicationListResponse.Applications> appList = powerAuthClient.getApplicationList();
+            for (GetApplicationListResponse.Applications app : appList) {
+                if (app.getApplicationName().equals(applicationId)) {
+                    logger.info("Destination application ID was resolved: {}", app.getId());
+                    return app.getId();
+                }
+            }
+        } catch (PowerAuthClientException ex) {
+            logger.error(ex.getMessage(), ex);
+        }
+        logger.error("Destination application was not found: {}", applicationId);
+        return null;
+    }
+
+    @Override
+    public List<String> addActivationFlags(String sourceActivationId, List<String> sourceActivationFlags, String userId, Long sourceAppId, List<String> sourceApplicationRoles, Long destinationAppId, String destinationActivationId, String activationCode, String activationCodeSignature) {
+        logger.info("No activation flags will be added by activation code handler for activation ID: {}", destinationActivationId);
+        return null;
+    }
+
+    @Override
+    public void didReturnActivationCode(String sourceActivationId, String userId, Long sourceAppId, Long destinationAppId, String destinationActivationId, String activationCode, String activationCodeSignature) {
+        logger.info("Activation was successfully created in activation code handler, activation ID: {}, activation code: {}", destinationActivationId, activationCode);
+    }
+}

--- a/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/impl/handler/SampleDelegatingActivationCodeHandler.java
+++ b/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/impl/handler/SampleDelegatingActivationCodeHandler.java
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.wultra.app.enrollmentserver.demo;
+package com.wultra.app.enrollmentserver.impl.handler;
 
 import com.wultra.app.enrollmentserver.impl.service.DelegatingActivationCodeHandler;
 import com.wultra.security.powerauth.client.PowerAuthClient;
@@ -25,24 +25,29 @@ import com.wultra.security.powerauth.client.v3.GetApplicationListResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
 
 /**
- * Delegating activation code handler demo.
+ * Delegating activation code handler demonstration sample.
  *
  * @author Roman Strobl, roman.strobl@wultra.com
  */
 @Component
-public class DelegatingActivationCodeHandlerDemo implements DelegatingActivationCodeHandler {
+@ConditionalOnProperty(
+        value = "enrollment-server.activation-spawn.sample-handler.enabled",
+        havingValue = "true"
+)
+public class SampleDelegatingActivationCodeHandler implements DelegatingActivationCodeHandler {
 
-    private static final Logger logger = LoggerFactory.getLogger(DelegatingActivationCodeHandlerDemo.class);
+    private static final Logger logger = LoggerFactory.getLogger(SampleDelegatingActivationCodeHandler.class);
 
     private final PowerAuthClient powerAuthClient;
 
     @Autowired
-    public DelegatingActivationCodeHandlerDemo(PowerAuthClient powerAuthClient) {
+    public SampleDelegatingActivationCodeHandler(PowerAuthClient powerAuthClient) {
         this.powerAuthClient = powerAuthClient;
     }
 

--- a/enrollment-server/src/main/resources/application.properties
+++ b/enrollment-server/src/main/resources/application.properties
@@ -74,3 +74,4 @@ powerauth.service.security.clientSecret=
 # Enrollment Server Configuration
 enrollment-server.mtoken.enabled=true
 enrollment-server.activation-spawn.enabled=false
+enrollment-server.activation-spawn.sample-handler.enabled=false

--- a/mtoken-model/pom.xml
+++ b/mtoken-model/pom.xml
@@ -6,12 +6,12 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>mtoken-model</artifactId>
     <groupId>com.wultra.security</groupId>
-    <version>1.1.0</version>
+    <version>1.2.0-SNAPSHOT</version>
 
     <parent>
         <artifactId>enrollment-server-parent</artifactId>
         <groupId>com.wultra.security</groupId>
-        <version>1.1.0</version>
+        <version>1.2.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>com.wultra.security</groupId>
     <artifactId>enrollment-server-parent</artifactId>
-    <version>1.1.0</version>
+    <version>1.2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>


### PR DESCRIPTION
This pull request integrates the sample activation code handler into `develop`. The component is disabled by default. It can be enabled for testing purposes using property `enrollment-server.activation-spawn.sample-handler.enabled`.

The purpose of this pull request is to integrate the sample handler into enrollment server code so that we do not need to maintain a separate branch for testing the activation using activation code and OTP and can activate this feature easily using a property.