### PR TITLE
Implement presence check restarts with an already enrolled photo

### DIFF
--- a/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/database/entity/IdentityVerificationEntity.java
+++ b/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/database/entity/IdentityVerificationEntity.java
@@ -20,15 +20,15 @@ package com.wultra.app.enrollmentserver.database.entity;
 
 import com.wultra.app.enrollmentserver.model.enumeration.IdentityVerificationPhase;
 import com.wultra.app.enrollmentserver.model.enumeration.IdentityVerificationStatus;
-import lombok.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 import org.hibernate.annotations.GenericGenerator;
 
 import javax.persistence.*;
 import java.io.Serializable;
-import java.util.Date;
-import java.util.LinkedHashSet;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 
 /**
  * Entity representing identity verification.
@@ -96,4 +96,22 @@ public class IdentityVerificationEntity implements Serializable {
     public int hashCode() {
         return Objects.hash(activationId, timestampCreated);
     }
+
+    /**
+     * Checks if the presence check was initialized or not
+     * <p>
+     *     Any of the statuses [{@link IdentityVerificationStatus#FAILED},
+     *     {@link IdentityVerificationStatus#IN_PROGRESS}, {@link IdentityVerificationStatus#REJECTED}]
+     *     means an already initialized presence check.
+     * </p>
+     * @return true when the presence check is already initialized
+     */
+    @Transient
+    public boolean isPresenceCheckInitialized() {
+        return IdentityVerificationPhase.PRESENCE_CHECK.equals(phase) &&
+                List.of(IdentityVerificationStatus.FAILED,
+                        IdentityVerificationStatus.IN_PROGRESS,
+                        IdentityVerificationStatus.REJECTED).contains(status);
+    }
+
 }

--- a/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/impl/service/IdentityVerificationStatusService.java
+++ b/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/impl/service/IdentityVerificationStatusService.java
@@ -123,7 +123,7 @@ public class IdentityVerificationStatusService {
                 try {
                     presenceCheckResult =
                             presenceCheckService.checkPresenceVerification(apiAuthentication, idVerification, sessionInfo);
-                } catch (DocumentVerificationException | PresenceCheckException e) {
+                } catch (PresenceCheckException e) {
                     logger.error("Checking presence verification failed, " + ownerId, e);
                     idVerification.setErrorDetail(e.getMessage());
                     idVerification.setStatus(IdentityVerificationStatus.FAILED);

--- a/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/impl/service/PresenceCheckService.java
+++ b/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/impl/service/PresenceCheckService.java
@@ -89,7 +89,7 @@ public class PresenceCheckService {
      * Initializes presence check process.
      *
      * @param apiAuthentication Authentication object.
-     * @return Session info with data needed to start the presence check process
+     * @return Session info with data needed to perform the presence check process
      * @throws DocumentVerificationException When an error during obtaining the user personal image occurred
      * @throws PresenceCheckException When an error during initializing the presence check occurred
      */
@@ -97,57 +97,23 @@ public class PresenceCheckService {
     public SessionInfo init(PowerAuthApiAuthentication apiAuthentication)
             throws DocumentVerificationException, PresenceCheckException {
         OwnerId ownerId = PowerAuthUtil.getOwnerId(apiAuthentication);
+        IdentityVerificationEntity idVerification = fetchIdVerification(ownerId);
 
-        Optional<IdentityVerificationEntity> idVerificationOptional = identityVerificationService.findBy(ownerId);
-        if (!idVerificationOptional.isPresent()) {
-            logger.error("No identity verification entity found to initialize the presence check, {}", ownerId);
-            throw new PresenceCheckException("Unable to initialize presence check");
+        if (!idVerification.isPresenceCheckInitialized()) {
+            // TODO - use a better way to locate the photo to be used in presence check
+            Optional<DocumentVerificationEntity> docVerificationEntityWithPhoto =
+                    documentVerificationRepository.findFirstByActivationIdAndPhotoIdNotNull(ownerId.getActivationId());
+
+            if (docVerificationEntityWithPhoto.isPresent()) {
+                String photoId = docVerificationEntityWithPhoto.get().getPhotoId();
+                Image photo = identityVerificationService.getPhotoById(photoId);
+                presenceCheckProvider.initPresenceCheck(ownerId, photo);
+            } else {
+                logger.error("Missing selfie photo to initialize presence check, {}", ownerId);
+                throw new PresenceCheckException("Unable to initialize presence check");
+            }
         }
-        IdentityVerificationEntity idVerification = idVerificationOptional.get();
-
-        if (IdentityVerificationPhase.PRESENCE_CHECK.equals(idVerification.getPhase()) &&
-                IdentityVerificationStatus.ACCEPTED.equals(idVerification.getStatus())) {
-            logger.error("The presence check is already accepted, not allowed to initialize it again, {}", ownerId);
-            throw new PresenceCheckException("Unable to initialize presence check");
-        } else if (!IdentityVerificationPhase.DOCUMENT_UPLOAD.equals(idVerification.getPhase())) {
-            logger.error("The verification phase is {} but expected {}, {}",
-                    idVerification.getPhase(), IdentityVerificationPhase.DOCUMENT_UPLOAD, ownerId
-            );
-            throw new PresenceCheckException("Unable to initialize presence check");
-        } else if (!IdentityVerificationStatus.VERIFICATION_PENDING.equals(idVerification.getStatus())) {
-            logger.error("The verification status is {} but expected {}, {}",
-                    idVerification.getStatus(), IdentityVerificationStatus.VERIFICATION_PENDING, ownerId
-            );
-            throw new PresenceCheckException("Unable to initialize presence check");
-        }
-
-        // TODO - use a better way to locate the photo to be used in presence check
-        Optional<DocumentVerificationEntity> docVerificationEntityWithPhoto =
-                documentVerificationRepository.findFirstByActivationIdAndPhotoIdNotNull(ownerId.getActivationId());
-
-        if (docVerificationEntityWithPhoto.isPresent()) {
-            String photoId = docVerificationEntityWithPhoto.get().getPhotoId();
-            Image photo = identityVerificationService.getPhotoById(photoId);
-            presenceCheckProvider.initPresenceCheck(ownerId, photo);
-        } else {
-            logger.error("Missing selfie photo to initialize presence check, {}", ownerId);
-            throw new PresenceCheckException("Unable to initialize presence check");
-        }
-
-        SessionInfo sessionInfo = presenceCheckProvider.startPresenceCheck(ownerId);
-
-        String sessionInfoJson = jsonSerializationService.serialize(sessionInfo);
-        if (sessionInfoJson == null) {
-            logger.error("JSON serialization of session info failed, {}", ownerId);
-            throw new PresenceCheckException("Unable to initialize presence check");
-        }
-
-        idVerification.setSessionInfo(sessionInfoJson);
-        idVerification.setPhase(IdentityVerificationPhase.PRESENCE_CHECK);
-        idVerification.setStatus(IdentityVerificationStatus.IN_PROGRESS);
-        idVerification.setTimestampLastUpdated(ownerId.getTimestamp());
-
-        return sessionInfo;
+        return startPresenceCheck(ownerId, idVerification);
     }
 
     /**
@@ -159,47 +125,54 @@ public class PresenceCheckService {
      * @param apiAuthentication Authentication object.
      * @param sessionInfo Session info with presence check data.
      * @return Result of the presence check
-     * @throws DocumentVerificationException
-     * @throws PresenceCheckException
+     * @throws PresenceCheckException When an error during the presence check verification occurred
      */
     @Transactional
-    public PresenceCheckResult checkPresenceVerification(PowerAuthApiAuthentication apiAuthentication, IdentityVerificationEntity idVerification,  SessionInfo sessionInfo)
-            throws DocumentVerificationException, PresenceCheckException {
+    public PresenceCheckResult checkPresenceVerification(PowerAuthApiAuthentication apiAuthentication,
+                                                         IdentityVerificationEntity idVerification,
+                                                         SessionInfo sessionInfo) throws PresenceCheckException {
         OwnerId ownerId = PowerAuthUtil.getOwnerId(apiAuthentication);
         PresenceCheckResult result = presenceCheckProvider.getResult(ownerId, sessionInfo);
-        if (PresenceCheckStatus.ACCEPTED.equals(result.getStatus())) {
-            Image photo = result.getPhoto();
-            if (photo == null) {
-                logger.error("Missing person photo from presence verification, {}", ownerId);
-                throw new PresenceCheckException("Missing person photo from presence verification");
-            }
 
-            SubmittedDocument submittedDoc = new SubmittedDocument();
-            // TODO use different random id approach
-            submittedDoc.setDocumentId(
-                    Ascii.truncate("selfie-photo-" + ownerId.getActivationId(), 36, "...")
-            );
-            submittedDoc.setPhoto(photo);
-            submittedDoc.setType(DocumentType.SELFIE_PHOTO);
-
-            DocumentVerificationEntity docVerificationEntity = new DocumentVerificationEntity();
-            docVerificationEntity.setActivationId(ownerId.getActivationId());
-            docVerificationEntity.setIdentityVerification(idVerification);
-            docVerificationEntity.setFilename(result.getPhoto().getFilename());
-            docVerificationEntity.setStatus(DocumentStatus.VERIFICATION_PENDING);
-            docVerificationEntity.setTimestampCreated(ownerId.getTimestamp());
-            docVerificationEntity.setType(DocumentType.SELFIE_PHOTO);
-            docVerificationEntity.setUsedForVerification(true);
-
-            DocumentSubmitResult documentSubmitResult =
-                    documentProcessingService.submitDocumentToProvider(ownerId, docVerificationEntity, submittedDoc);
-            docVerificationEntity.setTimestampUploaded(ownerId.getTimestamp());
-            docVerificationEntity.setUploadId(documentSubmitResult.getUploadId());
-
-            documentVerificationRepository.save(docVerificationEntity);
-
-            documentVerificationRepository.setVerificationPending(ownerId.getActivationId(), ownerId.getTimestamp());
+        if (!PresenceCheckStatus.ACCEPTED.equals(result.getStatus())) {
+            logger.info("Not accepted presence check, {}", ownerId);
+            return result;
         }
+        logger.debug("Processing a result of an accepted presence check, {}", ownerId);
+
+        Image photo = result.getPhoto();
+        if (photo == null) {
+            logger.error("Missing person photo from presence verification, {}", ownerId);
+            throw new PresenceCheckException("Missing person photo from presence verification");
+        }
+        logger.debug("Obtained a photo from the result, {}", ownerId);
+
+        SubmittedDocument submittedDoc = new SubmittedDocument();
+        // TODO use different random id approach
+        submittedDoc.setDocumentId(
+                Ascii.truncate("selfie-photo-" + ownerId.getActivationId(), 36, "...")
+        );
+        submittedDoc.setPhoto(photo);
+        submittedDoc.setType(DocumentType.SELFIE_PHOTO);
+
+        DocumentVerificationEntity docVerificationEntity = new DocumentVerificationEntity();
+        docVerificationEntity.setActivationId(ownerId.getActivationId());
+        docVerificationEntity.setIdentityVerification(idVerification);
+        docVerificationEntity.setFilename(result.getPhoto().getFilename());
+        docVerificationEntity.setStatus(DocumentStatus.VERIFICATION_PENDING);
+        docVerificationEntity.setTimestampCreated(ownerId.getTimestamp());
+        docVerificationEntity.setType(DocumentType.SELFIE_PHOTO);
+        docVerificationEntity.setUsedForVerification(true);
+
+        DocumentSubmitResult documentSubmitResult =
+                documentProcessingService.submitDocumentToProvider(ownerId, docVerificationEntity, submittedDoc);
+        docVerificationEntity.setTimestampUploaded(ownerId.getTimestamp());
+        docVerificationEntity.setUploadId(documentSubmitResult.getUploadId());
+
+        documentVerificationRepository.save(docVerificationEntity);
+
+        documentVerificationRepository.setVerificationPending(ownerId.getActivationId(), ownerId.getTimestamp());
+
         return result;
     }
 
@@ -217,6 +190,71 @@ public class PresenceCheckService {
         } else {
             logger.debug("Skipped cleanup of presence check data at the provider (not enabled), {}", ownerId);
         }
+    }
+
+    /**
+     * Starts new presence check process.
+     *
+     * @param ownerId Owner identification.
+     * @param idVerification Verification identity.
+     * @return Session info with data needed to perform the presence check process
+     * @throws PresenceCheckException When an error during starting the presence check process occurred.
+     */
+    private SessionInfo startPresenceCheck(OwnerId ownerId, IdentityVerificationEntity idVerification) throws PresenceCheckException {
+        SessionInfo sessionInfo = presenceCheckProvider.startPresenceCheck(ownerId);
+
+        String sessionInfoJson = jsonSerializationService.serialize(sessionInfo);
+        if (sessionInfoJson == null) {
+            logger.error("JSON serialization of session info failed, {}", ownerId);
+            throw new PresenceCheckException("Unable to initialize presence check");
+        }
+
+        idVerification.setSessionInfo(sessionInfoJson);
+        idVerification.setPhase(IdentityVerificationPhase.PRESENCE_CHECK);
+        idVerification.setStatus(IdentityVerificationStatus.IN_PROGRESS);
+        idVerification.setTimestampLastUpdated(ownerId.getTimestamp());
+
+        return sessionInfo;
+    }
+
+    /**
+     * Fetches a current identity verification for presence check initialization
+     * @param ownerId Owner identification.
+     * @return Verification identity ready to be initialized for the presence check.
+     * @throws PresenceCheckException When an error during validating the identity verification status occurred.
+     */
+    private IdentityVerificationEntity fetchIdVerification(OwnerId ownerId) throws PresenceCheckException {
+        Optional<IdentityVerificationEntity> idVerificationOptional = identityVerificationService.findBy(ownerId);
+        if (!idVerificationOptional.isPresent()) {
+            logger.error("No identity verification entity found to initialize the presence check, {}", ownerId);
+            throw new PresenceCheckException("Unable to initialize presence check");
+        }
+
+        IdentityVerificationEntity idVerification = idVerificationOptional.get();
+
+        if (IdentityVerificationPhase.PRESENCE_CHECK.equals(idVerification.getPhase()) &&
+                IdentityVerificationStatus.ACCEPTED.equals(idVerification.getStatus())) {
+            logger.error("The presence check is already accepted, not allowed to initialize it again, {}", ownerId);
+            throw new PresenceCheckException("Unable to initialize presence check");
+        } else if (IdentityVerificationPhase.PRESENCE_CHECK.equals(idVerification.getPhase()) &&
+                IdentityVerificationStatus.IN_PROGRESS.equals(idVerification.getStatus())) {
+            logger.info("The presence check is currently in progress, ready to be initialized again, {}", ownerId);
+        } else if (IdentityVerificationPhase.PRESENCE_CHECK.equals(idVerification.getPhase()) &&
+                IdentityVerificationStatus.REJECTED.equals(idVerification.getStatus())) {
+            logger.info("The presence check is rejected, ready to be initialized again, {}", ownerId);
+        } else if (!IdentityVerificationPhase.DOCUMENT_UPLOAD.equals(idVerification.getPhase())) {
+            logger.error("The verification phase is {} but expected {}, {}",
+                    idVerification.getPhase(), IdentityVerificationPhase.DOCUMENT_UPLOAD, ownerId
+            );
+            throw new PresenceCheckException("Unable to initialize presence check");
+        } else if (!IdentityVerificationStatus.VERIFICATION_PENDING.equals(idVerification.getStatus())) {
+            logger.error("The verification status is {} but expected {}, {}",
+                    idVerification.getStatus(), IdentityVerificationStatus.VERIFICATION_PENDING, ownerId
+            );
+            throw new PresenceCheckException("Unable to initialize presence check");
+        }
+
+        return idVerification;
     }
 
 }

--- a/enrollment-server/src/test/java/com/wultra/app/presencecheck/iproov/provider/IProovPresenceCheckProviderTest.java
+++ b/enrollment-server/src/test/java/com/wultra/app/presencecheck/iproov/provider/IProovPresenceCheckProviderTest.java
@@ -36,8 +36,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author Lukas Lukovsky, lukas.lukovsky@wultra.com
@@ -88,6 +87,27 @@ public class IProovPresenceCheckProviderTest {
         PresenceCheckResult result = provider.getResult(ownerId, sessionInfo);
 
         assertEquals(PresenceCheckStatus.IN_PROGRESS, result.getStatus());
+    }
+
+    @Test
+    public void repeatPresenceCheckStartTest() throws Exception {
+        initPresenceCheck(ownerId);
+
+        SessionInfo sessionInfo1 = provider.startPresenceCheck(ownerId);
+        assertNotNull(
+                sessionInfo1.getSessionAttributes().get(IProovConst.VERIFICATION_TOKEN),
+                "Missing presence check verification token in session 1"
+        );
+
+        SessionInfo sessionInfo2 = provider.startPresenceCheck(ownerId);
+        assertNotNull(
+                sessionInfo2.getSessionAttributes().get(IProovConst.VERIFICATION_TOKEN),
+                "Missing presence check verification token in session 2"
+        );
+        assertNotEquals(
+                sessionInfo1.getSessionAttributes().get(IProovConst.VERIFICATION_TOKEN),
+                sessionInfo2.getSessionAttributes().get(IProovConst.VERIFICATION_TOKEN),
+                "Same presence check verification tokens between session 1 and session 2");
     }
 
     private OwnerId createOwnerId() {

--- a/enrollment-server/tools/iproov-verify-nextjs/pages/index.js
+++ b/enrollment-server/tools/iproov-verify-nextjs/pages/index.js
@@ -39,7 +39,7 @@ export default function Home() {
                                         <label htmlFor="tokenValue">Token value </label>
                                         <input className="ml-1" id="tokenValue" name="tokenValue" type="text" value={token} onChange={handleChange} autoComplete="off" required />
                                         <button className="ml-1" type="submit">
-                                            <Link href={{pathname: '/verify-token', query: {value: token}}} prefetch={false}>
+                                            <Link href={{pathname: 'verify-token', query: {value: token}}} prefetch={false}>
                                                 <a className="text-reset" target="_blank" rel="noreferrer">Verify</a>
                                             </Link>
                                         </button>


### PR DESCRIPTION
- Allowed repeated starts of already initialized presence check at expected statuses
- Refactored presence check code a little
- Added more logging
- Removed not thrown DocumentVerificationException from checkPresenceVerification
- Added integration test for repeated presence check
- Fixed verify-token context


Updated diagram at https://lucid.app/lucidchart/4e66ce07-cdfc-4505-a284-e71f385a9299/edit?page=0_0&invitationId=inv_6a5fae3f-23c6-46c4-910e-de92dfd69aa0#