### PR TITLE
Fix #206: Add OnboardingProviderAutoConfiguration

### DIFF
--- a/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/errorhandling/OnboardingProviderException.java
+++ b/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/errorhandling/OnboardingProviderException.java
@@ -26,4 +26,21 @@ public class OnboardingProviderException extends Exception {
 
     private static final long serialVersionUID = 787256528155796393L;
 
+    /**
+     * No-arg constructor.
+     */
+    public OnboardingProviderException() {
+        super();
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message.
+     * The cause is not initialized, and may subsequently be initialized by a call to initCause.
+     *
+     * @param message – the detail message. The detail message is saved for later retrieval by the getMessage() method.
+     */
+    public OnboardingProviderException(final String message) {
+        super(message);
+    }
+
 }

--- a/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/impl/service/OnboardingService.java
+++ b/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/impl/service/OnboardingService.java
@@ -59,7 +59,7 @@ public class OnboardingService {
     private final IdentityVerificationConfig identityVerificationConfig;
     private final OtpService otpService;
 
-    private OnboardingProvider onboardingProvider;
+    private final OnboardingProvider onboardingProvider;
 
     /**
      * Service constructor.
@@ -70,20 +70,19 @@ public class OnboardingService {
      * @param otpService OTP service.
      */
     @Autowired
-    public OnboardingService(OnboardingProcessRepository onboardingProcessRepository, JsonSerializationService serializer, OnboardingConfig config, IdentityVerificationConfig identityVerificationConfig, OtpService otpService) {
+    public OnboardingService(
+            final OnboardingProcessRepository onboardingProcessRepository,
+            final JsonSerializationService serializer,
+            final OnboardingConfig config,
+            final IdentityVerificationConfig identityVerificationConfig,
+            final OtpService otpService,
+            final OnboardingProvider onboardingProvider) {
+
         this.onboardingProcessRepository = onboardingProcessRepository;
         this.serializer = serializer;
         this.onboardingConfig = config;
         this.identityVerificationConfig = identityVerificationConfig;
         this.otpService = otpService;
-    }
-
-    /**
-     * Set onboarding provider via setter injection.
-     * @param onboardingProvider Onboarding provider.
-     */
-    @Autowired(required = false)
-    public void setOnboardingProvider(OnboardingProvider onboardingProvider) {
         this.onboardingProvider = onboardingProvider;
     }
 
@@ -96,10 +95,6 @@ public class OnboardingService {
      */
     @Transactional
     public OnboardingStartResponse startOnboarding(OnboardingStartRequest request) throws OnboardingProcessException, OnboardingOtpDeliveryException, TooManyProcessesException {
-        if (onboardingProvider == null) {
-            logger.error("Onboarding provider is not available. Implement an onboarding provider and make it accessible using autowiring.");
-            throw new OnboardingProcessException();
-        }
         Map<String, Object> identification = request.getIdentification();
         String identificationData = serializer.serialize(identification);
 
@@ -162,10 +157,6 @@ public class OnboardingService {
      */
     @Transactional
     public Response resendOtp(OnboardingOtpResendRequest request) throws OnboardingProcessException, OnboardingOtpDeliveryException {
-        if (onboardingProvider == null) {
-            logger.error("Onboarding provider is not available. Implement an onboarding provider and make it accessible using autowiring.");
-            throw new OnboardingProcessException();
-        }
         String processId = request.getProcessId();
         OnboardingProcessEntity process = findProcess(processId);
         String userId = process.getUserId();

--- a/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/provider/EmptyOnboardingProvider.java
+++ b/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/provider/EmptyOnboardingProvider.java
@@ -1,0 +1,45 @@
+/*
+ * PowerAuth Enrollment Server
+ * Copyright (C) 2022 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.wultra.app.enrollmentserver.provider;
+
+import com.wultra.app.enrollmentserver.errorhandling.OnboardingProviderException;
+
+import java.util.Map;
+
+/**
+ * Implementation of {@link OnboardingProvider} throwing an exception for each method.
+ *
+ * @author Lubos Racansky, lubos.racansky@wultra.com
+ */
+class EmptyOnboardingProvider implements OnboardingProvider {
+
+    @Override
+    public String lookupUser(Map<String, Object> identification) throws OnboardingProviderException {
+        throw createException();
+    }
+
+    @Override
+    public void sendOtpCode(String userId, String otpCode, boolean resend) throws OnboardingProviderException {
+        throw createException();
+    }
+
+    private static OnboardingProviderException createException() {
+        return new OnboardingProviderException("OnboardingProvider is not available. " +
+                "Implement an onboarding provider and make it accessible using autowiring.");
+    }
+}

--- a/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/provider/OnboardingProviderAutoConfiguration.java
+++ b/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/provider/OnboardingProviderAutoConfiguration.java
@@ -1,0 +1,42 @@
+/*
+ * PowerAuth Enrollment Server
+ * Copyright (C) 2022 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.wultra.app.enrollmentserver.provider;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Autoconfiguration for {@link OnboardingProvider} registering {@link EmptyOnboardingProvider}.
+ *
+ * @author Lubos Racansky, lubos.racansky@wultra.com
+ */
+@Configuration
+@ConditionalOnMissingBean(OnboardingProvider.class)
+class OnboardingProviderAutoConfiguration {
+
+    private static final Logger logger = LoggerFactory.getLogger(OnboardingProviderAutoConfiguration.class);
+
+    @Bean
+    OnboardingProvider onboardingProvider() {
+        logger.warn("No OnboardingProvider found, registering default EmptyOnboardingProvider");
+        return new EmptyOnboardingProvider();
+    }
+}

--- a/enrollment-server/src/main/resources/META-INF/spring.factories
+++ b/enrollment-server/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+  com.wultra.app.enrollmentserver.provider.OnboardingProviderAutoConfiguration


### PR DESCRIPTION
Add `OnboardingProviderAutoConfiguration` and provide empty `OnboardingProvider` to avoid _null_ checks.