### PR TITLE
Fix #370: UnsatisfiedDependencyException: Error creating bean

### DIFF
--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/statemachine/service/StateMachineService.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/statemachine/service/StateMachineService.java
@@ -27,6 +27,7 @@ import com.wultra.app.onboardingserver.statemachine.enums.OnboardingEvent;
 import com.wultra.app.onboardingserver.statemachine.enums.OnboardingState;
 import com.wultra.app.onboardingserver.statemachine.interceptor.CustomStateMachineInterceptor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.statemachine.ExtendedState;
@@ -52,6 +53,7 @@ import java.util.stream.Stream;
  */
 @Service
 @Slf4j
+@ConditionalOnProperty(value = "enrollment-server-onboarding.identity-verification.enabled", havingValue = "true")
 public class StateMachineService {
 
     private final EnrollmentStateProvider enrollmentStateProvider;

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/StateMachineTask.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/StateMachineTask.java
@@ -21,6 +21,7 @@ import com.wultra.app.onboardingserver.statemachine.service.StateMachineService;
 import lombok.extern.slf4j.Slf4j;
 import net.javacrumbs.shedlock.core.LockAssert;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -33,6 +34,7 @@ import org.springframework.stereotype.Component;
  */
 @Component
 @Slf4j
+@ConditionalOnProperty(value = "enrollment-server-onboarding.identity-verification.enabled", havingValue = "true")
 public class StateMachineTask {
 
     private final StateMachineService stateMachineService;


### PR DESCRIPTION
Fix UnsatisfiedDependencyException: Error creating bean with name stateMachineService

Fix start when `enrollment-server-onboarding.identity-verification.enabled=false`