### PR TITLE
Fix #95: Add applicationId (the string ID sent from client) to all callback methods

### DIFF
--- a/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/impl/service/ActivationCodeService.java
+++ b/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/impl/service/ActivationCodeService.java
@@ -125,13 +125,13 @@ public class ActivationCodeService {
 
             // Notify systems about newly created activation
             delegatingActivationCodeHandler.didReturnActivationCode(
-                    sourceActivationId, sourceUserId, sourceAppId, destinationAppId,
+                    sourceActivationId, sourceUserId, applicationId, sourceAppId, destinationAppId,
                     iar.getActivationId(), iar.getActivationCode(), iar.getActivationSignature()
             );
 
             // Add the activation flags
             final List<String> flags = delegatingActivationCodeHandler.addActivationFlags(
-                    sourceActivationId, sourceActivationFlags, sourceUserId, sourceAppId, sourceApplicationRoles, destinationAppId,
+                    sourceActivationId, sourceActivationFlags, applicationId, sourceUserId, sourceAppId, sourceApplicationRoles, destinationAppId,
                     iar.getActivationId(), iar.getActivationCode(), iar.getActivationSignature()
             );
             if (flags != null && !flags.isEmpty()) {

--- a/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/impl/service/DelegatingActivationCodeHandler.java
+++ b/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/impl/service/DelegatingActivationCodeHandler.java
@@ -17,6 +17,8 @@
  */
 package com.wultra.app.enrollmentserver.impl.service;
 
+import com.wultra.app.enrollmentserver.errorhandling.ActivationCodeException;
+
 import java.util.List;
 
 /**
@@ -36,8 +38,9 @@ public interface DelegatingActivationCodeHandler {
      * @param activationFlags Activation flags.
      * @param applicationRoles Application roles.
      * @return Destination application ID.
+     * @throws ActivationCodeException Thrown in case destination application ID could not be retrieved.
      */
-    Long fetchDestinationApplicationId(String applicationId, Long sourceAppId, List<String> activationFlags, List<String> applicationRoles);
+    Long fetchDestinationApplicationId(String applicationId, Long sourceAppId, List<String> activationFlags, List<String> applicationRoles) throws ActivationCodeException;
 
     /**
      * Callback method to add new activation flags to activation.
@@ -53,8 +56,9 @@ public interface DelegatingActivationCodeHandler {
      * @param activationCode Activation code of the new activation.
      * @param activationCodeSignature Activation code signature of the new activation code.
      * @return List of new activation flags for the destination activation.
+     * @throws ActivationCodeException Thrown in case activation flag processing fails.
      */
-    List<String> addActivationFlags(String sourceActivationId, List<String> sourceActivationFlags, String userId, String applicationId, Long sourceAppId, List<String> sourceApplicationRoles, Long destinationAppId, String destinationActivationId, String activationCode, String activationCodeSignature);
+    List<String> addActivationFlags(String sourceActivationId, List<String> sourceActivationFlags, String userId, String applicationId, Long sourceAppId, List<String> sourceApplicationRoles, Long destinationAppId, String destinationActivationId, String activationCode, String activationCodeSignature) throws ActivationCodeException;
 
     /**
      * Callback method with newly created activation code information.
@@ -67,7 +71,8 @@ public interface DelegatingActivationCodeHandler {
      * @param destinationActivationId Destination activation ID (the activation ID of the new activation).
      * @param activationCode Activation code of the new activation.
      * @param activationCodeSignature Activation code signature of the new activation code.
+     * @throws ActivationCodeException Thrown in case activation code processing fails.
      */
-    void didReturnActivationCode(String sourceActivationId, String userId, String applicationId, Long sourceAppId, Long destinationAppId, String destinationActivationId, String activationCode, String activationCodeSignature);
+    void didReturnActivationCode(String sourceActivationId, String userId, String applicationId, Long sourceAppId, Long destinationAppId, String destinationActivationId, String activationCode, String activationCodeSignature) throws ActivationCodeException;
 
 }

--- a/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/impl/service/DelegatingActivationCodeHandler.java
+++ b/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/impl/service/DelegatingActivationCodeHandler.java
@@ -45,27 +45,29 @@ public interface DelegatingActivationCodeHandler {
      * @param sourceActivationId Source activation ID (activation used to fetch the code).
      * @param sourceActivationFlags Source activation flags (flags of the activation that initiated the transfer).
      * @param userId User ID (user ID who requested the activation).
+     * @param applicationId Application identifier which was used for app lookup (String identifier sent from client).
      * @param sourceAppId Source app ID (the app that initiated the process).
-     * @param sourceApplicationRoles Source application roles (roles of the app that intiated the transfer).
+     * @param sourceApplicationRoles Source application roles (roles of the app that initiated the transfer).
      * @param destinationAppId Destination app ID (the app that is to be activated).
      * @param destinationActivationId Destination activation ID (the activation ID of the new activation).
      * @param activationCode Activation code of the new activation.
      * @param activationCodeSignature Activation code signature of the new activation code.
      * @return List of new activation flags for the destination activation.
      */
-    List<String> addActivationFlags(String sourceActivationId, List<String> sourceActivationFlags, String userId, Long sourceAppId, List<String> sourceApplicationRoles, Long destinationAppId, String destinationActivationId, String activationCode, String activationCodeSignature);
+    List<String> addActivationFlags(String sourceActivationId, List<String> sourceActivationFlags, String userId, String applicationId, Long sourceAppId, List<String> sourceApplicationRoles, Long destinationAppId, String destinationActivationId, String activationCode, String activationCodeSignature);
 
     /**
      * Callback method with newly created activation code information.
      *
      * @param sourceActivationId Source activation ID (activation used to fetch the code).
      * @param userId User ID (user ID who requested the activation).
+     * @param applicationId Application identifier which was used for app lookup (String identifier sent from client).
      * @param sourceAppId Source app ID (the app that initiated the process).
      * @param destinationAppId Destination app ID (the app that is to be activated).
      * @param destinationActivationId Destination activation ID (the activation ID of the new activation).
      * @param activationCode Activation code of the new activation.
      * @param activationCodeSignature Activation code signature of the new activation code.
      */
-    void didReturnActivationCode(String sourceActivationId, String userId, Long sourceAppId, Long destinationAppId, String destinationActivationId, String activationCode, String activationCodeSignature);
+    void didReturnActivationCode(String sourceActivationId, String userId, String applicationId, Long sourceAppId, Long destinationAppId, String destinationActivationId, String activationCode, String activationCodeSignature);
 
 }


### PR DESCRIPTION
I added the parameter, please check the Javadoc if it can be further improved because there are 3 application identifiers present in the methods.