### PR TITLE
Fix #181: ZenId provider changes date serialization for Mobile Token

### DIFF
--- a/enrollment-server/src/main/java/com/wultra/app/docverify/zenid/config/ZenidConfig.java
+++ b/enrollment-server/src/main/java/com/wultra/app/docverify/zenid/config/ZenidConfig.java
@@ -66,11 +66,6 @@ public class ZenidConfig {
         return mapper;
     }
 
-    @Bean
-    public MappingJackson2HttpMessageConverter mappingJackson2HttpMessageConverter(@Qualifier("objectMapperZenid") ObjectMapper mapper) {
-        return new MappingJackson2HttpMessageConverter(mapper);
-    }
-
     /**
      * Prepares REST client specific to ZenID
      * @param configProps Configuration properties


### PR DESCRIPTION
This change fixes date serialization for Mobile Token. Although the Object Mapper was separated, the instance for Zen ID was set globally using `MappingJackson2HttpMessageConverter`.