### PR TITLE
Allow run of swagger codegen on JDK16

### DIFF
--- a/enrollment-server/pom.xml
+++ b/enrollment-server/pom.xml
@@ -180,6 +180,13 @@
                 <groupId>io.swagger.codegen.v3</groupId>
                 <artifactId>swagger-codegen-maven-plugin</artifactId>
                 <version>${maven-swagger-codegen-plugin.version}</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.github.jknack</groupId>
+                        <artifactId>handlebars</artifactId>
+                        <version>${maven-swagger-codegen-handlebars.version}</version>
+                    </dependency>
+                </dependencies>
                 <executions>
                     <execution>
                         <id>swagger-definitions-iproov</id>

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,7 @@
         <maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>
         <maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
         <maven-swagger-codegen-plugin.version>3.0.29</maven-swagger-codegen-plugin.version>
+        <maven-swagger-codegen-handlebars.version>4.3.0</maven-swagger-codegen-handlebars.version>
 
         <db-h2.version>1.4.200</db-h2.version>
         <swagger-annotations.version>2.1.11</swagger-annotations.version>


### PR DESCRIPTION
- Swagger codegen was failing during the build
- https://github.com/swagger-api/swagger-codegen/issues/10966
- Fixed by setting direct dependency on latest handlebars 4.3.0 library