### PR TITLE
Fix #230: Invalid status returned for expired onboarding process

### DIFF
--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/OnboardingServiceImpl.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/OnboardingServiceImpl.java
@@ -34,6 +34,7 @@ import com.wultra.app.onboardingserver.errorhandling.OnboardingOtpDeliveryExcept
 import com.wultra.app.onboardingserver.errorhandling.OnboardingProviderException;
 import com.wultra.app.onboardingserver.errorhandling.TooManyProcessesException;
 import com.wultra.app.onboardingserver.impl.service.internal.JsonSerializationService;
+import com.wultra.app.onboardingserver.impl.util.DateUtil;
 import com.wultra.app.onboardingserver.provider.*;
 import io.getlime.core.rest.model.base.response.Response;
 import org.slf4j.Logger;
@@ -203,6 +204,15 @@ public class OnboardingServiceImpl extends CommonOnboardingService {
         OnboardingProcessEntity process = processOptional.get();
         OnboardingStatusResponse response = new OnboardingStatusResponse();
         response.setProcessId(processId);
+
+        // Check for expiration of onboarding process
+        if (hasProcessExpired(process)) {
+            // Trigger immediate processing of expired processes
+            terminateInactiveProcesses();
+            response.setOnboardingStatus(OnboardingStatus.FAILED);
+            return response;
+        }
+
         response.setOnboardingStatus(process.getStatus());
         return response;
     }
@@ -289,18 +299,17 @@ public class OnboardingServiceImpl extends CommonOnboardingService {
     public void terminateInactiveProcesses() {
         // Terminate processes with activations in progress
         final int activationExpirationSeconds = onboardingConfig.getActivationExpirationTime();
-        final Date createdDateActivations = convertExpirationToCreatedDate(activationExpirationSeconds);
-        onboardingProcessRepository.terminateOldProcesses(createdDateActivations, OnboardingStatus.ACTIVATION_IN_PROGRESS);
+        final Date createdDateExpiredActivations = DateUtil.convertExpirationToCreatedDate(activationExpirationSeconds);
+        onboardingProcessRepository.terminateOldProcesses(createdDateExpiredActivations, OnboardingStatus.ACTIVATION_IN_PROGRESS);
 
         // Terminate processes with verifications in progress
         final int verificationExpirationSeconds = identityVerificationConfig.getVerificationExpirationTime();
-        //TODO: Unused variable `createdDateExpirations` - evaluate.
-        final Date createdDateExpirations = convertExpirationToCreatedDate(verificationExpirationSeconds);
-        onboardingProcessRepository.terminateOldProcesses(convertExpirationToCreatedDate(verificationExpirationSeconds), OnboardingStatus.VERIFICATION_IN_PROGRESS);
+        final Date createdDateExpiredVerifications = DateUtil.convertExpirationToCreatedDate(verificationExpirationSeconds);
+        onboardingProcessRepository.terminateOldProcesses(createdDateExpiredVerifications, OnboardingStatus.VERIFICATION_IN_PROGRESS);
 
         // Terminate OTP codes for all processes
         final int otpExpirationSeconds = (int) onboardingConfig.getOtpExpirationTime().getSeconds();
-        final Date createdDateOtp = convertExpirationToCreatedDate(otpExpirationSeconds);
+        final Date createdDateOtp = DateUtil.convertExpirationToCreatedDate(otpExpirationSeconds);
         otpService.terminateOldOtps(createdDateOtp);
     }
 
@@ -357,14 +366,28 @@ public class OnboardingServiceImpl extends CommonOnboardingService {
     }
 
     /**
-     * Convert expiration time to minimal created date used for expiration.
-     * @param expirationSeconds Expiration time in seconds.
-     * @return Created date used for expiration.
+     * Check whether onboarding process has expired.
+     * @param onboardingProcess Onboarding process entity.
+     * @return Whether onboarding process has expired.
      */
-    private Date convertExpirationToCreatedDate(int expirationSeconds) {
-        Calendar c = GregorianCalendar.getInstance();
-        c.add(Calendar.SECOND, -expirationSeconds);
-        return c.getTime();
+    public boolean hasProcessExpired(OnboardingProcessEntity onboardingProcess) {
+        if (onboardingProcess.getStatus() == OnboardingStatus.ACTIVATION_IN_PROGRESS) {
+            final int activationExpirationSeconds = onboardingConfig.getActivationExpirationTime();
+            final Date createdDateExpirationActivation = DateUtil.convertExpirationToCreatedDate(activationExpirationSeconds);
+            if (onboardingProcess.getTimestampCreated().before(createdDateExpirationActivation)) {
+                return true;
+            }
+        }
+
+        if (onboardingProcess.getStatus() == OnboardingStatus.VERIFICATION_IN_PROGRESS) {
+            final int verificationExpirationSeconds = identityVerificationConfig.getVerificationExpirationTime();
+            final Date createdDateExpirationVerification = DateUtil.convertExpirationToCreatedDate(verificationExpirationSeconds);
+            if (onboardingProcess.getTimestampCreated().before(createdDateExpirationVerification)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
 }

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/OnboardingServiceImpl.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/OnboardingServiceImpl.java
@@ -309,8 +309,8 @@ public class OnboardingServiceImpl extends CommonOnboardingService {
 
         // Terminate OTP codes for all processes
         final int otpExpirationSeconds = (int) onboardingConfig.getOtpExpirationTime().getSeconds();
-        final Date createdDateOtp = DateUtil.convertExpirationToCreatedDate(otpExpirationSeconds);
-        otpService.terminateOldOtps(createdDateOtp);
+        final Date createdDateExpiredOtp = DateUtil.convertExpirationToCreatedDate(otpExpirationSeconds);
+        otpService.terminateOldOtps(createdDateExpiredOtp);
     }
 
     /**

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/util/DateUtil.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/util/DateUtil.java
@@ -1,0 +1,43 @@
+/*
+ * PowerAuth Enrollment Server
+ * Copyright (C) 2022 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.wultra.app.onboardingserver.impl.util;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+
+/**
+ * Utility class for date conversions.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+public class DateUtil {
+
+    /**
+     * Convert expiration time to minimal created date used for expiration.
+     * @param expirationSeconds Expiration time in seconds.
+     * @return Created date used for expiration.
+     */
+    public static Date convertExpirationToCreatedDate(int expirationSeconds) {
+        Calendar c = GregorianCalendar.getInstance();
+        c.add(Calendar.SECOND, -expirationSeconds);
+        return c.getTime();
+    }
+}


### PR DESCRIPTION
The status endpoints previously returned invalid status for expired processes. This pull request should fix this.