### PR TITLE
Reset identity verification process during cleanup

### DIFF
--- a/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/impl/service/IdentityVerificationResetService.java
+++ b/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/impl/service/IdentityVerificationResetService.java
@@ -1,0 +1,88 @@
+/*
+ * PowerAuth Enrollment Server
+ * Copyright (C) 2021 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.wultra.app.enrollmentserver.impl.service;
+
+import com.wultra.app.enrollmentserver.errorhandling.DocumentVerificationException;
+import com.wultra.app.enrollmentserver.model.integration.OwnerId;
+import com.wultra.security.powerauth.client.PowerAuthClient;
+import com.wultra.security.powerauth.client.model.error.PowerAuthClientException;
+import com.wultra.security.powerauth.client.v3.ListActivationFlagsResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Service implementing reset of identity verification.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+@Service
+public class IdentityVerificationResetService {
+
+    private static final Logger logger = LoggerFactory.getLogger(IdentityVerificationResetService.class);
+
+    private static final String ACTIVATION_FLAG_VERIFICATION_PENDING = "VERIFICATION_PENDING";
+    private static final String ACTIVATION_FLAG_VERIFICATION_IN_PROGRESS = "VERIFICATION_IN_PROGRESS";
+
+    /**
+     * PowerAuth client.
+     */
+    private final PowerAuthClient powerAuthClient;
+
+    /**
+     * Service constructor.
+     * @param powerAuthClient PowerAuth client.
+     */
+    @Autowired
+    public IdentityVerificationResetService(PowerAuthClient powerAuthClient) {
+        this.powerAuthClient = powerAuthClient;
+    }
+
+    /**
+     * Reset identity verification by setting activation flag to VERIFICATION_PENDING.
+     *
+     * @param ownerId Owner identification.
+     * @throws DocumentVerificationException Thrown in case communication with PowerAuth server fails.
+     */
+    public void resetIdentityVerification(OwnerId ownerId) throws DocumentVerificationException {
+        try {
+            ListActivationFlagsResponse response = powerAuthClient.listActivationFlags(ownerId.getActivationId());
+
+            List<String> activationFlags = new ArrayList<>(response.getActivationFlags());
+            // Remove flag VERIFICATION_IN_PROGRESS
+            activationFlags.remove(ACTIVATION_FLAG_VERIFICATION_IN_PROGRESS);
+
+            // Add flag VERIFICATION_PENDING to restart the identity verification process
+            if (!activationFlags.contains(ACTIVATION_FLAG_VERIFICATION_PENDING)) {
+                activationFlags.add(ACTIVATION_FLAG_VERIFICATION_PENDING);
+            }
+
+            powerAuthClient.updateActivationFlags(ownerId.getActivationId(), activationFlags);
+        } catch (PowerAuthClientException ex) {
+            logger.warn("Activation flag request failed, error: {}", ex.getMessage());
+            logger.debug(ex.getMessage(), ex);
+            throw new DocumentVerificationException("Communication with PowerAuth server failed");
+        }
+    }
+
+}

--- a/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/impl/service/IdentityVerificationService.java
+++ b/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/impl/service/IdentityVerificationService.java
@@ -62,20 +62,14 @@ public class IdentityVerificationService {
     private static final Logger logger = LoggerFactory.getLogger(IdentityVerificationService.class);
 
     private final IdentityVerificationConfig identityVerificationConfig;
-
     private final DocumentDataRepository documentDataRepository;
-
     private final DocumentVerificationRepository documentVerificationRepository;
-
     private final IdentityVerificationRepository identityVerificationRepository;
-
     private final DocumentProcessingService documentProcessingService;
-
     private final IdentityVerificationCreateService identityVerificationCreateService;
-
     private final VerificationProcessingService verificationProcessingService;
-
     private final DocumentVerificationProvider documentVerificationProvider;
+    private final IdentityVerificationResetService identityVerificationResetService;
 
     /**
      * Service constructor.
@@ -87,6 +81,7 @@ public class IdentityVerificationService {
      * @param identityVerificationCreateService Identity verification create service.
      * @param verificationProcessingService Verification processing service.
      * @param documentVerificationProvider Document verification provider.
+     * @param identityVerificationResetService Identity verification reset service.
      */
     @Autowired
     public IdentityVerificationService(
@@ -97,16 +92,16 @@ public class IdentityVerificationService {
             DocumentProcessingService documentProcessingService,
             IdentityVerificationCreateService identityVerificationCreateService,
             VerificationProcessingService verificationProcessingService,
-            DocumentVerificationProvider documentVerificationProvider) {
+            DocumentVerificationProvider documentVerificationProvider, IdentityVerificationResetService identityVerificationResetService) {
         this.identityVerificationConfig = identityVerificationConfig;
         this.documentDataRepository = documentDataRepository;
         this.documentVerificationRepository = documentVerificationRepository;
         this.identityVerificationRepository = identityVerificationRepository;
-
         this.documentProcessingService = documentProcessingService;
         this.identityVerificationCreateService = identityVerificationCreateService;
         this.verificationProcessingService = verificationProcessingService;
         this.documentVerificationProvider = documentVerificationProvider;
+        this.identityVerificationResetService = identityVerificationResetService;
     }
 
     /**
@@ -350,6 +345,8 @@ public class IdentityVerificationService {
         documentVerificationRepository.failInProgressVerifications(ownerId.getActivationId(), ownerId.getTimestamp());
         // Set status of all in-progress identity verifications to failed
         identityVerificationRepository.failInProgressVerifications(ownerId.getActivationId(), ownerId.getTimestamp());
+        // Reset activation flags, the client is expected to call /api/identity/init for the next round of verification
+        identityVerificationResetService.resetIdentityVerification(ownerId);
     }
 
     /**


### PR DESCRIPTION
The activation flags are reset during cleanup, allowing the next round of identity verification process. The client should call `/api/identity/init` to continue with the next round.