### PR TITLE
Changes of OTP delivery based on requirements from mobile application

### DIFF
--- a/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/controller/api/IdentityVerificationController.java
+++ b/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/controller/api/IdentityVerificationController.java
@@ -154,6 +154,7 @@ public class IdentityVerificationController {
      * @throws IdentityVerificationException Thrown when identity verification status fails.
      * @throws RemoteCommunicationException Thrown when communication with PowerAuth server fails.
      * @throws OnboardingProcessException Thrown when onboarding process is invalid.
+     * @throws OnboardingOtpDeliveryException Thrown when OTP could not be sent when changing status.
      */
     @RequestMapping(value = "status", method = RequestMethod.POST)
     @PowerAuthEncryption(scope = EciesScope.ACTIVATION_SCOPE)
@@ -163,7 +164,7 @@ public class IdentityVerificationController {
     public ObjectResponse<IdentityVerificationStatusResponse> checkIdentityVerificationStatus(@EncryptedRequestBody ObjectRequest<IdentityVerificationStatusRequest> request,
                                                                                               @Parameter(hidden = true) EciesEncryptionContext eciesContext,
                                                                                               @Parameter(hidden = true) PowerAuthApiAuthentication apiAuthentication)
-            throws PowerAuthAuthenticationException, PowerAuthEncryptionException, IdentityVerificationException, RemoteCommunicationException, OnboardingProcessException {
+            throws PowerAuthAuthenticationException, PowerAuthEncryptionException, IdentityVerificationException, RemoteCommunicationException, OnboardingProcessException, OnboardingOtpDeliveryException {
         // Check if the authentication object is present
         if (apiAuthentication == null) {
             logger.error("Unable to verify device registration when checking identity verification status");
@@ -387,7 +388,7 @@ public class IdentityVerificationController {
     }
 
     /**
-     * Send or resend OTP code to the user.
+     * Resend OTP code to the user.
      * @param request Presence check initialization request.
      * @param eciesContext ECIES context.
      * @return Send OTP response.
@@ -395,10 +396,10 @@ public class IdentityVerificationController {
      * @throws OnboardingProcessException Thrown when OTP code could not be generated.
      * @throws OnboardingOtpDeliveryException Thrown when OTP code could not be sent.
      */
-    @RequestMapping(value = "otp/send", method = RequestMethod.POST)
+    @RequestMapping(value = "otp/resend", method = RequestMethod.POST)
     @PowerAuthEncryption(scope = EciesScope.ACTIVATION_SCOPE)
-    public Response sendOtp(@EncryptedRequestBody ObjectRequest<IdentityVerificationOtpSendRequest> request,
-                            @Parameter(hidden = true) EciesEncryptionContext eciesContext)
+    public Response resendOtp(@EncryptedRequestBody ObjectRequest<IdentityVerificationOtpSendRequest> request,
+                              @Parameter(hidden = true) EciesEncryptionContext eciesContext)
             throws PowerAuthEncryptionException, OnboardingProcessException, OnboardingOtpDeliveryException {
 
         // Check if the request was correctly decrypted
@@ -413,7 +414,7 @@ public class IdentityVerificationController {
         }
 
         final String processId = request.getRequestObject().getProcessId();
-        identityVerificationOtpService.sendOtpCode(processId);
+        identityVerificationOtpService.sendOtpCode(processId, true);
         return new Response();
     }
 

--- a/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/database/OnboardingOtpRepository.java
+++ b/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/database/OnboardingOtpRepository.java
@@ -36,7 +36,8 @@ import java.util.Optional;
 @Repository
 public interface OnboardingOtpRepository extends CrudRepository<OnboardingOtpEntity, String> {
 
-    @Query("SELECT o FROM OnboardingOtpEntity o WHERE o.process.id = :processId AND o.type = :type ORDER BY o.timestampCreated DESC")
+    @Query("SELECT o FROM OnboardingOtpEntity o WHERE o.process.id = :processId AND o.type = :type AND o.timestampCreated = " +
+            "(SELECT MAX(o2.timestampCreated) FROM OnboardingOtpEntity o2 WHERE o2.process.id = :processId AND o2.type = :type)")
     Optional<OnboardingOtpEntity> findLastOtp(String processId, OtpType type);
 
     @Modifying

--- a/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/impl/service/IdentityVerificationOtpService.java
+++ b/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/impl/service/IdentityVerificationOtpService.java
@@ -75,10 +75,11 @@ public class IdentityVerificationOtpService {
     /**
      * Send or resend an OTP code for a process during identity verification.
      * @param processId Process ID.
+     * @param isResend Whether the OTP code is being resent.
      * @throws OnboardingProcessException Thrown when OTP code could not be generated.
      * @throws OnboardingOtpDeliveryException Thrown when OTP code could not be sent.
      */
-    public void sendOtpCode(String processId) throws OnboardingProcessException, OnboardingOtpDeliveryException {
+    public void sendOtpCode(String processId, boolean isResend) throws OnboardingProcessException, OnboardingOtpDeliveryException {
         if (onboardingProvider == null) {
             logger.error("Onboarding provider is not available. Implement an onboarding provider and make it accessible using autowiring.");
             throw new OnboardingProcessException();
@@ -89,7 +90,6 @@ public class IdentityVerificationOtpService {
             throw new OnboardingProcessException();
         }
         final OnboardingProcessEntity process = processOptional.get();
-        final boolean isResend = otpService.isNextOtpResend(process, OtpType.USER_VERIFICATION);
         // Create an OTP code
         final String otpCode;
         if (isResend) {

--- a/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/impl/service/IdentityVerificationStatusService.java
+++ b/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/impl/service/IdentityVerificationStatusService.java
@@ -107,9 +107,10 @@ public class IdentityVerificationStatusService {
      * @throws IdentityVerificationException Thrown when identity verification could not be started.
      * @throws RemoteCommunicationException Thrown when communication with PowerAuth server fails.
      * @throws OnboardingProcessException Thrown when onboarding process is invalid.
+     * @throws OnboardingOtpDeliveryException Thrown when OTP could not be sent when changing status.
      */
     @Transactional
-    public IdentityVerificationStatusResponse checkIdentityVerificationStatus(IdentityVerificationStatusRequest request, OwnerId ownerId) throws IdentityVerificationException, RemoteCommunicationException, OnboardingProcessException {
+    public IdentityVerificationStatusResponse checkIdentityVerificationStatus(IdentityVerificationStatusRequest request, OwnerId ownerId) throws IdentityVerificationException, RemoteCommunicationException, OnboardingProcessException, OnboardingOtpDeliveryException {
         IdentityVerificationStatusResponse response = new IdentityVerificationStatusResponse();
 
         Optional<IdentityVerificationEntity> idVerificationOptional =

--- a/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/impl/service/OtpService.java
+++ b/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/impl/service/OtpService.java
@@ -81,16 +81,6 @@ public class OtpService {
     }
 
     /**
-     * Get whether the next generated OTP is going to be a resend OTP for given OTP type.
-     * @param process Onboarding process.
-     * @param otpType OTP type.
-     * @return Whether the next generated OTP is going to be a resend OTP for given OTP type.
-     */
-    public boolean isNextOtpResend(OnboardingProcessEntity process, OtpType otpType) {
-        return onboardingOtpRepository.getOtpCount(process.getId(), otpType) > 0;
-    }
-
-    /**
      * Create an OTP code for onboarding process for resend.
      * @param process Onboarding process.
      * @param otpType OTP type.


### PR DESCRIPTION
- Send OTP when changing status automatically.
- Change `otp/send` endpoint to `otp/resend`.
- Return only 1 result when checking OTP detail.