### PR TITLE
Fix #258: Implement limit for max attempts of selfie check and OTP verification

### DIFF
--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/configuration/IdentityVerificationConfig.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/configuration/IdentityVerificationConfig.java
@@ -68,4 +68,7 @@ public class IdentityVerificationConfig {
     @Value("${enrollment-server-onboarding.identity-verification.max-failed-attempts-document-upload:5}")
     private int documentUploadMaxFailedAttempts;
 
+    @Value("${enrollment-server-onboarding.presence-check.max-failed-attempts:5}")
+    private int presenceCheckMaxFailedAttempts;
+
 }

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/controller/api/IdentityVerificationController.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/controller/api/IdentityVerificationController.java
@@ -436,6 +436,10 @@ public class IdentityVerificationController {
      * @throws PowerAuthAuthenticationException Thrown when request authentication fails.
      * @throws PowerAuthEncryptionException Thrown when request decryption fails.
      * @throws OnboardingProcessException Thrown when onboarding process identifier is invalid.
+     * @throws IdentityVerificationException Thrown when identity verification is invalid.
+     * @throws PresenceCheckLimitException Thrown when presence check limit is exceeded.
+     * @throws RemoteCommunicationException Thrown when communication with PowerAuth server fails.
+     * @throws OnboardingProcessLimitException Thrown when maximum failed attempts for identity verification have been reached.
      */
     @PostMapping("presence-check/init")
     @PowerAuthEncryption(scope = EciesScope.ACTIVATION_SCOPE)
@@ -446,7 +450,7 @@ public class IdentityVerificationController {
                                                                        @Parameter(hidden = true) EciesEncryptionContext eciesContext,
                                                                        @Parameter(hidden = true) PowerAuthApiAuthentication apiAuthentication)
             throws PowerAuthAuthenticationException, DocumentVerificationException, PresenceCheckException,
-            PresenceCheckNotEnabledException, PowerAuthEncryptionException, OnboardingProcessException {
+            PresenceCheckNotEnabledException, PowerAuthEncryptionException, OnboardingProcessException, PresenceCheckLimitException, RemoteCommunicationException, IdentityVerificationException, OnboardingProcessLimitException {
 
         // Check if the authentication object is present
         if (apiAuthentication == null) {

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/database/entity/IdentityVerificationEntity.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/database/entity/IdentityVerificationEntity.java
@@ -45,7 +45,8 @@ public class IdentityVerificationEntity implements Serializable {
 
     private static final long serialVersionUID = 6307591849271145826L;
 
-    public static final String ERROR_MAX_FAILED_ATTEMPTS_UPLOAD = "maxFailedAttemptsDocumentUpload";
+    public static final String ERROR_MAX_FAILED_ATTEMPTS_DOCUMENT_UPLOAD = "maxFailedAttemptsDocumentUpload";
+    public static final String ERROR_MAX_FAILED_ATTEMPTS_PRESENCE_CHECK = "maxFailedAttemptsPresenceCheck";
 
     @Id
     @GeneratedValue(generator = "uuid")

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/errorhandling/PresenceCheckLimitException.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/errorhandling/PresenceCheckLimitException.java
@@ -1,0 +1,36 @@
+/*
+ * PowerAuth Enrollment Server
+ * Copyright (C) 2022 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.wultra.app.onboardingserver.errorhandling;
+
+/**
+ * Exception thrown in case of a limit reached for a presence check.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+public class PresenceCheckLimitException extends Exception {
+
+    private static final long serialVersionUID = -814024875324296277L;
+
+    public PresenceCheckLimitException() {
+    }
+
+    public PresenceCheckLimitException(String message) {
+        super(message);
+    }
+
+}

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/IdentityVerificationLimitService.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/IdentityVerificationLimitService.java
@@ -132,7 +132,7 @@ public class IdentityVerificationLimitService {
         List<DocumentVerificationEntity> documentVerificationsFailed = documentVerificationRepository.findAllDocumentVerifications(identityVerification, DocumentStatus.ALL_UNSUCCESSFUL);
         if (documentVerificationsFailed.size() > identityVerificationConfig.getDocumentUploadMaxFailedAttempts()) {
             identityVerification.setStatus(IdentityVerificationStatus.FAILED);
-            identityVerification.setErrorDetail(IdentityVerificationEntity.ERROR_MAX_FAILED_ATTEMPTS_UPLOAD);
+            identityVerification.setErrorDetail(IdentityVerificationEntity.ERROR_MAX_FAILED_ATTEMPTS_DOCUMENT_UPLOAD);
             identityVerificationRepository.save(identityVerification);
             identityVerificationResetService.resetIdentityVerification(ownerId);
             logger.warn("Max failed attempts reached for document upload, {}.", ownerId);

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/PresenceCheckLimitService.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/PresenceCheckLimitService.java
@@ -1,0 +1,101 @@
+/*
+ * PowerAuth Enrollment Server
+ * Copyright (C) 2022 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.wultra.app.onboardingserver.impl.service;
+
+import com.wultra.app.enrollmentserver.model.enumeration.IdentityVerificationStatus;
+import com.wultra.app.enrollmentserver.model.enumeration.OtpType;
+import com.wultra.app.enrollmentserver.model.integration.OwnerId;
+import com.wultra.app.onboardingserver.common.database.OnboardingOtpRepository;
+import com.wultra.app.onboardingserver.configuration.IdentityVerificationConfig;
+import com.wultra.app.onboardingserver.database.IdentityVerificationRepository;
+import com.wultra.app.onboardingserver.database.entity.IdentityVerificationEntity;
+import com.wultra.app.onboardingserver.errorhandling.IdentityVerificationException;
+import com.wultra.app.onboardingserver.errorhandling.OnboardingProcessLimitException;
+import com.wultra.app.onboardingserver.errorhandling.PresenceCheckLimitException;
+import com.wultra.app.onboardingserver.errorhandling.RemoteCommunicationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+import static com.wultra.app.onboardingserver.database.entity.IdentityVerificationEntity.ERROR_MAX_FAILED_ATTEMPTS_PRESENCE_CHECK;
+
+/**
+ * Service for checking presence check limits.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+@Service
+public class PresenceCheckLimitService {
+
+    private static final Logger logger = LoggerFactory.getLogger(PresenceCheckLimitService.class);
+
+    private final IdentityVerificationConfig identityVerificationConfig;
+    private final OnboardingOtpRepository otpRepository;
+    private final IdentityVerificationRepository identityVerificationRepository;
+    private final IdentityVerificationResetService identityVerificationResetService;
+
+    /**
+     * Service constructor.
+     * @param identityVerificationConfig Identity verification configuration.
+     * @param otpRepository Onboarding OTP repository.
+     * @param identityVerificationRepository Identity verification repository.
+     * @param identityVerificationResetService Identity verification reset service.
+     */
+    @Autowired
+    public PresenceCheckLimitService(IdentityVerificationConfig identityVerificationConfig, OnboardingOtpRepository otpRepository, IdentityVerificationRepository identityVerificationRepository, IdentityVerificationResetService identityVerificationResetService) {
+        this.identityVerificationConfig = identityVerificationConfig;
+        this.otpRepository = otpRepository;
+        this.identityVerificationRepository = identityVerificationRepository;
+        this.identityVerificationResetService = identityVerificationResetService;
+    }
+
+    /**
+     * Check limit for maximum number of attempts for presence check and OTP verification.
+     * @param ownerId Owner identification.
+     * @param processId Process identifier.
+     * @throws IdentityVerificationException Thrown when identity verification is invalid.
+     * @throws PresenceCheckLimitException Thrown when presence check limit is exceeded.
+     * @throws RemoteCommunicationException Thrown when communication with PowerAuth server fails.
+     * @throws OnboardingProcessLimitException Thrown when maximum failed attempts for identity verification have been reached.
+     */
+    public void checkPresenceCheckMaxAttemptLimit(OwnerId ownerId, String processId) throws IdentityVerificationException, PresenceCheckLimitException, RemoteCommunicationException, OnboardingProcessLimitException {
+        int otpCount = otpRepository.getOtpCount(processId, OtpType.USER_VERIFICATION);
+        if (otpCount > identityVerificationConfig.getPresenceCheckMaxFailedAttempts()) {
+            Optional<IdentityVerificationEntity> identityVerificationOptional = identityVerificationRepository.findFirstByActivationIdOrderByTimestampCreatedDesc(ownerId.getActivationId());
+            if (identityVerificationOptional.isEmpty()) {
+                logger.warn("Identity verification was not found, {}.", ownerId);
+                throw new IdentityVerificationException("Identity verification was not found");
+            }
+            IdentityVerificationEntity identityVerification = identityVerificationOptional.get();
+            if (!identityVerification.getProcessId().equals(processId)) {
+                logger.warn("Process identifier mismatch for owner {}: {}.", ownerId, processId);
+                throw new IdentityVerificationException("Process identifier mismatch");
+            }
+            identityVerification.setStatus(IdentityVerificationStatus.FAILED);
+            identityVerification.setErrorDetail(ERROR_MAX_FAILED_ATTEMPTS_PRESENCE_CHECK);
+            identityVerificationResetService.resetIdentityVerification(ownerId);
+            throw new PresenceCheckLimitException("Max failed attempts reached for presence check");
+        }
+    }
+
+}

--- a/enrollment-server-onboarding/src/main/resources/application.properties
+++ b/enrollment-server-onboarding/src/main/resources/application.properties
@@ -103,6 +103,7 @@ enrollment-server-onboarding.presence-check.provider=mock
 enrollment-server-onboarding.presence-check.cleanupEnabled=false
 # Enables/disabled verification of the presence check selfie photo with the documents
 enrollment-server-onboarding.presence-check.verifySelfieWithDocumentsEnabled=false
+enrollment-server-onboarding.presence-check.max-failed-attempts=5
 
 # iProov configuration
 enrollment-server-onboarding.presence-check.iproov.apiKey=${IPROOV_API_KEY}


### PR DESCRIPTION
This PR builds on changes introduced in: https://github.com/wultra/enrollment-server/pull/267 and adds a limit for maximum number of presence checks with OTP, verified using count of OTP entities with type = `USER_VERIFICATION`.