### PR TITLE
Fix #234: Missing DocumentVerificationProvider

### DIFF
--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/docverify/mock/provider/WultraMockDocumentVerificationProvider.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/docverify/mock/provider/WultraMockDocumentVerificationProvider.java
@@ -43,7 +43,7 @@ import java.util.stream.Collectors;
 /**
  * Mock implementation of the {@link DocumentVerificationProvider}
  */
-@ConditionalOnProperty(value = "enrollment-server-onboarding.document-verification.provider", havingValue = "mock")
+@ConditionalOnProperty(value = "enrollment-server-onboarding.document-verification.provider", havingValue = "mock", matchIfMissing = true)
 @Component
 public class WultraMockDocumentVerificationProvider implements DocumentVerificationProvider {
 

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/presencecheck/mock/provider/WultraMockPresenceCheckProvider.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/presencecheck/mock/provider/WultraMockPresenceCheckProvider.java
@@ -39,7 +39,7 @@ import java.util.UUID;
  *
  * @author Lukas Lukovsky, lukas.lukovsky@wultra.com
  */
-@ConditionalOnProperty(value = "enrollment-server-onboarding.presence-check.provider", havingValue = "mock")
+@ConditionalOnProperty(value = "enrollment-server-onboarding.presence-check.provider", havingValue = "mock", matchIfMissing = true)
 @Component
 public class WultraMockPresenceCheckProvider implements PresenceCheckProvider {
 


### PR DESCRIPTION
This change will cause that mock providers are autowired in case no provider is specified. 