### PR TITLE
Fix #415: Implement locking mechanism for DB rows in enrollment-onboarding

### DIFF
--- a/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/api/OnboardingService.java
+++ b/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/api/OnboardingService.java
@@ -31,7 +31,8 @@ import com.wultra.app.onboardingserver.common.errorhandling.OnboardingProcessExc
 public interface OnboardingService {
 
     /**
-     * Find a user identifier by the given onboarding process.
+     * Find a user identifier by the given onboarding process. The onboarding process is locked using PESSIMISTIC_WRITE
+     * lock until the end of the transaction.
      *
      * @param processId Process identifier.
      * @return user identifier
@@ -40,7 +41,9 @@ public interface OnboardingService {
     String findUserIdByProcessId(String processId) throws OnboardingProcessException;
 
     /**
-     * Get process status for an onboarding process.
+     * Get process status for an onboarding process. The onboarding process is locked using PESSIMISTIC_WRITE lock
+     * until the end of the transaction.
+     *
      * @param processId Onboarding process identifier.
      * @return Onboarding process status.
      * @throws OnboardingProcessException Thrown when onboarding process is not found.

--- a/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/database/OnboardingOtpRepository.java
+++ b/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/database/OnboardingOtpRepository.java
@@ -40,7 +40,7 @@ public interface OnboardingOtpRepository extends CrudRepository<OnboardingOtpEnt
 
     @Query("SELECT o FROM OnboardingOtpEntity o WHERE o.process.id = :processId AND o.type = :type AND o.timestampCreated = " +
             "(SELECT MAX(o2.timestampCreated) FROM OnboardingOtpEntity o2 WHERE o2.process.id = :processId AND o2.type = :type)")
-    Optional<OnboardingOtpEntity> findLastOtp(String processId, OtpType type);
+    Optional<OnboardingOtpEntity> findNewestByProcessIdAndType(String processId, OtpType type);
 
     /**
      * Return OTP IDs by the given timestamp.
@@ -51,7 +51,7 @@ public interface OnboardingOtpRepository extends CrudRepository<OnboardingOtpEnt
     @Query("SELECT o.id FROM OnboardingOtpEntity o " +
             "WHERE o.status = com.wultra.app.enrollmentserver.model.enumeration.OtpStatus.ACTIVE " +
             "AND o.timestampCreated < :dateCreatedBefore")
-    List<String> findExpiredOtps(Date dateCreatedBefore);
+    List<String> findExpiredIds(Date dateCreatedBefore);
 
     /**
      * Mark the given OTPs as failed.
@@ -70,12 +70,12 @@ public interface OnboardingOtpRepository extends CrudRepository<OnboardingOtpEnt
     void terminate(Collection<String> ids, Date timestampExpired);
 
     @Query("SELECT SUM(o.failedAttempts) FROM OnboardingOtpEntity o WHERE o.process.id = :processId AND o.type = :type")
-    int getFailedAttemptsByProcess(String processId, OtpType type);
+    int countFailedAttemptsByProcessIdAndType(String processId, OtpType type);
 
     @Query("SELECT MAX(o.timestampCreated) FROM OnboardingOtpEntity o WHERE o.process.id = :processId AND o.type = :type")
     Date getNewestOtpCreatedTimestamp(String processId, OtpType type);
 
     @Query("SELECT COUNT(o.id) FROM OnboardingOtpEntity o WHERE o.process.id = :processId AND o.type = :type")
-    int getOtpCount(String processId, OtpType type);
+    int countByProcessIdAndType(String processId, OtpType type);
 
 }

--- a/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/database/OnboardingProcessRepository.java
+++ b/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/database/OnboardingProcessRepository.java
@@ -57,6 +57,7 @@ public interface OnboardingProcessRepository extends CrudRepository<OnboardingPr
      * Find an existing process using identification data and status. Lock this process using PESSIMISTIC_WRITE lock
      * until the end of the transaction.
      *
+     * @see #findByActivationIdAndStatus(String, OnboardingStatus) (String, OnboardingStatus) - alternative method without lock
      * @param identificationData Identification data.
      * @param status Process status.
      * @return Optional onboarding process.
@@ -68,6 +69,7 @@ public interface OnboardingProcessRepository extends CrudRepository<OnboardingPr
     /**
      * Find an existing process by activation identifier and process status. The process is not locked.
      *
+     * @see #findByActivationIdAndStatusWithLock(String, OnboardingStatus) - alternative method with lock
      * @param activationId Activation identifier.
      * @param status Onboarding process status.
      * @return Optional onboarding process.

--- a/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/database/OnboardingProcessRepository.java
+++ b/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/database/OnboardingProcessRepository.java
@@ -51,7 +51,7 @@ public interface OnboardingProcessRepository extends CrudRepository<OnboardingPr
      */
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT p FROM OnboardingProcessEntity p WHERE p.id = :processId")
-    Optional<OnboardingProcessEntity> findProcessByIdWithLock(String processId);
+    Optional<OnboardingProcessEntity> findByIdWithLock(String processId);
 
     /**
      * Find an existing process using identification data and status. Lock this process using PESSIMISTIC_WRITE lock
@@ -63,7 +63,7 @@ public interface OnboardingProcessRepository extends CrudRepository<OnboardingPr
      */
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT p FROM OnboardingProcessEntity p WHERE p.status = :status AND p.identificationData = :identificationData")
-    Optional<OnboardingProcessEntity> findExistingProcessWithLock(String identificationData, OnboardingStatus status);
+    Optional<OnboardingProcessEntity> findByIdentificationDataAndStatusWithLock(String identificationData, OnboardingStatus status);
 
     /**
      * Find an existing process by activation identifier and process status. The process is not locked.
@@ -75,11 +75,11 @@ public interface OnboardingProcessRepository extends CrudRepository<OnboardingPr
     @Query("SELECT p FROM OnboardingProcessEntity p WHERE p.status = :status " +
             "AND p.activationId = :activationId " +
             "ORDER BY p.timestampCreated DESC")
-    Optional<OnboardingProcessEntity> findExistingProcessForActivation(String activationId, OnboardingStatus status);
+    Optional<OnboardingProcessEntity> findByActivationIdAndStatus(String activationId, OnboardingStatus status);
 
     /**
-     * Find an existing process by activation identifier and process status. Lock the onboarding process until the
-     * end of the transaction.
+     * Find an existing process by activation identifier and process status. Lock this process using PESSIMISTIC_WRITE
+     * lock until the end of the transaction.
      *
      * @param activationId Activation identifier.
      * @param status Onboarding process status.
@@ -89,7 +89,7 @@ public interface OnboardingProcessRepository extends CrudRepository<OnboardingPr
     @Query("SELECT p FROM OnboardingProcessEntity p WHERE p.status = :status " +
             "AND p.activationId = :activationId " +
             "ORDER BY p.timestampCreated DESC")
-    Optional<OnboardingProcessEntity> findExistingProcessForActivationWithLock(String activationId, OnboardingStatus status);
+    Optional<OnboardingProcessEntity> findByActivationIdAndStatusWithLock(String activationId, OnboardingStatus status);
 
     /**
      * Find process by activation identifier. Do not lock the process.
@@ -100,7 +100,7 @@ public interface OnboardingProcessRepository extends CrudRepository<OnboardingPr
     @Query("SELECT p FROM OnboardingProcessEntity p " +
             "WHERE p.activationId = :activationId " +
             "ORDER BY p.timestampCreated DESC")
-    Optional<OnboardingProcessEntity> findProcessByActivationId(String activationId);
+    Optional<OnboardingProcessEntity> findByActivationId(String activationId);
 
     /**
      * Count onboarding processes for user with timestamp created after given timestamp.
@@ -110,7 +110,7 @@ public interface OnboardingProcessRepository extends CrudRepository<OnboardingPr
      * @return Count of onboarding processes satisfying query criteria.
      */
     @Query("SELECT count(p) FROM OnboardingProcessEntity p WHERE p.userId = :userId AND p.timestampCreated > :dateAfter")
-    int countProcessesAfterTimestamp(String userId, Date dateAfter);
+    int countByUserIdAndTimestamp(String userId, Date dateAfter);
 
     /**
      * Return onboarding process IDs by the given timestamp and status. Lock these processes using PESSIMISTIC_WRITE
@@ -124,7 +124,7 @@ public interface OnboardingProcessRepository extends CrudRepository<OnboardingPr
     @Query("SELECT p.id FROM OnboardingProcessEntity p " +
             "WHERE p.status = :status " +
             "AND p.timestampCreated < :dateCreatedBefore")
-    List<String> findExpiredProcessIdsByStatusWithLock(Date dateCreatedBefore, OnboardingStatus status);
+    List<String> findByTimestampAndStatusWithLock(Date dateCreatedBefore, OnboardingStatus status);
 
     /**
      * Return onboarding process IDs by the given timestamp. Include only not yet finished entities. Lock these
@@ -138,7 +138,7 @@ public interface OnboardingProcessRepository extends CrudRepository<OnboardingPr
             "WHERE p.status <> com.wultra.app.enrollmentserver.model.enumeration.OnboardingStatus.FINISHED " +
             "AND p.status <> com.wultra.app.enrollmentserver.model.enumeration.OnboardingStatus.FAILED " +
             "AND p.timestampCreated < :dateCreatedBefore")
-    List<String> findExpiredProcessIdsWithLock(Date dateCreatedBefore);
+    List<String> findActiveByTimestampWithLock(Date dateCreatedBefore);
 
     /**
      * Return onboarding processes to remove activation. Lock these processes using PESSIMISTIC_WRITE lock until
@@ -151,7 +151,7 @@ public interface OnboardingProcessRepository extends CrudRepository<OnboardingPr
             "WHERE p.status = com.wultra.app.enrollmentserver.model.enumeration.OnboardingStatus.FAILED " +
             "AND p.activationId IS NOT NULL " +
             "AND p.activationRemoved = false")
-    Stream<OnboardingProcessEntity> findProcessesToRemoveActivationWithLock();
+    Stream<OnboardingProcessEntity> findAllToRemoveActivationWithLock();
 
     /**
      * Mark the given onboarding processes as failed.

--- a/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/database/OnboardingProcessRepository.java
+++ b/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/database/OnboardingProcessRepository.java
@@ -92,6 +92,17 @@ public interface OnboardingProcessRepository extends CrudRepository<OnboardingPr
     Optional<OnboardingProcessEntity> findExistingProcessForActivationWithLock(String activationId, OnboardingStatus status);
 
     /**
+     * Find process by activation identifier. Do not lock the process.
+     *
+     * @param activationId Activation identifier.
+     * @return Optional onboarding process.
+     */
+    @Query("SELECT p FROM OnboardingProcessEntity p " +
+            "WHERE p.activationId = :activationId " +
+            "ORDER BY p.timestampCreated DESC")
+    Optional<OnboardingProcessEntity> findProcessByActivationId(String activationId);
+
+    /**
      * Count onboarding processes for user with timestamp created after given timestamp.
      *
      * @param userId User identifier.

--- a/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/database/OnboardingProcessRepository.java
+++ b/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/database/OnboardingProcessRepository.java
@@ -50,7 +50,7 @@ public interface OnboardingProcessRepository extends CrudRepository<OnboardingPr
      * @return Optional onboarding process.
      */
     @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("SELECT p FROM OnboardingOtpEntity p WHERE p.id = :processId")
+    @Query("SELECT p FROM OnboardingProcessEntity p WHERE p.id = :processId")
     Optional<OnboardingProcessEntity> findProcessByIdWithLock(String processId);
 
     /**

--- a/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/database/OnboardingProcessRepository.java
+++ b/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/database/OnboardingProcessRepository.java
@@ -21,11 +21,13 @@ package com.wultra.app.onboardingserver.common.database;
 import com.wultra.app.enrollmentserver.model.enumeration.ErrorOrigin;
 import com.wultra.app.enrollmentserver.model.enumeration.OnboardingStatus;
 import com.wultra.app.onboardingserver.common.database.entity.OnboardingProcessEntity;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
+import javax.persistence.LockModeType;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
@@ -40,33 +42,105 @@ import java.util.stream.Stream;
 @Repository
 public interface OnboardingProcessRepository extends CrudRepository<OnboardingProcessEntity, String> {
 
-    @Query("SELECT p FROM OnboardingProcessEntity p WHERE p.status = :status AND p.identificationData = :identificationData")
-    Optional<OnboardingProcessEntity> findExistingProcessByIdentificationData(String identificationData, OnboardingStatus status);
+    /**
+     * Find an onboarding process using process ID. Lock this process using PESSIMISTIC_WRITE lock
+     * until the end of the transaction.
+     *
+     * @param processId Onboarding process identifier.
+     * @return Optional onboarding process.
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT p FROM OnboardingOtpEntity p WHERE p.id = :processId")
+    Optional<OnboardingProcessEntity> findProcessByIdWithLock(String processId);
 
+    /**
+     * Find an existing process using identification data and status. Lock this process using PESSIMISTIC_WRITE lock
+     * until the end of the transaction.
+     *
+     * @param identificationData Identification data.
+     * @param status Process status.
+     * @return Optional onboarding process.
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT p FROM OnboardingProcessEntity p WHERE p.status = :status AND p.identificationData = :identificationData")
+    Optional<OnboardingProcessEntity> findExistingProcessWithLock(String identificationData, OnboardingStatus status);
+
+    /**
+     * Find an existing process by activation identifier and process status. The process is not locked.
+     *
+     * @param activationId Activation identifier.
+     * @param status Onboarding process status.
+     * @return Optional onboarding process.
+     */
     @Query("SELECT p FROM OnboardingProcessEntity p WHERE p.status = :status " +
             "AND p.activationId = :activationId " +
             "ORDER BY p.timestampCreated DESC")
     Optional<OnboardingProcessEntity> findExistingProcessForActivation(String activationId, OnboardingStatus status);
 
-    @Query("SELECT p FROM OnboardingProcessEntity p " +
-            "WHERE p.activationId = :activationId " +
+    /**
+     * Find an existing process by activation identifier and process status. Lock the onboarding process until the
+     * end of the transaction.
+     *
+     * @param activationId Activation identifier.
+     * @param status Onboarding process status.
+     * @return Optional onboarding process.
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT p FROM OnboardingProcessEntity p WHERE p.status = :status " +
+            "AND p.activationId = :activationId " +
             "ORDER BY p.timestampCreated DESC")
-    Optional<OnboardingProcessEntity> findProcessByActivationId(String activationId);
+    Optional<OnboardingProcessEntity> findExistingProcessForActivationWithLock(String activationId, OnboardingStatus status);
 
+    /**
+     * Count onboarding processes for user with timestamp created after given timestamp.
+     *
+     * @param userId User identifier.
+     * @param dateAfter Timestamp for comparison.
+     * @return Count of onboarding processes satisfying query criteria.
+     */
     @Query("SELECT count(p) FROM OnboardingProcessEntity p WHERE p.userId = :userId AND p.timestampCreated > :dateAfter")
     int countProcessesAfterTimestamp(String userId, Date dateAfter);
 
     /**
-     * Return onboarding process IDs by the given timestamp and status.
+     * Return onboarding process IDs by the given timestamp and status. Lock these processes using PESSIMISTIC_WRITE
+     * lock until the end of the transaction.
      *
      * @param dateCreatedBefore timestamp created must be before the given value
      * @param status onboarding status
      * @return onboarding process IDs
      */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT p.id FROM OnboardingProcessEntity p " +
             "WHERE p.status = :status " +
             "AND p.timestampCreated < :dateCreatedBefore")
-    List<String> findExpiredProcessIdsByStatusAndCreatedDate(Date dateCreatedBefore, OnboardingStatus status);
+    List<String> findExpiredProcessIdsByStatusWithLock(Date dateCreatedBefore, OnboardingStatus status);
+
+    /**
+     * Return onboarding process IDs by the given timestamp. Include only not yet finished entities. Lock these
+     * processes using PESSIMISTIC_WRITE lock until the end of the transaction.
+     *
+     * @param dateCreatedBefore timestamp created must be before the given value
+     * @return onboarding process IDs
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT p.id FROM OnboardingProcessEntity p " +
+            "WHERE p.status <> com.wultra.app.enrollmentserver.model.enumeration.OnboardingStatus.FINISHED " +
+            "AND p.status <> com.wultra.app.enrollmentserver.model.enumeration.OnboardingStatus.FAILED " +
+            "AND p.timestampCreated < :dateCreatedBefore")
+    List<String> findExpiredProcessIdsWithLock(Date dateCreatedBefore);
+
+    /**
+     * Return onboarding processes to remove activation. Lock these processes using PESSIMISTIC_WRITE lock until
+     * the end of the transaction.
+     *
+     * @return onboarding processes
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT p FROM OnboardingProcessEntity p " +
+            "WHERE p.status = com.wultra.app.enrollmentserver.model.enumeration.OnboardingStatus.FAILED " +
+            "AND p.activationId IS NOT NULL " +
+            "AND p.activationRemoved = false")
+    Stream<OnboardingProcessEntity> findProcessesToRemoveActivationWithLock();
 
     /**
      * Mark the given onboarding processes as failed.
@@ -86,26 +160,4 @@ public interface OnboardingProcessRepository extends CrudRepository<OnboardingPr
             "WHERE p.id IN :ids")
     void terminate(Collection<String> ids, Date timestampExpired, String errorDetail, ErrorOrigin errorOrigin);
 
-    /**
-     * Return onboarding process IDs by the given timestamp. Include only not yet finished entities.
-     *
-     * @param dateCreatedBefore timestamp created must be before the given value
-     * @return onboarding process IDs
-     */
-    @Query("SELECT p.id FROM OnboardingProcessEntity p " +
-            "WHERE p.status <> com.wultra.app.enrollmentserver.model.enumeration.OnboardingStatus.FINISHED " +
-            "AND p.status <> com.wultra.app.enrollmentserver.model.enumeration.OnboardingStatus.FAILED " +
-            "AND p.timestampCreated < :dateCreatedBefore")
-    List<String> findExpiredProcessIdsByCreatedDate(Date dateCreatedBefore);
-
-    /**
-     * Return onboarding processes to remove activation.
-     *
-     * @return onboarding processes
-     */
-    @Query("SELECT p FROM OnboardingProcessEntity p " +
-            "WHERE p.status = com.wultra.app.enrollmentserver.model.enumeration.OnboardingStatus.FAILED " +
-            "AND p.activationId IS NOT NULL " +
-            "AND p.activationRemoved = false")
-    Stream<OnboardingProcessEntity> findProcessesToRemoveActivation();
 }

--- a/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/service/CommonOnboardingService.java
+++ b/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/service/CommonOnboardingService.java
@@ -66,6 +66,7 @@ public class CommonOnboardingService implements OnboardingService {
      * @throws OnboardingProcessException Thrown when onboarding process is not found.
      */
     public OnboardingProcessEntity findProcessWithLock(String processId) throws OnboardingProcessException {
+        logger.debug("Onboarding process will be locked using PESSIMISTIC_WRITE lock, {}", processId);
         return onboardingProcessRepository.findByIdWithLock(processId).orElseThrow(() ->
                 new OnboardingProcessException("Onboarding process not found, process ID: " + processId));
     }
@@ -91,7 +92,6 @@ public class CommonOnboardingService implements OnboardingService {
 
     @Override
     public void updateProcess(final UpdateProcessRequest request) throws OnboardingProcessException {
-        // The onboarding process is locked until the end of the transaction
         final OnboardingProcessEntity process = findProcessWithLock(request.getProcessId());
         process.setStatus(request.getStatus());
         process.setActivationId(request.getActivationId());

--- a/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/service/CommonOnboardingService.java
+++ b/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/service/CommonOnboardingService.java
@@ -25,8 +25,6 @@ import com.wultra.app.onboardingserver.common.database.entity.OnboardingProcessE
 import com.wultra.app.onboardingserver.common.errorhandling.OnboardingProcessException;
 import lombok.extern.slf4j.Slf4j;
 
-import java.util.Optional;
-
 /**
  * Implementation of {@link OnboardingService} which is shared both for enrollment and onboarding.
  *
@@ -68,19 +66,17 @@ public class CommonOnboardingService implements OnboardingService {
      * @throws OnboardingProcessException Thrown when onboarding process is not found.
      */
     public OnboardingProcessEntity findProcessWithLock(String processId) throws OnboardingProcessException {
-        return onboardingProcessRepository.findProcessByIdWithLock(processId).orElseThrow(() ->
+        return onboardingProcessRepository.findByIdWithLock(processId).orElseThrow(() ->
                 new OnboardingProcessException("Onboarding process not found, process ID: " + processId));
     }
 
     @Override
     public String findUserIdByProcessId(final String processId) throws OnboardingProcessException {
-        // The onboarding process is locked until the end of the transaction
         return findProcessWithLock(processId).getUserId();
     }
 
     @Override
     public OnboardingStatus getProcessStatus(String processId) throws OnboardingProcessException {
-        // The onboarding process is locked until the end of the transaction
         return findProcessWithLock(processId).getStatus();
     }
 

--- a/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/service/IdentityVerificationLimitService.java
+++ b/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/service/IdentityVerificationLimitService.java
@@ -95,7 +95,7 @@ public class IdentityVerificationLimitService {
         // Make sure that the maximum attempt number of identity verifications is not exceeded based on count of database rows.
         final List<IdentityVerificationEntity> identityVerifications = identityVerificationRepository.findByActivationIdOrderByTimestampCreatedDesc(ownerId.getActivationId());
         if (identityVerifications.size() >= config.getVerificationMaxFailedAttempts()) {
-            final OnboardingProcessEntity process = onboardingProcessRepository.findExistingProcessForActivation(ownerId.getActivationId(), OnboardingStatus.VERIFICATION_IN_PROGRESS)
+            final OnboardingProcessEntity process = onboardingProcessRepository.findByActivationIdAndStatus(ownerId.getActivationId(), OnboardingStatus.VERIFICATION_IN_PROGRESS)
                     .orElseThrow(() -> new IdentityVerificationException("Onboarding process not found, activation ID: " + ownerId.getActivationId()));
 
             // In case any of the identity verifications is not FAILED or REJECTED yet, fail it.
@@ -162,7 +162,7 @@ public class IdentityVerificationLimitService {
      * @throws OnboardingProcessException Thrown when onboarding process is invalid.
      */
     public void resetIdentityVerification(OwnerId ownerId) throws RemoteCommunicationException, IdentityVerificationException, OnboardingProcessLimitException, OnboardingProcessException {
-        OnboardingProcessEntity process = onboardingProcessRepository.findExistingProcessForActivation(ownerId.getActivationId(), OnboardingStatus.VERIFICATION_IN_PROGRESS)
+        OnboardingProcessEntity process = onboardingProcessRepository.findByActivationIdAndStatus(ownerId.getActivationId(), OnboardingStatus.VERIFICATION_IN_PROGRESS)
                 .orElseThrow(() -> new OnboardingProcessException("Onboarding process not found, activation ID: " + ownerId.getActivationId()));
 
         // Increase process error score

--- a/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/service/IdentityVerificationLimitService.java
+++ b/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/service/IdentityVerificationLimitService.java
@@ -95,7 +95,7 @@ public class IdentityVerificationLimitService {
         // Make sure that the maximum attempt number of identity verifications is not exceeded based on count of database rows.
         final List<IdentityVerificationEntity> identityVerifications = identityVerificationRepository.findByActivationIdOrderByTimestampCreatedDesc(ownerId.getActivationId());
         if (identityVerifications.size() >= config.getVerificationMaxFailedAttempts()) {
-            final OnboardingProcessEntity process = onboardingProcessRepository.findExistingProcessForActivationWithLock(ownerId.getActivationId(), OnboardingStatus.VERIFICATION_IN_PROGRESS)
+            final OnboardingProcessEntity process = onboardingProcessRepository.findExistingProcessForActivation(ownerId.getActivationId(), OnboardingStatus.VERIFICATION_IN_PROGRESS)
                     .orElseThrow(() -> new IdentityVerificationException("Onboarding process not found, activation ID: " + ownerId.getActivationId()));
 
             // In case any of the identity verifications is not FAILED or REJECTED yet, fail it.
@@ -162,7 +162,7 @@ public class IdentityVerificationLimitService {
      * @throws OnboardingProcessException Thrown when onboarding process is invalid.
      */
     public void resetIdentityVerification(OwnerId ownerId) throws RemoteCommunicationException, IdentityVerificationException, OnboardingProcessLimitException, OnboardingProcessException {
-        OnboardingProcessEntity process = onboardingProcessRepository.findExistingProcessForActivationWithLock(ownerId.getActivationId(), OnboardingStatus.VERIFICATION_IN_PROGRESS)
+        OnboardingProcessEntity process = onboardingProcessRepository.findExistingProcessForActivation(ownerId.getActivationId(), OnboardingStatus.VERIFICATION_IN_PROGRESS)
                 .orElseThrow(() -> new OnboardingProcessException("Onboarding process not found, activation ID: " + ownerId.getActivationId()));
 
         // Increase process error score

--- a/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/service/IdentityVerificationLimitService.java
+++ b/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/service/IdentityVerificationLimitService.java
@@ -95,7 +95,7 @@ public class IdentityVerificationLimitService {
         // Make sure that the maximum attempt number of identity verifications is not exceeded based on count of database rows.
         final List<IdentityVerificationEntity> identityVerifications = identityVerificationRepository.findByActivationIdOrderByTimestampCreatedDesc(ownerId.getActivationId());
         if (identityVerifications.size() >= config.getVerificationMaxFailedAttempts()) {
-            final OnboardingProcessEntity process = onboardingProcessRepository.findProcessByActivationId(ownerId.getActivationId())
+            final OnboardingProcessEntity process = onboardingProcessRepository.findExistingProcessForActivationWithLock(ownerId.getActivationId(), OnboardingStatus.VERIFICATION_IN_PROGRESS)
                     .orElseThrow(() -> new IdentityVerificationException("Onboarding process not found, activation ID: " + ownerId.getActivationId()));
 
             // In case any of the identity verifications is not FAILED or REJECTED yet, fail it.
@@ -162,7 +162,7 @@ public class IdentityVerificationLimitService {
      * @throws OnboardingProcessException Thrown when onboarding process is invalid.
      */
     public void resetIdentityVerification(OwnerId ownerId) throws RemoteCommunicationException, IdentityVerificationException, OnboardingProcessLimitException, OnboardingProcessException {
-        OnboardingProcessEntity process = onboardingProcessRepository.findProcessByActivationId(ownerId.getActivationId())
+        OnboardingProcessEntity process = onboardingProcessRepository.findExistingProcessForActivationWithLock(ownerId.getActivationId(), OnboardingStatus.VERIFICATION_IN_PROGRESS)
                 .orElseThrow(() -> new OnboardingProcessException("Onboarding process not found, activation ID: " + ownerId.getActivationId()));
 
         // Increase process error score

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/configuration/SchedulerConfig.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/configuration/SchedulerConfig.java
@@ -33,7 +33,7 @@ import javax.sql.DataSource;
  * @author Lukas Lukovsky, lukas.lukovsky@wultra.com
  */
 @EnableScheduling
-@EnableSchedulerLock(defaultLockAtLeastFor = "15s", defaultLockAtMostFor = "1m")
+@EnableSchedulerLock(defaultLockAtLeastFor = "100ms", defaultLockAtMostFor = "1m")
 @Configuration
 public class SchedulerConfig {
 

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/controller/api/IdentityVerificationController.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/controller/api/IdentityVerificationController.java
@@ -174,7 +174,7 @@ public class IdentityVerificationController {
         final OwnerId ownerId = PowerAuthUtil.getOwnerId(apiAuthentication);
         final String processId = request.getRequestObject().getProcessId();
 
-        // Lock onboarding process
+        logger.debug("Onboarding process will be locked using PESSIMISTIC_WRITE lock, {}", processId);
         onboardingService.verifyProcessIdAndLock(ownerId, processId, OnboardingStatus.VERIFICATION_IN_PROGRESS);
 
         StateMachine<OnboardingState, OnboardingEvent> stateMachine =
@@ -212,8 +212,7 @@ public class IdentityVerificationController {
 
         final OwnerId ownerId = PowerAuthUtil.getOwnerId(apiAuthentication);
 
-        // Onboarding process is not locked, status endpoint does not require process lock
-
+        logger.debug("Onboarding process will not be locked, {}", ownerId);
         // Check verification status
         final IdentityVerificationStatusResponse response =
                 identityVerificationStatusService.checkIdentityVerificationStatus(request.getRequestObject(), ownerId);
@@ -257,7 +256,7 @@ public class IdentityVerificationController {
         final OwnerId ownerId = extractOwnerId(eciesContext);
         final String processId = request.getRequestObject().getProcessId();
 
-        // Lock onboarding process
+        logger.debug("Onboarding process will be locked using PESSIMISTIC_WRITE lock, {}", processId);
         onboardingService.verifyProcessIdAndLock(ownerId, processId, OnboardingStatus.VERIFICATION_IN_PROGRESS);
 
         // Submit documents for verification
@@ -301,8 +300,7 @@ public class IdentityVerificationController {
         // Extract user ID from onboarding process for current activation
         final OwnerId ownerId = extractOwnerId(eciesContext);
 
-        // Onboarding process is not locked, upload updates the es_document_data table
-
+        logger.debug("Onboarding process will not be locked, {}", ownerId);
         IdentityVerificationEntity idVerification = identityVerificationService.findBy(ownerId);
 
         final DocumentMetadata uploadedDocument = documentProcessingService.uploadDocument(idVerification, requestData, ownerId);
@@ -342,7 +340,7 @@ public class IdentityVerificationController {
         final OwnerId ownerId = PowerAuthUtil.getOwnerId(apiAuthentication);
         final String processId = request.getRequestObject().getProcessId();
 
-        // Onboarding process is not locked
+        logger.debug("Onboarding process will not be locked, {}", processId);
         onboardingService.verifyProcessId(ownerId, processId, OnboardingStatus.VERIFICATION_IN_PROGRESS);
 
         final DocumentStatusResponse response = identityVerificationService.fetchDocumentStatusResponse(request.getRequestObject(), ownerId);
@@ -380,7 +378,7 @@ public class IdentityVerificationController {
         final OwnerId ownerId = PowerAuthUtil.getOwnerId(apiAuthentication);
         final String processId = request.getRequestObject().getProcessId();
 
-        // Onboarding process is not locked
+        logger.debug("Onboarding process will not be locked, {}", processId);
         onboardingService.verifyProcessId(ownerId, processId, OnboardingStatus.VERIFICATION_IN_PROGRESS);
 
         final Map<String, String> attributes = request.getRequestObject().getAttributes();
@@ -423,7 +421,7 @@ public class IdentityVerificationController {
         final OwnerId ownerId = PowerAuthUtil.getOwnerId(apiAuthentication);
         final String processId = request.getRequestObject().getProcessId();
 
-        // Lock onboarding process
+        logger.debug("Onboarding process will be locked using PESSIMISTIC_WRITE lock, {}", processId);
         onboardingService.verifyProcessIdAndLock(ownerId, processId, OnboardingStatus.VERIFICATION_IN_PROGRESS);
 
         StateMachine<OnboardingState, OnboardingEvent> stateMachine = stateMachineService.processStateMachineEvent(ownerId, processId, OnboardingEvent.PRESENCE_CHECK_INIT);
@@ -460,7 +458,7 @@ public class IdentityVerificationController {
         final OwnerId ownerId = PowerAuthUtil.getOwnerId(apiAuthentication);
         final String processId = request.getRequestObject().getProcessId();
 
-        // Lock onboarding process
+        logger.debug("Onboarding process will be locked using PESSIMISTIC_WRITE lock, {}", processId);
         onboardingService.verifyProcessIdAndLock(ownerId, processId, OnboardingStatus.VERIFICATION_IN_PROGRESS);
 
         StateMachine<OnboardingState, OnboardingEvent> stateMachine = stateMachineService.processStateMachineEvent(ownerId, processId, OnboardingEvent.PRESENCE_CHECK_SUBMITTED);
@@ -491,7 +489,7 @@ public class IdentityVerificationController {
         final OwnerId ownerId = extractOwnerId(eciesContext);
         final String processId = request.getRequestObject().getProcessId();
 
-        // Lock onboarding process
+        logger.debug("Onboarding process will be locked using PESSIMISTIC_WRITE lock, {}", processId);
         onboardingService.verifyProcessIdAndLock(ownerId, processId, OnboardingStatus.VERIFICATION_IN_PROGRESS);
 
         StateMachine<OnboardingState, OnboardingEvent> stateMachine = stateMachineService.processStateMachineEvent(ownerId, processId, OnboardingEvent.OTP_VERIFICATION_RESEND);
@@ -521,7 +519,7 @@ public class IdentityVerificationController {
         final OwnerId ownerId = extractOwnerId(eciesContext);
         final String processId = request.getRequestObject().getProcessId();
 
-        // Lock onboarding process
+        logger.debug("Onboarding process will be locked using PESSIMISTIC_WRITE lock, {}", processId);
         onboardingService.verifyProcessIdAndLock(ownerId, processId, OnboardingStatus.VERIFICATION_IN_PROGRESS);
 
         final String otpCode = request.getRequestObject().getOtpCode();
@@ -569,7 +567,7 @@ public class IdentityVerificationController {
         final OwnerId ownerId = PowerAuthUtil.getOwnerId(apiAuthentication);
         final String processId = request.getRequestObject().getProcessId();
 
-        // Lock onboarding process
+        logger.debug("Onboarding process will be locked using PESSIMISTIC_WRITE lock, {}", processId);
         onboardingService.verifyProcessIdAndLock(ownerId, processId, OnboardingStatus.VERIFICATION_IN_PROGRESS);
 
         // Process cleanup request
@@ -603,7 +601,7 @@ public class IdentityVerificationController {
         final OwnerId ownerId = extractOwnerId(eciesContext);
         final String processId = requestObject.getProcessId();
 
-        // Onboarding process is not locked
+        logger.debug("Onboarding process will not be locked, {}", processId);
         onboardingService.verifyProcessId(ownerId, processId, OnboardingStatus.VERIFICATION_IN_PROGRESS);
 
         return new ObjectResponse<>(onboardingService.fetchConsentText(requestObject));
@@ -633,7 +631,7 @@ public class IdentityVerificationController {
         final OwnerId ownerId = PowerAuthUtil.getOwnerId(apiAuthentication);
         final String processId = requestObject.getProcessId();
 
-        // Onboarding process is not locked
+        logger.debug("Onboarding process will not be locked, {}", processId);
         onboardingService.verifyProcessId(ownerId, processId, OnboardingStatus.VERIFICATION_IN_PROGRESS);
 
         onboardingService.approveConsent(requestObject);

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/controller/api/IdentityVerificationController.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/controller/api/IdentityVerificationController.java
@@ -19,28 +19,12 @@ package com.wultra.app.onboardingserver.controller.api;
 
 import com.wultra.app.enrollmentserver.api.model.onboarding.request.*;
 import com.wultra.app.enrollmentserver.api.model.onboarding.response.*;
-import com.wultra.app.enrollmentserver.api.model.onboarding.response.data.ConfigurationDataDto;
-import com.wultra.app.enrollmentserver.api.model.onboarding.response.data.DocumentMetadataResponseDto;
-import com.wultra.app.enrollmentserver.model.DocumentMetadata;
-import com.wultra.app.enrollmentserver.model.enumeration.OnboardingStatus;
-import com.wultra.app.enrollmentserver.model.integration.OwnerId;
-import com.wultra.app.enrollmentserver.model.integration.VerificationSdkInfo;
-import com.wultra.app.onboardingserver.common.database.entity.OnboardingProcessEntity;
 import com.wultra.app.onboardingserver.common.errorhandling.*;
-import com.wultra.app.onboardingserver.configuration.IdentityVerificationConfig;
-import com.wultra.app.onboardingserver.configuration.OnboardingConfig;
-import com.wultra.app.onboardingserver.common.database.entity.DocumentVerificationEntity;
-import com.wultra.app.onboardingserver.common.database.entity.IdentityVerificationEntity;
-import com.wultra.app.onboardingserver.errorhandling.*;
-import com.wultra.app.onboardingserver.impl.service.*;
-import com.wultra.app.onboardingserver.impl.service.document.DocumentProcessingService;
-import com.wultra.app.onboardingserver.impl.util.PowerAuthUtil;
-import com.wultra.app.onboardingserver.statemachine.consts.ExtendedStateVariable;
-import com.wultra.app.onboardingserver.statemachine.enums.OnboardingEvent;
-import com.wultra.app.onboardingserver.statemachine.enums.OnboardingState;
-import com.wultra.app.onboardingserver.statemachine.service.StateMachineService;
+import com.wultra.app.onboardingserver.errorhandling.DocumentSubmitException;
+import com.wultra.app.onboardingserver.errorhandling.DocumentVerificationException;
+import com.wultra.app.onboardingserver.errorhandling.PresenceCheckException;
+import com.wultra.app.onboardingserver.impl.service.IdentityVerificationRestService;
 import io.getlime.core.rest.model.base.request.ObjectRequest;
-import io.getlime.core.rest.model.base.response.ErrorResponse;
 import io.getlime.core.rest.model.base.response.ObjectResponse;
 import io.getlime.core.rest.model.base.response.Response;
 import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.model.EciesScope;
@@ -53,24 +37,14 @@ import io.getlime.security.powerauth.rest.api.spring.authentication.PowerAuthApi
 import io.getlime.security.powerauth.rest.api.spring.encryption.EciesEncryptionContext;
 import io.getlime.security.powerauth.rest.api.spring.exception.PowerAuthAuthenticationException;
 import io.getlime.security.powerauth.rest.api.spring.exception.PowerAuthEncryptionException;
-import io.getlime.security.powerauth.rest.api.spring.exception.authentication.PowerAuthTokenInvalidException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.statemachine.StateMachine;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import javax.annotation.Nullable;
-import java.util.List;
-import java.util.Map;
 
 /**
  * Controller publishing REST services for identity document verification.
@@ -85,61 +59,15 @@ import java.util.Map;
 @RequestMapping(value = "api/identity")
 public class IdentityVerificationController {
 
-    private static final Logger logger = LoggerFactory.getLogger(IdentityVerificationController.class);
-
-    private final IdentityVerificationConfig identityVerificationConfig;
-
-    private final DocumentProcessingService documentProcessingService;
-    private final IdentityVerificationService identityVerificationService;
-    private final IdentityVerificationStatusService identityVerificationStatusService;
-    private final IdentityVerificationOtpService identityVerificationOtpService;
-    private final PresenceCheckService presenceCheckService;
-
-    private final StateMachineService stateMachineService;
-
-    private final OnboardingServiceImpl onboardingService;
-
-    /**
-     * Configuration data for client integration
-     */
-    private final ConfigurationDataDto integrationConfigDto;
+    private final IdentityVerificationRestService identityVerificationRestService;
 
     /**
      * Controller constructor.
-     *
-     * @param identityVerificationConfig        Configuration of identity verification.
-     * @param onboardingConfig                  Configuration of onboarding.
-     * @param documentProcessingService         Document processing service.
-     * @param identityVerificationService       Identity verification service.
-     * @param identityVerificationStatusService Identity verification status service.
-     * @param identityVerificationOtpService    Identity OTP verification service.
-     * @param onboardingService                 Onboarding service.
-     * @param presenceCheckService              Presence check service.
-     * @param stateMachineService               State machine service.
+     * @param identityVerificationRestService  Identity verification entry service.
      */
     @Autowired
-    public IdentityVerificationController(
-            IdentityVerificationConfig identityVerificationConfig,
-            OnboardingConfig onboardingConfig,
-            DocumentProcessingService documentProcessingService,
-            IdentityVerificationService identityVerificationService,
-            IdentityVerificationStatusService identityVerificationStatusService,
-            IdentityVerificationOtpService identityVerificationOtpService,
-            OnboardingServiceImpl onboardingService,
-            PresenceCheckService presenceCheckService,
-            StateMachineService stateMachineService) {
-        this.identityVerificationConfig = identityVerificationConfig;
-
-        this.documentProcessingService = documentProcessingService;
-        this.identityVerificationService = identityVerificationService;
-        this.identityVerificationStatusService = identityVerificationStatusService;
-        this.identityVerificationOtpService = identityVerificationOtpService;
-        this.onboardingService = onboardingService;
-        this.presenceCheckService = presenceCheckService;
-        this.stateMachineService = stateMachineService;
-
-        this.integrationConfigDto = new ConfigurationDataDto();
-        integrationConfigDto.setOtpResendPeriod(onboardingConfig.getOtpResendPeriod().toString());
+    public IdentityVerificationController(IdentityVerificationRestService identityVerificationRestService) {
+        this.identityVerificationRestService = identityVerificationRestService;
     }
 
     /**
@@ -158,29 +86,12 @@ public class IdentityVerificationController {
     @PowerAuth(resourceId = "/api/identity/init", signatureType = {
             PowerAuthSignatureTypes.POSSESSION
     })
-    // TODO - move to service before finishing pull request
-    @Transactional
     public ResponseEntity<Response> initializeIdentityVerification(@EncryptedRequestBody ObjectRequest<IdentityVerificationInitRequest> request,
                                                                    @Parameter(hidden = true) EciesEncryptionContext eciesContext,
                                                                    @Parameter(hidden = true) PowerAuthApiAuthentication apiAuthentication)
             throws PowerAuthAuthenticationException, IdentityVerificationException, PowerAuthEncryptionException, OnboardingProcessException {
 
-        final String operationDescription = "initializing identity verification";
-        checkApiAuthentication(apiAuthentication, operationDescription);
-        checkEciesContext(eciesContext, operationDescription);
-        checkRequestObject(request, operationDescription);
-
-        // Initialize identity verification
-        final OwnerId ownerId = PowerAuthUtil.getOwnerId(apiAuthentication);
-        final String processId = request.getRequestObject().getProcessId();
-
-        logger.debug("Onboarding process will be locked using PESSIMISTIC_WRITE lock, {}", processId);
-        onboardingService.verifyProcessIdAndLock(ownerId, processId, OnboardingStatus.VERIFICATION_IN_PROGRESS);
-
-        StateMachine<OnboardingState, OnboardingEvent> stateMachine =
-                stateMachineService.processStateMachineEvent(ownerId, processId, OnboardingEvent.IDENTITY_VERIFICATION_INIT);
-
-        return createResponseEntity(stateMachine);
+        return identityVerificationRestService.initializeIdentityVerification(request, eciesContext, apiAuthentication);
     }
 
     /**
@@ -205,20 +116,7 @@ public class IdentityVerificationController {
                                                                                               @Parameter(hidden = true) PowerAuthApiAuthentication apiAuthentication)
             throws PowerAuthAuthenticationException, PowerAuthEncryptionException, RemoteCommunicationException, OnboardingProcessException {
 
-        final String operationDescription = "checking identity verification status";
-        checkApiAuthentication(apiAuthentication, operationDescription);
-        checkEciesContext(eciesContext, operationDescription);
-        checkRequestObject(request, operationDescription);
-
-        final OwnerId ownerId = PowerAuthUtil.getOwnerId(apiAuthentication);
-
-        logger.debug("Onboarding process will not be locked, {}", ownerId);
-        // Check verification status
-        final IdentityVerificationStatusResponse response =
-                identityVerificationStatusService.checkIdentityVerificationStatus(request.getRequestObject(), ownerId);
-        response.setConfig(integrationConfigDto);
-
-        return new ObjectResponse<>(response);
+       return identityVerificationRestService.checkIdentityVerificationStatus(request, eciesContext, apiAuthentication);
     }
 
     /**
@@ -240,35 +138,12 @@ public class IdentityVerificationController {
     @PowerAuthToken(signatureType = {
             PowerAuthSignatureTypes.POSSESSION
     })
-    // TODO - move to service before finishing pull request
-    @Transactional
     public ObjectResponse<DocumentSubmitResponse> submitDocuments(@EncryptedRequestBody ObjectRequest<DocumentSubmitRequest> request,
                                                                   @Parameter(hidden = true) EciesEncryptionContext eciesContext,
                                                                   @Parameter(hidden = true) PowerAuthApiAuthentication apiAuthentication)
             throws PowerAuthAuthenticationException, PowerAuthEncryptionException, DocumentSubmitException, OnboardingProcessException, IdentityVerificationLimitException, RemoteCommunicationException, IdentityVerificationException, OnboardingProcessLimitException {
 
-        final String operationDescription = "submitting documents for verification";
-        checkApiAuthentication(apiAuthentication, operationDescription);
-        checkEciesContext(eciesContext, operationDescription);
-        checkRequestObject(request, operationDescription);
-
-        // Extract user ID from onboarding process for current activation
-        final OwnerId ownerId = extractOwnerId(eciesContext);
-        final String processId = request.getRequestObject().getProcessId();
-
-        logger.debug("Onboarding process will be locked using PESSIMISTIC_WRITE lock, {}", processId);
-        onboardingService.verifyProcessIdAndLock(ownerId, processId, OnboardingStatus.VERIFICATION_IN_PROGRESS);
-
-        // Submit documents for verification
-        final List<DocumentVerificationEntity> docVerificationEntities =
-                identityVerificationService.submitDocuments(request.getRequestObject(), ownerId);
-
-        final DocumentSubmitResponse response = new DocumentSubmitResponse();
-        final List<DocumentMetadataResponseDto> respsMetadata =
-                identityVerificationService.createDocsMetadata(docVerificationEntities);
-        response.setDocuments(respsMetadata);
-
-        return new ObjectResponse<>(response);
+        return identityVerificationRestService.submitDocuments(request, eciesContext, apiAuthentication);
     }
 
     /**
@@ -292,24 +167,7 @@ public class IdentityVerificationController {
                                                                  @Parameter(hidden = true) PowerAuthApiAuthentication apiAuthentication)
             throws IdentityVerificationException, PowerAuthAuthenticationException, PowerAuthEncryptionException, DocumentVerificationException, OnboardingProcessException {
 
-        final String operationDescription = "uploading document for verification";
-        checkApiAuthentication(apiAuthentication, operationDescription);
-        checkEciesContext(eciesContext, operationDescription);
-        checkRequest(requestData, operationDescription);
-
-        // Extract user ID from onboarding process for current activation
-        final OwnerId ownerId = extractOwnerId(eciesContext);
-
-        logger.debug("Onboarding process will not be locked, {}", ownerId);
-        IdentityVerificationEntity idVerification = identityVerificationService.findBy(ownerId);
-
-        final DocumentMetadata uploadedDocument = documentProcessingService.uploadDocument(idVerification, requestData, ownerId);
-
-        final DocumentUploadResponse response = new DocumentUploadResponse();
-        response.setFilename(uploadedDocument.getFilename());
-        response.setId(uploadedDocument.getId());
-
-        return new ObjectResponse<>(response);
+        return identityVerificationRestService.uploadDocument(requestData, eciesContext, apiAuthentication);
     }
 
     /**
@@ -332,19 +190,7 @@ public class IdentityVerificationController {
                                                                       @Parameter(hidden = true) PowerAuthApiAuthentication apiAuthentication)
             throws PowerAuthAuthenticationException, PowerAuthEncryptionException, OnboardingProcessException {
 
-        final String operationDescription = "checking document verification status";
-        checkApiAuthentication(apiAuthentication, operationDescription);
-        checkEciesContext(eciesContext, operationDescription);
-        checkRequestObject(request, operationDescription);
-
-        final OwnerId ownerId = PowerAuthUtil.getOwnerId(apiAuthentication);
-        final String processId = request.getRequestObject().getProcessId();
-
-        logger.debug("Onboarding process will not be locked, {}", processId);
-        onboardingService.verifyProcessId(ownerId, processId, OnboardingStatus.VERIFICATION_IN_PROGRESS);
-
-        final DocumentStatusResponse response = identityVerificationService.fetchDocumentStatusResponse(request.getRequestObject(), ownerId);
-        return new ObjectResponse<>(response);
+        return identityVerificationRestService.checkDocumentStatus(request, eciesContext, apiAuthentication);
     }
 
     /**
@@ -370,23 +216,7 @@ public class IdentityVerificationController {
             @Parameter(hidden = true) PowerAuthApiAuthentication apiAuthentication)
             throws PowerAuthAuthenticationException, DocumentVerificationException, PowerAuthEncryptionException, OnboardingProcessException, RemoteCommunicationException {
 
-        final String operationDescription = "initializing document verification SDK";
-        checkApiAuthentication(apiAuthentication, operationDescription);
-        checkEciesContext(eciesContext, operationDescription);
-        checkRequestObject(request, operationDescription);
-
-        final OwnerId ownerId = PowerAuthUtil.getOwnerId(apiAuthentication);
-        final String processId = request.getRequestObject().getProcessId();
-
-        logger.debug("Onboarding process will not be locked, {}", processId);
-        onboardingService.verifyProcessId(ownerId, processId, OnboardingStatus.VERIFICATION_IN_PROGRESS);
-
-        final Map<String, String> attributes = request.getRequestObject().getAttributes();
-        final VerificationSdkInfo sdkVerificationInfo = identityVerificationService.initVerificationSdk(ownerId, attributes);
-
-        final DocumentVerificationSdkInitResponse response = new DocumentVerificationSdkInitResponse();
-        response.setAttributes(sdkVerificationInfo.getAttributes());
-        return new ObjectResponse<>(response);
+        return identityVerificationRestService.initVerificationSdk(request, eciesContext, apiAuthentication);
     }
 
     /**
@@ -406,26 +236,12 @@ public class IdentityVerificationController {
     @PowerAuth(resourceId = "/api/identity/presence-check/init", signatureType = {
             PowerAuthSignatureTypes.POSSESSION
     })
-    // TODO - move to service before finishing pull request
-    @Transactional
     public ResponseEntity<Response> initPresenceCheck(@EncryptedRequestBody ObjectRequest<PresenceCheckInitRequest> request,
                                                       @Parameter(hidden = true) EciesEncryptionContext eciesContext,
                                                       @Parameter(hidden = true) PowerAuthApiAuthentication apiAuthentication)
             throws IdentityVerificationException, PowerAuthAuthenticationException, PowerAuthEncryptionException, OnboardingProcessException {
 
-        final String operationDescription = "initializing presence check";
-        checkApiAuthentication(apiAuthentication, operationDescription);
-        checkEciesContext(eciesContext, operationDescription);
-        checkRequestObject(request, operationDescription);
-
-        final OwnerId ownerId = PowerAuthUtil.getOwnerId(apiAuthentication);
-        final String processId = request.getRequestObject().getProcessId();
-
-        logger.debug("Onboarding process will be locked using PESSIMISTIC_WRITE lock, {}", processId);
-        onboardingService.verifyProcessIdAndLock(ownerId, processId, OnboardingStatus.VERIFICATION_IN_PROGRESS);
-
-        StateMachine<OnboardingState, OnboardingEvent> stateMachine = stateMachineService.processStateMachineEvent(ownerId, processId, OnboardingEvent.PRESENCE_CHECK_INIT);
-        return createResponseEntity(stateMachine);
+        return identityVerificationRestService.initPresenceCheck(request, eciesContext, apiAuthentication);
     }
 
     /**
@@ -443,26 +259,12 @@ public class IdentityVerificationController {
     @PostMapping("presence-check/submit")
     @PowerAuthEncryption(scope = EciesScope.ACTIVATION_SCOPE)
     @PowerAuth(resourceId = "/api/identity/presence-check/submit", signatureType = PowerAuthSignatureTypes.POSSESSION)
-    // TODO - move to service before finishing pull request
-    @Transactional
     public ResponseEntity<Response> submitPresenceCheck(@EncryptedRequestBody ObjectRequest<PresenceCheckSubmitRequest> request,
                                                         @Parameter(hidden = true) EciesEncryptionContext eciesContext,
                                                         @Parameter(hidden = true) PowerAuthApiAuthentication apiAuthentication)
             throws IdentityVerificationException, PowerAuthAuthenticationException, PowerAuthEncryptionException, OnboardingProcessException {
 
-        final String operationDescription = "submitting presence check";
-        checkApiAuthentication(apiAuthentication, operationDescription);
-        checkEciesContext(eciesContext, operationDescription);
-        checkRequestObject(request, operationDescription);
-
-        final OwnerId ownerId = PowerAuthUtil.getOwnerId(apiAuthentication);
-        final String processId = request.getRequestObject().getProcessId();
-
-        logger.debug("Onboarding process will be locked using PESSIMISTIC_WRITE lock, {}", processId);
-        onboardingService.verifyProcessIdAndLock(ownerId, processId, OnboardingStatus.VERIFICATION_IN_PROGRESS);
-
-        StateMachine<OnboardingState, OnboardingEvent> stateMachine = stateMachineService.processStateMachineEvent(ownerId, processId, OnboardingEvent.PRESENCE_CHECK_SUBMITTED);
-        return createResponseEntity(stateMachine);
+        return identityVerificationRestService.submitPresenceCheck(request, eciesContext, apiAuthentication);
     }
 
     /**
@@ -476,24 +278,11 @@ public class IdentityVerificationController {
      */
     @PostMapping("otp/resend")
     @PowerAuthEncryption(scope = EciesScope.ACTIVATION_SCOPE)
-    // TODO - move to service before finishing pull request
-    @Transactional
     public ResponseEntity<Response> resendOtp(@EncryptedRequestBody ObjectRequest<IdentityVerificationOtpSendRequest> request,
                                               @Parameter(hidden = true) EciesEncryptionContext eciesContext)
             throws IdentityVerificationException, PowerAuthEncryptionException, OnboardingProcessException {
 
-        checkEciesContext(eciesContext, "resending OTP during identity verification");
-        checkRequestObject(request, "resending OTP during identity verification");
-
-        // Extract user ID from onboarding process for current activation, lock onboarding process
-        final OwnerId ownerId = extractOwnerId(eciesContext);
-        final String processId = request.getRequestObject().getProcessId();
-
-        logger.debug("Onboarding process will be locked using PESSIMISTIC_WRITE lock, {}", processId);
-        onboardingService.verifyProcessIdAndLock(ownerId, processId, OnboardingStatus.VERIFICATION_IN_PROGRESS);
-
-        StateMachine<OnboardingState, OnboardingEvent> stateMachine = stateMachineService.processStateMachineEvent(ownerId, processId, OnboardingEvent.OTP_VERIFICATION_RESEND);
-        return createResponseEntity(stateMachine);
+        return identityVerificationRestService.resendOtp(request, eciesContext);
     }
 
     /**
@@ -506,32 +295,11 @@ public class IdentityVerificationController {
      */
     @PostMapping("otp/verify")
     @PowerAuthEncryption(scope = EciesScope.ACTIVATION_SCOPE)
-    // TODO - move to service before finishing pull request
-    @Transactional
     public ObjectResponse<OtpVerifyResponse> verifyOtp(@EncryptedRequestBody ObjectRequest<IdentityVerificationOtpVerifyRequest> request,
                                                        @Parameter(hidden = true) EciesEncryptionContext eciesContext)
             throws PowerAuthEncryptionException, OnboardingProcessException {
 
-        checkEciesContext(eciesContext, "verifying OTP during identity verification");
-        checkRequestObject(request, "verifying OTP during identity verification");
-
-        // Extract user ID from onboarding process for current activation
-        final OwnerId ownerId = extractOwnerId(eciesContext);
-        final String processId = request.getRequestObject().getProcessId();
-
-        logger.debug("Onboarding process will be locked using PESSIMISTIC_WRITE lock, {}", processId);
-        onboardingService.verifyProcessIdAndLock(ownerId, processId, OnboardingStatus.VERIFICATION_IN_PROGRESS);
-
-        final String otpCode = request.getRequestObject().getOtpCode();
-        final OtpVerifyResponse otpVerifyResponse = identityVerificationOtpService.verifyOtpCode(processId, ownerId, otpCode);
-
-        try {
-            stateMachineService.processStateMachineEvent(ownerId, processId, OnboardingEvent.EVENT_NEXT_STATE);
-        } catch (IdentityVerificationException e) {
-            throw new OnboardingProcessException("Unable to move state machine for " + ownerId, e);
-        }
-
-        return new ObjectResponse<>(otpVerifyResponse);
+        return identityVerificationRestService.verifyOtp(request, eciesContext);
     }
 
     /**
@@ -552,35 +320,22 @@ public class IdentityVerificationController {
     @PowerAuth(resourceId = "/api/identity/cleanup", signatureType = {
             PowerAuthSignatureTypes.POSSESSION
     })
-    // TODO - move to service before finishing pull request
-    @Transactional
     public Response cleanup(@EncryptedRequestBody ObjectRequest<IdentityVerificationCleanupRequest> request,
                             @Parameter(hidden = true) EciesEncryptionContext eciesContext,
                             @Parameter(hidden = true) PowerAuthApiAuthentication apiAuthentication)
             throws PowerAuthAuthenticationException, PowerAuthEncryptionException, DocumentVerificationException, PresenceCheckException, RemoteCommunicationException, OnboardingProcessException, IdentityVerificationException, OnboardingProcessLimitException {
 
-        final String operationDescription = "performing document cleanup";
-        checkApiAuthentication(apiAuthentication, operationDescription);
-        checkEciesContext(eciesContext, operationDescription);
-        checkRequestObject(request, operationDescription);
-
-        final OwnerId ownerId = PowerAuthUtil.getOwnerId(apiAuthentication);
-        final String processId = request.getRequestObject().getProcessId();
-
-        logger.debug("Onboarding process will be locked using PESSIMISTIC_WRITE lock, {}", processId);
-        onboardingService.verifyProcessIdAndLock(ownerId, processId, OnboardingStatus.VERIFICATION_IN_PROGRESS);
-
-        // Process cleanup request
-        identityVerificationService.cleanup(ownerId);
-        if (identityVerificationConfig.isPresenceCheckEnabled()) {
-            presenceCheckService.cleanup(ownerId);
-        } else {
-            logger.debug("Skipped presence check cleanup, not enabled");
-        }
-
-        return new Response();
+        return identityVerificationRestService.cleanup(request, eciesContext, apiAuthentication);
     }
 
+    /**
+     * Obtain consent text.
+     * @param request Obtain consent text request.
+     * @param eciesContext ECIES context.
+     * @return Consent text.
+     * @throws OnboardingProcessException Thrown when onboarding process is not found.
+     * @throws PowerAuthEncryptionException Thrown when request decryption fails.
+     */
     @PostMapping("consent/text")
     @Operation(
             summary = "Obtain consent text",
@@ -591,22 +346,19 @@ public class IdentityVerificationController {
             final @EncryptedRequestBody ObjectRequest<OnboardingConsentTextRequest> request,
             final @Parameter(hidden = true) EciesEncryptionContext eciesContext) throws OnboardingProcessException, PowerAuthEncryptionException {
 
-        checkEciesContext(eciesContext, "obtaining user consent text");
-        checkRequestObject(request, "obtaining user consent text");
-
-        final OnboardingConsentTextRequest requestObject = request.getRequestObject();
-        logger.debug("Returning consent for {}", requestObject);
-        OnboardingConsentTextRequestValidator.validate(requestObject);
-
-        final OwnerId ownerId = extractOwnerId(eciesContext);
-        final String processId = requestObject.getProcessId();
-
-        logger.debug("Onboarding process will not be locked, {}", processId);
-        onboardingService.verifyProcessId(ownerId, processId, OnboardingStatus.VERIFICATION_IN_PROGRESS);
-
-        return new ObjectResponse<>(onboardingService.fetchConsentText(requestObject));
+        return identityVerificationRestService.fetchConsentText(request, eciesContext);
     }
 
+    /**
+     * Approve or reject consent.
+     * @param request Approve consent request
+     * @param eciesContext ECIES context.
+     * @param apiAuthentication PowerAuth authentication.
+     * @return Response.
+     * @throws OnboardingProcessException Thrown when onboarding process is not found.
+     * @throws PowerAuthAuthenticationException Thrown when request authentication fails.
+     * @throws PowerAuthEncryptionException Thrown when request decryption fails.
+     */
     @PostMapping("consent/approve")
     @Operation(
             summary = "Store user consent",
@@ -619,92 +371,7 @@ public class IdentityVerificationController {
             final @Parameter(hidden = true) EciesEncryptionContext eciesContext,
             final @Parameter(hidden = true) PowerAuthApiAuthentication apiAuthentication) throws OnboardingProcessException, PowerAuthAuthenticationException, PowerAuthEncryptionException {
 
-        final String operationDescription = "approving user consent";
-        checkApiAuthentication(apiAuthentication, operationDescription);
-        checkEciesContext(eciesContext, operationDescription);
-        checkRequestObject(request, operationDescription);
-
-        final OnboardingConsentApprovalRequest requestObject = request.getRequestObject();
-        logger.debug("Approving consent for {}", requestObject);
-        OnboardingConsentApprovalRequestValidator.validate(requestObject);
-
-        final OwnerId ownerId = PowerAuthUtil.getOwnerId(apiAuthentication);
-        final String processId = requestObject.getProcessId();
-
-        logger.debug("Onboarding process will not be locked, {}", processId);
-        onboardingService.verifyProcessId(ownerId, processId, OnboardingStatus.VERIFICATION_IN_PROGRESS);
-
-        onboardingService.approveConsent(requestObject);
-        return new Response();
-    }
-
-    /**
-     * Checks if the API authentication object is present
-     * @param apiAuthentication API authentication object value
-     * @param description Additional description
-     * @throws PowerAuthTokenInvalidException When the API authentication object does not exist
-     */
-    private void checkApiAuthentication(@Nullable PowerAuthApiAuthentication apiAuthentication, String description) throws PowerAuthTokenInvalidException {
-        if (apiAuthentication == null) {
-            String errorMessage = String.format("Unable to verify device registration when %s", description);
-            logger.error(errorMessage);
-            throw new PowerAuthTokenInvalidException(errorMessage);
-        }
-    }
-
-    /**
-     * Checks if the request was correctly decrypted
-     * @param eciesContext ECIES encryption context
-     * @param description Additional description
-     * @throws PowerAuthEncryptionException When the ECIES encryption context does not exist
-     */
-    private void checkEciesContext(@Nullable EciesEncryptionContext eciesContext, String description) throws PowerAuthEncryptionException {
-        if (eciesContext == null) {
-            String errorMessage = String.format("ECIES encryption failed when %s", description);
-            logger.error(errorMessage);
-            throw new PowerAuthEncryptionException(errorMessage);
-        }
-    }
-
-    private void checkRequest(@Nullable Object request, String description) throws PowerAuthEncryptionException {
-        if (request == null) {
-            String errorMessage = String.format("Invalid request received when %s", description);
-            logger.error(errorMessage);
-            throw new PowerAuthEncryptionException(errorMessage);
-        }
-    }
-
-    private void checkRequestObject(@Nullable ObjectRequest<?> request, String description) throws PowerAuthEncryptionException {
-        if (request == null || request.getRequestObject() == null) {
-            String errorMessage = String.format("Invalid request received when %s", description);
-            logger.error(errorMessage);
-            throw new PowerAuthEncryptionException(errorMessage);
-        }
-    }
-
-    /**
-     * Extract owner identification from an ECIES context. The onboarding process is not locked.
-     *
-     * @param eciesContext ECIES context.
-     * @return Owner identification.
-     */
-    private OwnerId extractOwnerId(EciesEncryptionContext eciesContext) throws OnboardingProcessException {
-        final OnboardingProcessEntity onboardingProcess = onboardingService.findExistingProcessWithVerificationInProgress(eciesContext.getActivationId());
-        final OwnerId ownerId = new OwnerId();
-        ownerId.setActivationId(onboardingProcess.getActivationId());
-        ownerId.setUserId(onboardingProcess.getUserId());
-        return ownerId;
-    }
-
-    private ResponseEntity<Response> createResponseEntity(StateMachine<OnboardingState, OnboardingEvent> stateMachine) {
-        Response response = stateMachine.getExtendedState().get(ExtendedStateVariable.RESPONSE_OBJECT, Response.class);
-        HttpStatus status = stateMachine.getExtendedState().get(ExtendedStateVariable.RESPONSE_STATUS, HttpStatus.class);
-        if (response == null || status == null) {
-            logger.warn("Missing one of important values to generate response entity, response={}, status={}", response, status);
-            response = new ErrorResponse("UNEXPECTED_ERROR", "Unexpected error occurred.");
-            status = HttpStatus.INTERNAL_SERVER_ERROR;
-        }
-        return new ResponseEntity<>(response, status);
+        return identityVerificationRestService.approveConsent(request, eciesContext, apiAuthentication);
     }
 
 }

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/controller/api/IdentityVerificationController.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/controller/api/IdentityVerificationController.java
@@ -63,6 +63,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.statemachine.StateMachine;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -157,6 +158,8 @@ public class IdentityVerificationController {
     @PowerAuth(resourceId = "/api/identity/init", signatureType = {
             PowerAuthSignatureTypes.POSSESSION
     })
+    // TODO - move to service before finishing pull request
+    @Transactional
     public ResponseEntity<Response> initializeIdentityVerification(@EncryptedRequestBody ObjectRequest<IdentityVerificationInitRequest> request,
                                                                    @Parameter(hidden = true) EciesEncryptionContext eciesContext,
                                                                    @Parameter(hidden = true) PowerAuthApiAuthentication apiAuthentication)
@@ -238,6 +241,8 @@ public class IdentityVerificationController {
     @PowerAuthToken(signatureType = {
             PowerAuthSignatureTypes.POSSESSION
     })
+    // TODO - move to service before finishing pull request
+    @Transactional
     public ObjectResponse<DocumentSubmitResponse> submitDocuments(@EncryptedRequestBody ObjectRequest<DocumentSubmitRequest> request,
                                                                   @Parameter(hidden = true) EciesEncryptionContext eciesContext,
                                                                   @Parameter(hidden = true) PowerAuthApiAuthentication apiAuthentication)
@@ -403,6 +408,8 @@ public class IdentityVerificationController {
     @PowerAuth(resourceId = "/api/identity/presence-check/init", signatureType = {
             PowerAuthSignatureTypes.POSSESSION
     })
+    // TODO - move to service before finishing pull request
+    @Transactional
     public ResponseEntity<Response> initPresenceCheck(@EncryptedRequestBody ObjectRequest<PresenceCheckInitRequest> request,
                                                       @Parameter(hidden = true) EciesEncryptionContext eciesContext,
                                                       @Parameter(hidden = true) PowerAuthApiAuthentication apiAuthentication)
@@ -438,6 +445,8 @@ public class IdentityVerificationController {
     @PostMapping("presence-check/submit")
     @PowerAuthEncryption(scope = EciesScope.ACTIVATION_SCOPE)
     @PowerAuth(resourceId = "/api/identity/presence-check/submit", signatureType = PowerAuthSignatureTypes.POSSESSION)
+    // TODO - move to service before finishing pull request
+    @Transactional
     public ResponseEntity<Response> submitPresenceCheck(@EncryptedRequestBody ObjectRequest<PresenceCheckSubmitRequest> request,
                                                         @Parameter(hidden = true) EciesEncryptionContext eciesContext,
                                                         @Parameter(hidden = true) PowerAuthApiAuthentication apiAuthentication)
@@ -469,6 +478,8 @@ public class IdentityVerificationController {
      */
     @PostMapping("otp/resend")
     @PowerAuthEncryption(scope = EciesScope.ACTIVATION_SCOPE)
+    // TODO - move to service before finishing pull request
+    @Transactional
     public ResponseEntity<Response> resendOtp(@EncryptedRequestBody ObjectRequest<IdentityVerificationOtpSendRequest> request,
                                               @Parameter(hidden = true) EciesEncryptionContext eciesContext)
             throws IdentityVerificationException, PowerAuthEncryptionException, OnboardingProcessException {
@@ -497,6 +508,8 @@ public class IdentityVerificationController {
      */
     @PostMapping("otp/verify")
     @PowerAuthEncryption(scope = EciesScope.ACTIVATION_SCOPE)
+    // TODO - move to service before finishing pull request
+    @Transactional
     public ObjectResponse<OtpVerifyResponse> verifyOtp(@EncryptedRequestBody ObjectRequest<IdentityVerificationOtpVerifyRequest> request,
                                                        @Parameter(hidden = true) EciesEncryptionContext eciesContext)
             throws PowerAuthEncryptionException, OnboardingProcessException {
@@ -541,6 +554,8 @@ public class IdentityVerificationController {
     @PowerAuth(resourceId = "/api/identity/cleanup", signatureType = {
             PowerAuthSignatureTypes.POSSESSION
     })
+    // TODO - move to service before finishing pull request
+    @Transactional
     public Response cleanup(@EncryptedRequestBody ObjectRequest<IdentityVerificationCleanupRequest> request,
                             @Parameter(hidden = true) EciesEncryptionContext eciesContext,
                             @Parameter(hidden = true) PowerAuthApiAuthentication apiAuthentication)

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/controller/api/OnboardingController.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/controller/api/OnboardingController.java
@@ -156,7 +156,7 @@ public class OnboardingController {
             throw new PowerAuthEncryptionException("Invalid request received while getting status");
         }
 
-        // Onboarding process is not locked
+        logger.debug("Onboarding process will not be locked, {}", request.getRequestObject().getProcessId());
         OnboardingStatusResponse response = onboardingService.getStatus(request.getRequestObject());
         return new ObjectResponse<>(response);
     }

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/controller/api/OnboardingController.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/controller/api/OnboardingController.java
@@ -98,7 +98,6 @@ public class OnboardingController {
             throw new PowerAuthEncryptionException("Invalid request received during onboarding");
         }
 
-        // Onboarding process is locked inside the service
         OnboardingStartResponse response = onboardingService.startOnboarding(request.getRequestObject());
         return new ObjectResponse<>(response);
     }
@@ -128,7 +127,6 @@ public class OnboardingController {
             throw new PowerAuthEncryptionException("Invalid request received while resending OTP code");
         }
 
-        // Onboarding process is locked inside the service
         return onboardingService.resendOtp(request.getRequestObject());
     }
 
@@ -185,7 +183,6 @@ public class OnboardingController {
             throw new PowerAuthEncryptionException("Invalid request received during onboarding");
         }
 
-        // Onboarding process is locked inside the service
         return onboardingService.performCleanup(request.getRequestObject());
     }
 }

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/controller/api/OnboardingController.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/controller/api/OnboardingController.java
@@ -98,6 +98,7 @@ public class OnboardingController {
             throw new PowerAuthEncryptionException("Invalid request received during onboarding");
         }
 
+        // Onboarding process is locked inside the service
         OnboardingStartResponse response = onboardingService.startOnboarding(request.getRequestObject());
         return new ObjectResponse<>(response);
     }
@@ -127,6 +128,7 @@ public class OnboardingController {
             throw new PowerAuthEncryptionException("Invalid request received while resending OTP code");
         }
 
+        // Onboarding process is locked inside the service
         return onboardingService.resendOtp(request.getRequestObject());
     }
 
@@ -154,6 +156,7 @@ public class OnboardingController {
             throw new PowerAuthEncryptionException("Invalid request received while getting status");
         }
 
+        // Onboarding process is not locked
         OnboardingStatusResponse response = onboardingService.getStatus(request.getRequestObject());
         return new ObjectResponse<>(response);
     }
@@ -182,6 +185,7 @@ public class OnboardingController {
             throw new PowerAuthEncryptionException("Invalid request received during onboarding");
         }
 
+        // Onboarding process is locked inside the service
         return onboardingService.performCleanup(request.getRequestObject());
     }
 }

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/ClientEvaluationService.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/ClientEvaluationService.java
@@ -24,9 +24,7 @@ import com.wultra.app.enrollmentserver.model.enumeration.IdentityVerificationSta
 import com.wultra.app.enrollmentserver.model.integration.OwnerId;
 import com.wultra.app.onboardingserver.common.database.entity.DocumentVerificationEntity;
 import com.wultra.app.onboardingserver.common.database.entity.IdentityVerificationEntity;
-import com.wultra.app.onboardingserver.common.errorhandling.OnboardingProcessException;
 import com.wultra.app.onboardingserver.common.service.AuditService;
-import com.wultra.app.onboardingserver.common.service.CommonOnboardingService;
 import com.wultra.app.onboardingserver.configuration.IdentityVerificationConfig;
 import com.wultra.app.onboardingserver.provider.OnboardingProvider;
 import com.wultra.app.onboardingserver.provider.model.request.EvaluateClientRequest;
@@ -63,17 +61,15 @@ public class ClientEvaluationService {
 
     private final TransactionTemplate transactionTemplate;
 
-    private final CommonOnboardingService commonOnboardingService;
-
     private final AuditService auditService;
 
     /**
      * All-arg constructor.
+     *
      * @param onboardingProvider Onboarding provider.
      * @param config Identity verification config.
      * @param identityVerificationService Identity verification repository.
      * @param transactionTemplate Transaction template.
-     * @param commonOnboardingService Common onboarding service.
      * @param auditService Audit service.
      */
     @Autowired
@@ -82,13 +78,11 @@ public class ClientEvaluationService {
             final IdentityVerificationConfig config,
             final IdentityVerificationService identityVerificationService,
             final TransactionTemplate transactionTemplate,
-            final CommonOnboardingService commonOnboardingService,
             final AuditService auditService) {
         this.onboardingProvider = onboardingProvider;
         this.config = config;
         this.identityVerificationService = identityVerificationService;
         this.transactionTemplate = transactionTemplate;
-        this.commonOnboardingService = commonOnboardingService;
         this.auditService = auditService;
     }
 
@@ -134,13 +128,7 @@ public class ClientEvaluationService {
     }
 
     private Consumer<EvaluateClientResponse> createSuccessConsumer(final IdentityVerificationEntity identityVerification, final OwnerId ownerId) {
-        return response -> saveInANewTransaction(status -> {
-            try {
-                commonOnboardingService.findProcessWithLock(identityVerification.getProcessId());
-            } catch (OnboardingProcessException ex) {
-                logger.error(ex.getMessage(), ex);
-                return;
-            }
+        return response -> {
             auditService.auditOnboardingProvider(identityVerification, "Client evaluated for user: {}", ownerId.getUserId());
             // The timestampFinished parameter is not set yet, there may be other steps ahead
             if (response.isErrorOccurred()) {
@@ -153,7 +141,8 @@ public class ClientEvaluationService {
             final IdentityVerificationPhase phase = identityVerification.getPhase();
             if (response.isAccepted()) {
                 logger.info("Client evaluation accepted for {}", identityVerification);
-                identityVerificationService.moveToPhaseAndStatus(identityVerification, phase, ACCEPTED, ownerId);
+                saveInANewTransaction(status ->
+                        identityVerificationService.moveToPhaseAndStatus(identityVerification, phase, ACCEPTED, ownerId));
             } else {
                 logger.info("Client evaluation rejected for {}", identityVerification);
                 identityVerification.getDocumentVerifications()
@@ -162,32 +151,27 @@ public class ClientEvaluationService {
                             auditService.audit(document, "Document rejected because of client evaluation for user: {}", identityVerification.getUserId());
                         });
                 identityVerification.setTimestampFailed(ownerId.getTimestamp());
-                identityVerificationService.moveToPhaseAndStatus(identityVerification, phase, IdentityVerificationStatus.REJECTED, ownerId);
+                saveInANewTransaction(status ->
+                        identityVerificationService.moveToPhaseAndStatus(identityVerification, phase, IdentityVerificationStatus.REJECTED, ownerId));
             }
-        });
+        };
     }
 
     private Consumer<Throwable> createErrorConsumer(final IdentityVerificationEntity identityVerification, final OwnerId ownerId) {
-        return t -> saveInANewTransaction(status -> {
-            try {
-                commonOnboardingService.findProcessWithLock(identityVerification.getProcessId());
-            } catch (OnboardingProcessException ex) {
-                logger.error(ex.getMessage(), ex);
-                return;
-            }
+        return t -> {
             logger.warn("Client evaluation failed for {} - {}", identityVerification, t.getMessage());
             logger.debug("Client evaluation failed for {}", identityVerification, t);
             identityVerification.setErrorDetail(IdentityVerificationEntity.ERROR_MAX_FAILED_ATTEMPTS_CLIENT_EVALUATION);
             identityVerification.setErrorOrigin(ErrorOrigin.PROCESS_LIMIT_CHECK);
             identityVerification.setTimestampFailed(ownerId.getTimestamp());
             final IdentityVerificationPhase phase = identityVerification.getPhase();
-            identityVerificationService.moveToPhaseAndStatus(identityVerification, phase, IdentityVerificationStatus.FAILED, ownerId);
-        });
+            saveInANewTransaction(status ->
+                identityVerificationService.moveToPhaseAndStatus(identityVerification, phase, IdentityVerificationStatus.FAILED, ownerId));
+        };
     }
 
     private void saveInANewTransaction(final Consumer<TransactionStatus> consumer) {
         transactionTemplate.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
         transactionTemplate.executeWithoutResult(consumer);
     }
-
 }

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/IdentityVerificationOtpService.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/IdentityVerificationOtpService.java
@@ -173,7 +173,7 @@ public class IdentityVerificationOtpService {
      * @return Whether user is verified using OTP code.
      */
     public boolean isUserVerifiedUsingOtp(String processId) {
-        return onboardingOtpRepository.findLastOtp(processId, OtpType.USER_VERIFICATION)
+        return onboardingOtpRepository.findNewestByProcessIdAndType(processId, OtpType.USER_VERIFICATION)
                 .map(OnboardingOtpEntity::getStatus)
                 .filter(it -> it == OtpStatus.VERIFIED)
                 .isPresent();
@@ -232,7 +232,7 @@ public class IdentityVerificationOtpService {
     }
 
     private void markVerificationOtpAsFailed(String processId, IdentityVerificationEntity idVerification) throws OnboardingProcessException {
-        final OnboardingOtpEntity otp = onboardingOtpRepository.findLastOtp(processId, OtpType.USER_VERIFICATION).orElseThrow(() ->
+        final OnboardingOtpEntity otp = onboardingOtpRepository.findNewestByProcessIdAndType(processId, OtpType.USER_VERIFICATION).orElseThrow(() ->
             new OnboardingProcessException("Onboarding OTP not found, process ID: " + processId));
         otp.setStatus(OtpStatus.FAILED);
         otp.setErrorDetail(OnboardingOtpEntity.ERROR_CANCELED);

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/IdentityVerificationRestService.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/IdentityVerificationRestService.java
@@ -51,8 +51,7 @@ import io.getlime.security.powerauth.rest.api.spring.encryption.EciesEncryptionC
 import io.getlime.security.powerauth.rest.api.spring.exception.PowerAuthAuthenticationException;
 import io.getlime.security.powerauth.rest.api.spring.exception.PowerAuthEncryptionException;
 import io.getlime.security.powerauth.rest.api.spring.exception.authentication.PowerAuthTokenInvalidException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.HttpStatus;
@@ -75,9 +74,8 @@ import java.util.Map;
         havingValue = "true"
 )
 @Service
+@Slf4j
 public class IdentityVerificationRestService {
-
-    private static final Logger logger = LoggerFactory.getLogger(IdentityVerificationRestService.class);
 
     private final IdentityVerificationConfig identityVerificationConfig;
 

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/IdentityVerificationRestService.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/IdentityVerificationRestService.java
@@ -1,0 +1,653 @@
+/*
+ * PowerAuth Enrollment Server
+ * Copyright (C) 2022 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.wultra.app.onboardingserver.impl.service;
+
+import com.wultra.app.enrollmentserver.api.model.onboarding.request.*;
+import com.wultra.app.enrollmentserver.api.model.onboarding.response.*;
+import com.wultra.app.enrollmentserver.api.model.onboarding.response.data.ConfigurationDataDto;
+import com.wultra.app.enrollmentserver.api.model.onboarding.response.data.DocumentMetadataResponseDto;
+import com.wultra.app.enrollmentserver.model.DocumentMetadata;
+import com.wultra.app.enrollmentserver.model.enumeration.OnboardingStatus;
+import com.wultra.app.enrollmentserver.model.integration.OwnerId;
+import com.wultra.app.enrollmentserver.model.integration.VerificationSdkInfo;
+import com.wultra.app.onboardingserver.common.database.entity.DocumentVerificationEntity;
+import com.wultra.app.onboardingserver.common.database.entity.IdentityVerificationEntity;
+import com.wultra.app.onboardingserver.common.database.entity.OnboardingProcessEntity;
+import com.wultra.app.onboardingserver.common.errorhandling.*;
+import com.wultra.app.onboardingserver.configuration.IdentityVerificationConfig;
+import com.wultra.app.onboardingserver.configuration.OnboardingConfig;
+import com.wultra.app.onboardingserver.errorhandling.DocumentSubmitException;
+import com.wultra.app.onboardingserver.errorhandling.DocumentVerificationException;
+import com.wultra.app.onboardingserver.errorhandling.PresenceCheckException;
+import com.wultra.app.onboardingserver.impl.service.document.DocumentProcessingService;
+import com.wultra.app.onboardingserver.impl.service.validation.OnboardingConsentApprovalRequestValidator;
+import com.wultra.app.onboardingserver.impl.service.validation.OnboardingConsentTextRequestValidator;
+import com.wultra.app.onboardingserver.impl.util.PowerAuthUtil;
+import com.wultra.app.onboardingserver.statemachine.consts.ExtendedStateVariable;
+import com.wultra.app.onboardingserver.statemachine.enums.OnboardingEvent;
+import com.wultra.app.onboardingserver.statemachine.enums.OnboardingState;
+import com.wultra.app.onboardingserver.statemachine.service.StateMachineService;
+import io.getlime.core.rest.model.base.request.ObjectRequest;
+import io.getlime.core.rest.model.base.response.ErrorResponse;
+import io.getlime.core.rest.model.base.response.ObjectResponse;
+import io.getlime.core.rest.model.base.response.Response;
+import io.getlime.security.powerauth.rest.api.spring.authentication.PowerAuthApiAuthentication;
+import io.getlime.security.powerauth.rest.api.spring.encryption.EciesEncryptionContext;
+import io.getlime.security.powerauth.rest.api.spring.exception.PowerAuthAuthenticationException;
+import io.getlime.security.powerauth.rest.api.spring.exception.PowerAuthEncryptionException;
+import io.getlime.security.powerauth.rest.api.spring.exception.authentication.PowerAuthTokenInvalidException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.statemachine.StateMachine;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Service implementing REST API methods for identity document verification.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+@ConditionalOnProperty(
+        value = "enrollment-server-onboarding.identity-verification.enabled",
+        havingValue = "true"
+)
+@Service
+public class IdentityVerificationRestService {
+
+    private static final Logger logger = LoggerFactory.getLogger(IdentityVerificationRestService.class);
+
+    private final IdentityVerificationConfig identityVerificationConfig;
+
+    private final DocumentProcessingService documentProcessingService;
+    private final IdentityVerificationService identityVerificationService;
+    private final IdentityVerificationStatusService identityVerificationStatusService;
+    private final IdentityVerificationOtpService identityVerificationOtpService;
+    private final PresenceCheckService presenceCheckService;
+
+    private final StateMachineService stateMachineService;
+
+    private final OnboardingServiceImpl onboardingService;
+
+    /**
+     * Configuration data for client integration
+     */
+    private final ConfigurationDataDto integrationConfigDto;
+
+    /**
+     * Controller constructor.
+     *
+     * @param identityVerificationConfig        Configuration of identity verification.
+     * @param onboardingConfig                  Configuration of onboarding.
+     * @param documentProcessingService         Document processing service.
+     * @param identityVerificationService       Identity verification service.
+     * @param identityVerificationStatusService Identity verification status service.
+     * @param identityVerificationOtpService    Identity OTP verification service.
+     * @param onboardingService                 Onboarding service.
+     * @param presenceCheckService              Presence check service.
+     * @param stateMachineService               State machine service.
+     */
+    @Autowired
+    public IdentityVerificationRestService(
+            IdentityVerificationConfig identityVerificationConfig,
+            OnboardingConfig onboardingConfig,
+            DocumentProcessingService documentProcessingService,
+            IdentityVerificationService identityVerificationService,
+            IdentityVerificationStatusService identityVerificationStatusService,
+            IdentityVerificationOtpService identityVerificationOtpService,
+            OnboardingServiceImpl onboardingService,
+            PresenceCheckService presenceCheckService,
+            StateMachineService stateMachineService) {
+        this.identityVerificationConfig = identityVerificationConfig;
+
+        this.documentProcessingService = documentProcessingService;
+        this.identityVerificationService = identityVerificationService;
+        this.identityVerificationStatusService = identityVerificationStatusService;
+        this.identityVerificationOtpService = identityVerificationOtpService;
+        this.onboardingService = onboardingService;
+        this.presenceCheckService = presenceCheckService;
+        this.stateMachineService = stateMachineService;
+
+        this.integrationConfigDto = new ConfigurationDataDto();
+        integrationConfigDto.setOtpResendPeriod(onboardingConfig.getOtpResendPeriod().toString());
+    }
+
+    /**
+     * Initialize identity verification.
+     * @param request Initialize identity verification request.
+     * @param eciesContext ECIES context.
+     * @param apiAuthentication PowerAuth authentication.
+     * @return Response.
+     * @throws PowerAuthAuthenticationException Thrown when request authentication fails.
+     * @throws PowerAuthEncryptionException Thrown when encryption fails.
+     * @throws IdentityVerificationException Thrown when identity verification initialization fails.
+     * @throws OnboardingProcessException Thrown when onboarding process is invalid.
+     */
+    @Transactional
+    public ResponseEntity<Response> initializeIdentityVerification(ObjectRequest<IdentityVerificationInitRequest> request,
+                                                                   EciesEncryptionContext eciesContext,
+                                                                   PowerAuthApiAuthentication apiAuthentication)
+            throws PowerAuthAuthenticationException, IdentityVerificationException, PowerAuthEncryptionException, OnboardingProcessException {
+
+        final String operationDescription = "initializing identity verification";
+        checkApiAuthentication(apiAuthentication, operationDescription);
+        checkEciesContext(eciesContext, operationDescription);
+        checkRequestObject(request, operationDescription);
+
+        // Initialize identity verification
+        final OwnerId ownerId = PowerAuthUtil.getOwnerId(apiAuthentication);
+        final String processId = request.getRequestObject().getProcessId();
+
+        logger.debug("Onboarding process will be locked using PESSIMISTIC_WRITE lock, {}", processId);
+        onboardingService.verifyProcessIdAndLock(ownerId, processId, OnboardingStatus.VERIFICATION_IN_PROGRESS);
+
+        StateMachine<OnboardingState, OnboardingEvent> stateMachine =
+                stateMachineService.processStateMachineEvent(ownerId, processId, OnboardingEvent.IDENTITY_VERIFICATION_INIT);
+
+        return createResponseEntity(stateMachine);
+    }
+
+    /**
+     * Check status of identity verification.
+     *
+     * @param request Document submit request.
+     * @param eciesContext ECIES context.
+     * @param apiAuthentication PowerAuth authentication.
+     * @return Document submit response.
+     * @throws PowerAuthAuthenticationException Thrown when request authentication fails.
+     * @throws PowerAuthEncryptionException Thrown when request decryption fails.
+     * @throws RemoteCommunicationException Thrown when communication with PowerAuth server fails.
+     * @throws OnboardingProcessException Thrown when onboarding process is invalid.
+     */
+    public ObjectResponse<IdentityVerificationStatusResponse> checkIdentityVerificationStatus(ObjectRequest<IdentityVerificationStatusRequest> request,
+                                                                                              EciesEncryptionContext eciesContext,
+                                                                                              PowerAuthApiAuthentication apiAuthentication)
+            throws PowerAuthAuthenticationException, PowerAuthEncryptionException, RemoteCommunicationException, OnboardingProcessException {
+
+        final String operationDescription = "checking identity verification status";
+        checkApiAuthentication(apiAuthentication, operationDescription);
+        checkEciesContext(eciesContext, operationDescription);
+        checkRequestObject(request, operationDescription);
+
+        final OwnerId ownerId = PowerAuthUtil.getOwnerId(apiAuthentication);
+
+        logger.debug("Onboarding process will not be locked, {}", ownerId);
+        // Check verification status
+        final IdentityVerificationStatusResponse response =
+                identityVerificationStatusService.checkIdentityVerificationStatus(request.getRequestObject(), ownerId);
+        response.setConfig(integrationConfigDto);
+
+        return new ObjectResponse<>(response);
+    }
+
+    /**
+     * Submit identity-related documents for verification.
+     * @param request Document submit request.
+     * @param eciesContext ECIES context.
+     * @return Document submit response.
+     * @throws PowerAuthAuthenticationException Thrown when request authentication fails.
+     * @throws PowerAuthEncryptionException Thrown when request decryption fails.
+     * @throws DocumentSubmitException Thrown when document submission fails.
+     * @throws OnboardingProcessException Thrown when onboarding process is invalid.
+     * @throws IdentityVerificationLimitException Thrown in case document upload limit is reached.
+     * @throws RemoteCommunicationException Thrown when communication with PowerAuth server fails.
+     * @throws IdentityVerificationException Thrown in case identity verification is invalid.
+     * @throws OnboardingProcessLimitException Thrown when maximum failed attempts for identity verification have been reached.
+     */
+    @Transactional
+    public ObjectResponse<DocumentSubmitResponse> submitDocuments(ObjectRequest<DocumentSubmitRequest> request,
+                                                                  EciesEncryptionContext eciesContext,
+                                                                  PowerAuthApiAuthentication apiAuthentication)
+            throws PowerAuthAuthenticationException, PowerAuthEncryptionException, DocumentSubmitException, OnboardingProcessException, IdentityVerificationLimitException, RemoteCommunicationException, IdentityVerificationException, OnboardingProcessLimitException {
+
+        final String operationDescription = "submitting documents for verification";
+        checkApiAuthentication(apiAuthentication, operationDescription);
+        checkEciesContext(eciesContext, operationDescription);
+        checkRequestObject(request, operationDescription);
+
+        // Extract user ID from onboarding process for current activation
+        final OwnerId ownerId = extractOwnerId(eciesContext);
+        final String processId = request.getRequestObject().getProcessId();
+
+        logger.debug("Onboarding process will be locked using PESSIMISTIC_WRITE lock, {}", processId);
+        onboardingService.verifyProcessIdAndLock(ownerId, processId, OnboardingStatus.VERIFICATION_IN_PROGRESS);
+
+        // Submit documents for verification
+        final List<DocumentVerificationEntity> docVerificationEntities =
+                identityVerificationService.submitDocuments(request.getRequestObject(), ownerId);
+
+        final DocumentSubmitResponse response = new DocumentSubmitResponse();
+        final List<DocumentMetadataResponseDto> respsMetadata =
+                identityVerificationService.createDocsMetadata(docVerificationEntities);
+        response.setDocuments(respsMetadata);
+
+        return new ObjectResponse<>(response);
+    }
+
+    /**
+     * Upload a single document related to identity verification. This endpoint is used for upload of large documents.
+     * @param requestData Binary request data.
+     * @param eciesContext ECIES context.
+     * @return Document upload response.
+     * @throws IdentityVerificationException Thrown when identity verification was not found.
+     * @throws PowerAuthAuthenticationException Thrown when request authentication fails.
+     * @throws PowerAuthEncryptionException Thrown when request decryption fails.
+     * @throws DocumentVerificationException Thrown when document is invalid.
+     * @throws OnboardingProcessException Thrown when finished onboarding process is not found.
+     */
+    public ObjectResponse<DocumentUploadResponse> uploadDocument(byte[] requestData,
+                                                                 EciesEncryptionContext eciesContext,
+                                                                 PowerAuthApiAuthentication apiAuthentication)
+            throws IdentityVerificationException, PowerAuthAuthenticationException, PowerAuthEncryptionException, DocumentVerificationException, OnboardingProcessException {
+
+        final String operationDescription = "uploading document for verification";
+        checkApiAuthentication(apiAuthentication, operationDescription);
+        checkEciesContext(eciesContext, operationDescription);
+        checkRequest(requestData, operationDescription);
+
+        // Extract user ID from onboarding process for current activation
+        final OwnerId ownerId = extractOwnerId(eciesContext);
+
+        logger.debug("Onboarding process will not be locked, {}", ownerId);
+        IdentityVerificationEntity idVerification = identityVerificationService.findBy(ownerId);
+
+        final DocumentMetadata uploadedDocument = documentProcessingService.uploadDocument(idVerification, requestData, ownerId);
+
+        final DocumentUploadResponse response = new DocumentUploadResponse();
+        response.setFilename(uploadedDocument.getFilename());
+        response.setId(uploadedDocument.getId());
+
+        return new ObjectResponse<>(response);
+    }
+
+    /**
+     * Check status of document verification related to identity.
+     * @param request Document status request.
+     * @param eciesContext ECIES context.
+     * @param apiAuthentication PowerAuth authentication.
+     * @return Document status response.
+     * @throws PowerAuthAuthenticationException Thrown when request authentication fails.
+     * @throws PowerAuthEncryptionException Thrown when request decryption fails.
+     * @throws OnboardingProcessException Thrown when onboarding process identifier is invalid.
+     */
+    public ObjectResponse<DocumentStatusResponse> checkDocumentStatus(ObjectRequest<DocumentStatusRequest> request,
+                                                                      EciesEncryptionContext eciesContext,
+                                                                      PowerAuthApiAuthentication apiAuthentication)
+            throws PowerAuthAuthenticationException, PowerAuthEncryptionException, OnboardingProcessException {
+
+        final String operationDescription = "checking document verification status";
+        checkApiAuthentication(apiAuthentication, operationDescription);
+        checkEciesContext(eciesContext, operationDescription);
+        checkRequestObject(request, operationDescription);
+
+        final OwnerId ownerId = PowerAuthUtil.getOwnerId(apiAuthentication);
+        final String processId = request.getRequestObject().getProcessId();
+
+        logger.debug("Onboarding process will not be locked, {}", processId);
+        onboardingService.verifyProcessId(ownerId, processId, OnboardingStatus.VERIFICATION_IN_PROGRESS);
+
+        final DocumentStatusResponse response = identityVerificationService.fetchDocumentStatusResponse(request.getRequestObject(), ownerId);
+        return new ObjectResponse<>(response);
+    }
+
+    /**
+     * Initialize document verification SDK for an integration.
+     * @param request Presence check initialization request.
+     * @param eciesContext ECIES context.
+     * @param apiAuthentication PowerAuth authentication.
+     * @return Verification SDK initialization response.
+     * @throws PowerAuthAuthenticationException Thrown when request authentication fails.
+     * @throws PowerAuthEncryptionException Thrown when request decryption fails.
+     * @throws DocumentVerificationException Thrown when SKD initialization fails.
+     * @throws OnboardingProcessException Thrown when onboarding process identifier is invalid.
+     * @throws RemoteCommunicationException In case of remote communication error.
+     */
+    public ObjectResponse<DocumentVerificationSdkInitResponse> initVerificationSdk(
+            ObjectRequest<DocumentVerificationSdkInitRequest> request,
+            EciesEncryptionContext eciesContext,
+            PowerAuthApiAuthentication apiAuthentication)
+            throws PowerAuthAuthenticationException, DocumentVerificationException, PowerAuthEncryptionException, OnboardingProcessException, RemoteCommunicationException {
+
+        final String operationDescription = "initializing document verification SDK";
+        checkApiAuthentication(apiAuthentication, operationDescription);
+        checkEciesContext(eciesContext, operationDescription);
+        checkRequestObject(request, operationDescription);
+
+        final OwnerId ownerId = PowerAuthUtil.getOwnerId(apiAuthentication);
+        final String processId = request.getRequestObject().getProcessId();
+
+        logger.debug("Onboarding process will not be locked, {}", processId);
+        onboardingService.verifyProcessId(ownerId, processId, OnboardingStatus.VERIFICATION_IN_PROGRESS);
+
+        final Map<String, String> attributes = request.getRequestObject().getAttributes();
+        final VerificationSdkInfo sdkVerificationInfo = identityVerificationService.initVerificationSdk(ownerId, attributes);
+
+        final DocumentVerificationSdkInitResponse response = new DocumentVerificationSdkInitResponse();
+        response.setAttributes(sdkVerificationInfo.getAttributes());
+        return new ObjectResponse<>(response);
+    }
+
+    /**
+     * Initialize presence check process.
+     *
+     * @param request Presence check initialization request.
+     * @param eciesContext ECIES context.
+     * @param apiAuthentication PowerAuth authentication.
+     * @return Presence check initialization response.
+     * @throws PowerAuthAuthenticationException Thrown when request authentication fails.
+     * @throws PowerAuthEncryptionException Thrown when request decryption fails.
+     * @throws IdentityVerificationException Thrown when identity verification is invalid.
+     * @throws OnboardingProcessException Thrown when onboarding process is invalid.
+     */
+    @Transactional
+    public ResponseEntity<Response> initPresenceCheck(ObjectRequest<PresenceCheckInitRequest> request,
+                                                      EciesEncryptionContext eciesContext,
+                                                      PowerAuthApiAuthentication apiAuthentication)
+            throws IdentityVerificationException, PowerAuthAuthenticationException, PowerAuthEncryptionException, OnboardingProcessException {
+
+        final String operationDescription = "initializing presence check";
+        checkApiAuthentication(apiAuthentication, operationDescription);
+        checkEciesContext(eciesContext, operationDescription);
+        checkRequestObject(request, operationDescription);
+
+        final OwnerId ownerId = PowerAuthUtil.getOwnerId(apiAuthentication);
+        final String processId = request.getRequestObject().getProcessId();
+
+        logger.debug("Onboarding process will be locked using PESSIMISTIC_WRITE lock, {}", processId);
+        onboardingService.verifyProcessIdAndLock(ownerId, processId, OnboardingStatus.VERIFICATION_IN_PROGRESS);
+
+        StateMachine<OnboardingState, OnboardingEvent> stateMachine = stateMachineService.processStateMachineEvent(ownerId, processId, OnboardingEvent.PRESENCE_CHECK_INIT);
+        return createResponseEntity(stateMachine);
+    }
+
+    /**
+     * Submit presence check process.
+     *
+     * @param request Presence check initialization request.
+     * @param eciesContext ECIES context.
+     * @param apiAuthentication PowerAuth authentication.
+     * @return Presence check initialization response.
+     * @throws PowerAuthAuthenticationException Thrown when request authentication fails.
+     * @throws PowerAuthEncryptionException Thrown when request decryption fails.
+     * @throws IdentityVerificationException Thrown when identity verification is invalid.
+     * @throws OnboardingProcessException Thrown when onboarding process is invalid.
+     */
+    @Transactional
+    public ResponseEntity<Response> submitPresenceCheck(ObjectRequest<PresenceCheckSubmitRequest> request,
+                                                        EciesEncryptionContext eciesContext,
+                                                        PowerAuthApiAuthentication apiAuthentication)
+            throws IdentityVerificationException, PowerAuthAuthenticationException, PowerAuthEncryptionException, OnboardingProcessException {
+
+        final String operationDescription = "submitting presence check";
+        checkApiAuthentication(apiAuthentication, operationDescription);
+        checkEciesContext(eciesContext, operationDescription);
+        checkRequestObject(request, operationDescription);
+
+        final OwnerId ownerId = PowerAuthUtil.getOwnerId(apiAuthentication);
+        final String processId = request.getRequestObject().getProcessId();
+
+        logger.debug("Onboarding process will be locked using PESSIMISTIC_WRITE lock, {}", processId);
+        onboardingService.verifyProcessIdAndLock(ownerId, processId, OnboardingStatus.VERIFICATION_IN_PROGRESS);
+
+        StateMachine<OnboardingState, OnboardingEvent> stateMachine = stateMachineService.processStateMachineEvent(ownerId, processId, OnboardingEvent.PRESENCE_CHECK_SUBMITTED);
+        return createResponseEntity(stateMachine);
+    }
+
+    /**
+     * Resend OTP code to the user.
+     * @param request Presence check initialization request.
+     * @param eciesContext ECIES context.
+     * @return Send OTP response.
+     * @throws IdentityVerificationException Thrown when identity verification is not found.
+     * @throws PowerAuthEncryptionException Thrown when request decryption fails.
+     * @throws OnboardingProcessException Thrown when OTP code could not be generated.
+     */
+    @Transactional
+    public ResponseEntity<Response> resendOtp(ObjectRequest<IdentityVerificationOtpSendRequest> request,
+                                              EciesEncryptionContext eciesContext)
+            throws IdentityVerificationException, PowerAuthEncryptionException, OnboardingProcessException {
+
+        checkEciesContext(eciesContext, "resending OTP during identity verification");
+        checkRequestObject(request, "resending OTP during identity verification");
+
+        // Extract user ID from onboarding process for current activation, lock onboarding process
+        final OwnerId ownerId = extractOwnerId(eciesContext);
+        final String processId = request.getRequestObject().getProcessId();
+
+        logger.debug("Onboarding process will be locked using PESSIMISTIC_WRITE lock, {}", processId);
+        onboardingService.verifyProcessIdAndLock(ownerId, processId, OnboardingStatus.VERIFICATION_IN_PROGRESS);
+
+        StateMachine<OnboardingState, OnboardingEvent> stateMachine = stateMachineService.processStateMachineEvent(ownerId, processId, OnboardingEvent.OTP_VERIFICATION_RESEND);
+        return createResponseEntity(stateMachine);
+    }
+
+    /**
+     * Verify an OTP code received from the user.
+     * @param request Presence check initialization request.
+     * @param eciesContext ECIES context.
+     * @return Send OTP response.
+     * @throws PowerAuthEncryptionException Thrown when request decryption fails.
+     * @throws OnboardingProcessException Thrown when onboarding process is not found.
+     */
+    @Transactional
+    public ObjectResponse<OtpVerifyResponse> verifyOtp(ObjectRequest<IdentityVerificationOtpVerifyRequest> request,
+                                                       EciesEncryptionContext eciesContext)
+            throws PowerAuthEncryptionException, OnboardingProcessException {
+
+        checkEciesContext(eciesContext, "verifying OTP during identity verification");
+        checkRequestObject(request, "verifying OTP during identity verification");
+
+        // Extract user ID from onboarding process for current activation
+        final OwnerId ownerId = extractOwnerId(eciesContext);
+        final String processId = request.getRequestObject().getProcessId();
+
+        logger.debug("Onboarding process will be locked using PESSIMISTIC_WRITE lock, {}", processId);
+        onboardingService.verifyProcessIdAndLock(ownerId, processId, OnboardingStatus.VERIFICATION_IN_PROGRESS);
+
+        final String otpCode = request.getRequestObject().getOtpCode();
+        final OtpVerifyResponse otpVerifyResponse = identityVerificationOtpService.verifyOtpCode(processId, ownerId, otpCode);
+
+        try {
+            stateMachineService.processStateMachineEvent(ownerId, processId, OnboardingEvent.EVENT_NEXT_STATE);
+        } catch (IdentityVerificationException e) {
+            throw new OnboardingProcessException("Unable to move state machine for " + ownerId, e);
+        }
+
+        return new ObjectResponse<>(otpVerifyResponse);
+    }
+
+    /**
+     * Cleanup documents related to identity verification.
+     * @param apiAuthentication PowerAuth authentication.
+     * @return Document status response.
+     * @throws PowerAuthAuthenticationException Thrown when PowerAuth signature verification fails.
+     * @throws PowerAuthEncryptionException Thrown when request decryption fails.
+     * @throws DocumentVerificationException Thrown when document cleanup fails
+     * @throws PresenceCheckException Thrown when presence check cleanup fails.
+     * @throws RemoteCommunicationException Thrown when communication with PowerAuth server fails.
+     * @throws OnboardingProcessException Thrown when onboarding process identifier is invalid.
+     * @throws IdentityVerificationException Thrown when identity verification reset fails.
+     * @throws OnboardingProcessLimitException Thrown when maximum failed attempts for identity verification have been reached.
+     */
+    @Transactional
+    public Response cleanup(ObjectRequest<IdentityVerificationCleanupRequest> request,
+                            EciesEncryptionContext eciesContext,
+                            PowerAuthApiAuthentication apiAuthentication)
+            throws PowerAuthAuthenticationException, PowerAuthEncryptionException, DocumentVerificationException, PresenceCheckException, RemoteCommunicationException, OnboardingProcessException, IdentityVerificationException, OnboardingProcessLimitException {
+
+        final String operationDescription = "performing document cleanup";
+        checkApiAuthentication(apiAuthentication, operationDescription);
+        checkEciesContext(eciesContext, operationDescription);
+        checkRequestObject(request, operationDescription);
+
+        final OwnerId ownerId = PowerAuthUtil.getOwnerId(apiAuthentication);
+        final String processId = request.getRequestObject().getProcessId();
+
+        logger.debug("Onboarding process will be locked using PESSIMISTIC_WRITE lock, {}", processId);
+        onboardingService.verifyProcessIdAndLock(ownerId, processId, OnboardingStatus.VERIFICATION_IN_PROGRESS);
+
+        // Process cleanup request
+        identityVerificationService.cleanup(ownerId);
+        if (identityVerificationConfig.isPresenceCheckEnabled()) {
+            presenceCheckService.cleanup(ownerId);
+        } else {
+            logger.debug("Skipped presence check cleanup, not enabled");
+        }
+
+        return new Response();
+    }
+
+    /**
+     * Obtain consent text.
+     * @param request Obtain consent text request.
+     * @param eciesContext ECIES context.
+     * @return Consent text.
+     * @throws OnboardingProcessException Thrown when onboarding process is not found.
+     * @throws PowerAuthEncryptionException Thrown when request decryption fails.
+     */
+    public ObjectResponse<OnboardingConsentTextResponse> fetchConsentText(
+            final ObjectRequest<OnboardingConsentTextRequest> request,
+            final EciesEncryptionContext eciesContext) throws OnboardingProcessException, PowerAuthEncryptionException {
+
+        checkEciesContext(eciesContext, "obtaining user consent text");
+        checkRequestObject(request, "obtaining user consent text");
+
+        final OnboardingConsentTextRequest requestObject = request.getRequestObject();
+        logger.debug("Returning consent for {}", requestObject);
+        OnboardingConsentTextRequestValidator.validate(requestObject);
+
+        final OwnerId ownerId = extractOwnerId(eciesContext);
+        final String processId = requestObject.getProcessId();
+
+        logger.debug("Onboarding process will not be locked, {}", processId);
+        onboardingService.verifyProcessId(ownerId, processId, OnboardingStatus.VERIFICATION_IN_PROGRESS);
+
+        return new ObjectResponse<>(onboardingService.fetchConsentText(requestObject));
+    }
+
+    /**
+     * Approve or reject consent.
+     * @param request Approve consent request
+     * @param eciesContext ECIES context.
+     * @param apiAuthentication PowerAuth authentication.
+     * @return Response.
+     * @throws OnboardingProcessException Thrown when onboarding process is not found.
+     * @throws PowerAuthAuthenticationException Thrown when request authentication fails.
+     * @throws PowerAuthEncryptionException Thrown when request decryption fails.
+     */
+    public Response approveConsent(
+            final ObjectRequest<OnboardingConsentApprovalRequest> request,
+            final EciesEncryptionContext eciesContext,
+            final PowerAuthApiAuthentication apiAuthentication) throws OnboardingProcessException, PowerAuthAuthenticationException, PowerAuthEncryptionException {
+
+        final String operationDescription = "approving user consent";
+        checkApiAuthentication(apiAuthentication, operationDescription);
+        checkEciesContext(eciesContext, operationDescription);
+        checkRequestObject(request, operationDescription);
+
+        final OnboardingConsentApprovalRequest requestObject = request.getRequestObject();
+        logger.debug("Approving consent for {}", requestObject);
+        OnboardingConsentApprovalRequestValidator.validate(requestObject);
+
+        final OwnerId ownerId = PowerAuthUtil.getOwnerId(apiAuthentication);
+        final String processId = requestObject.getProcessId();
+
+        logger.debug("Onboarding process will not be locked, {}", processId);
+        onboardingService.verifyProcessId(ownerId, processId, OnboardingStatus.VERIFICATION_IN_PROGRESS);
+
+        onboardingService.approveConsent(requestObject);
+        return new Response();
+    }
+
+    /**
+     * Checks if the API authentication object is present
+     * @param apiAuthentication API authentication object value
+     * @param description Additional description
+     * @throws PowerAuthTokenInvalidException When the API authentication object does not exist
+     */
+    private void checkApiAuthentication(@Nullable PowerAuthApiAuthentication apiAuthentication, String description) throws PowerAuthTokenInvalidException {
+        if (apiAuthentication == null) {
+            String errorMessage = String.format("Unable to verify device registration when %s", description);
+            logger.error(errorMessage);
+            throw new PowerAuthTokenInvalidException(errorMessage);
+        }
+    }
+
+    /**
+     * Checks if the request was correctly decrypted
+     * @param eciesContext ECIES encryption context
+     * @param description Additional description
+     * @throws PowerAuthEncryptionException When the ECIES encryption context does not exist
+     */
+    private void checkEciesContext(@Nullable EciesEncryptionContext eciesContext, String description) throws PowerAuthEncryptionException {
+        if (eciesContext == null) {
+            String errorMessage = String.format("ECIES encryption failed when %s", description);
+            logger.error(errorMessage);
+            throw new PowerAuthEncryptionException(errorMessage);
+        }
+    }
+
+    private void checkRequest(@Nullable Object request, String description) throws PowerAuthEncryptionException {
+        if (request == null) {
+            String errorMessage = String.format("Invalid request received when %s", description);
+            logger.error(errorMessage);
+            throw new PowerAuthEncryptionException(errorMessage);
+        }
+    }
+
+    private void checkRequestObject(@Nullable ObjectRequest<?> request, String description) throws PowerAuthEncryptionException {
+        if (request == null || request.getRequestObject() == null) {
+            String errorMessage = String.format("Invalid request received when %s", description);
+            logger.error(errorMessage);
+            throw new PowerAuthEncryptionException(errorMessage);
+        }
+    }
+
+    /**
+     * Extract owner identification from an ECIES context. The onboarding process is not locked.
+     *
+     * @param eciesContext ECIES context.
+     * @return Owner identification.
+     */
+    private OwnerId extractOwnerId(EciesEncryptionContext eciesContext) throws OnboardingProcessException {
+        final OnboardingProcessEntity onboardingProcess = onboardingService.findExistingProcessWithVerificationInProgress(eciesContext.getActivationId());
+        final OwnerId ownerId = new OwnerId();
+        ownerId.setActivationId(onboardingProcess.getActivationId());
+        ownerId.setUserId(onboardingProcess.getUserId());
+        return ownerId;
+    }
+
+    private ResponseEntity<Response> createResponseEntity(StateMachine<OnboardingState, OnboardingEvent> stateMachine) {
+        Response response = stateMachine.getExtendedState().get(ExtendedStateVariable.RESPONSE_OBJECT, Response.class);
+        HttpStatus status = stateMachine.getExtendedState().get(ExtendedStateVariable.RESPONSE_STATUS, HttpStatus.class);
+        if (response == null || status == null) {
+            logger.warn("Missing one of important values to generate response entity, response={}, status={}", response, status);
+            response = new ErrorResponse("UNEXPECTED_ERROR", "Unexpected error occurred.");
+            status = HttpStatus.INTERNAL_SERVER_ERROR;
+        }
+        return new ResponseEntity<>(response, status);
+    }
+
+}

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/IdentityVerificationService.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/IdentityVerificationService.java
@@ -326,7 +326,7 @@ public class IdentityVerificationService {
             DocumentsVerificationResult docVerificationResult = documentVerificationProvider.getVerificationResult(ownerId, entry.getKey());
             auditService.auditDocumentVerificationProvider(idVerification, "Got verification result: {} for user: {}", docVerificationResult.getStatus(), ownerId.getUserId());
 
-            // Lock the onboarding process until the end of the transaction
+            logger.debug("Onboarding process will be locked using PESSIMISTIC_WRITE lock, {}", idVerification.getProcessId());
             onboardingProcessRepository.findByIdWithLock(idVerification.getProcessId());
 
             verificationProcessingService.processVerificationResult(ownerId, entry.getValue(), docVerificationResult);

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/IdentityVerificationService.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/IdentityVerificationService.java
@@ -327,7 +327,7 @@ public class IdentityVerificationService {
             auditService.auditDocumentVerificationProvider(idVerification, "Got verification result: {} for user: {}", docVerificationResult.getStatus(), ownerId.getUserId());
 
             // Lock the onboarding process until the end of the transaction
-            onboardingProcessRepository.findProcessByIdWithLock(idVerification.getProcessId());
+            onboardingProcessRepository.findByIdWithLock(idVerification.getProcessId());
 
             verificationProcessingService.processVerificationResult(ownerId, entry.getValue(), docVerificationResult);
         }

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/IdentityVerificationService.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/IdentityVerificationService.java
@@ -90,8 +90,6 @@ public class IdentityVerificationService {
 
     private final AuditService auditService;
 
-    private final OnboardingProcessRepository onboardingProcessRepository;
-
     private static final List<DocumentStatus> DOCUMENT_STATUSES_PROCESSED = Arrays.asList(DocumentStatus.ACCEPTED, DocumentStatus.FAILED, DocumentStatus.REJECTED);
 
     /**
@@ -107,7 +105,6 @@ public class IdentityVerificationService {
      * @param processService Common onboarding process service.
      * @param processLimitService Onboarding process limit service.
      * @param auditService Audit service.
-     * @param onboardingProcessRepository Onboarding process repository.
      */
     @Autowired
     public IdentityVerificationService(
@@ -122,7 +119,7 @@ public class IdentityVerificationService {
             final CommonOnboardingService processService,
             final OnboardingProcessLimitService processLimitService,
             final RequiredDocumentTypesGuard requiredDocumentTypesGuard,
-            final AuditService auditService, OnboardingProcessRepository onboardingProcessRepository) {
+            final AuditService auditService) {
 
         this.identityVerificationConfig = identityVerificationConfig;
         this.documentDataRepository = documentDataRepository;
@@ -136,7 +133,6 @@ public class IdentityVerificationService {
         this.processLimitService = processLimitService;
         this.requiredDocumentTypesGuard = requiredDocumentTypesGuard;
         this.auditService = auditService;
-        this.onboardingProcessRepository = onboardingProcessRepository;
     }
 
     /**
@@ -326,8 +322,7 @@ public class IdentityVerificationService {
             DocumentsVerificationResult docVerificationResult = documentVerificationProvider.getVerificationResult(ownerId, entry.getKey());
             auditService.auditDocumentVerificationProvider(idVerification, "Got verification result: {} for user: {}", docVerificationResult.getStatus(), ownerId.getUserId());
 
-            logger.debug("Onboarding process will be locked using PESSIMISTIC_WRITE lock, {}", idVerification.getProcessId());
-            onboardingProcessRepository.findByIdWithLock(idVerification.getProcessId());
+            processService.findProcessWithLock(idVerification.getProcessId());
 
             verificationProcessingService.processVerificationResult(ownerId, entry.getValue(), docVerificationResult);
         }

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/IdentityVerificationStatusService.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/IdentityVerificationStatusService.java
@@ -86,7 +86,8 @@ public class IdentityVerificationStatusService {
 
         Optional<IdentityVerificationEntity> idVerificationOptional = identityVerificationService.findByOptional(ownerId);
 
-        final OnboardingProcessEntity onboardingProcess = onboardingService.findProcessByActivationId(ownerId.getActivationId());
+        // Do not lock onboarding process, it is not required for status check
+        final OnboardingProcessEntity onboardingProcess = onboardingService.findExistingProcessWithVerificationInProgress(ownerId.getActivationId());
         if (idVerificationOptional.isEmpty()) {
             response.setIdentityVerificationStatus(IdentityVerificationStatus.NOT_INITIALIZED);
             response.setIdentityVerificationPhase(null);

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/IdentityVerificationStatusService.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/IdentityVerificationStatusService.java
@@ -87,7 +87,7 @@ public class IdentityVerificationStatusService {
         Optional<IdentityVerificationEntity> idVerificationOptional = identityVerificationService.findByOptional(ownerId);
 
         // Do not lock onboarding process, it is not required for status check
-        final OnboardingProcessEntity onboardingProcess = onboardingService.findExistingProcessWithVerificationInProgress(ownerId.getActivationId());
+        final OnboardingProcessEntity onboardingProcess = onboardingService.findProcessByActivationId(ownerId.getActivationId());
         if (idVerificationOptional.isEmpty()) {
             response.setIdentityVerificationStatus(IdentityVerificationStatus.NOT_INITIALIZED);
             response.setIdentityVerificationPhase(null);

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/OnboardingServiceImpl.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/OnboardingServiceImpl.java
@@ -229,9 +229,7 @@ public class OnboardingServiceImpl extends CommonOnboardingService {
     @Transactional
     public Response performCleanup(OnboardingCleanupRequest request) throws OnboardingProcessException {
         final String processId = request.getProcessId();
-        logger.debug("Onboarding process will be locked using PESSIMISTIC_WRITE lock, {}", request.getProcessId());
-        final OnboardingProcessEntity process = onboardingProcessRepository.findByIdWithLock(processId).orElseThrow(() ->
-                new OnboardingProcessException("Onboarding process not found, process ID: " + processId));
+        final OnboardingProcessEntity process = findProcessWithLock(processId);
 
         otpService.cancelOtp(process, OtpType.ACTIVATION);
         otpService.cancelOtp(process, OtpType.USER_VERIFICATION);

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/OnboardingServiceImpl.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/OnboardingServiceImpl.java
@@ -301,6 +301,21 @@ public class OnboardingServiceImpl extends CommonOnboardingService {
     }
 
     /**
+     * Find an existing onboarding process by activation ID in any state.
+     * @param activationId Activation identifier.
+     * @return Onboarding process.
+     * @throws OnboardingProcessException Thrown when onboarding process is not found.
+     */
+    public OnboardingProcessEntity findProcessByActivationId(String activationId) throws OnboardingProcessException {
+        Optional<OnboardingProcessEntity> processOptional = onboardingProcessRepository.findProcessByActivationId(activationId);
+        if (processOptional.isEmpty()) {
+            logger.warn("Onboarding process not found, activation ID: {}", activationId);
+            throw new OnboardingProcessException();
+        }
+        return processOptional.get();
+    }
+
+    /**
      * Provide consent text.
      *
      * @param request consent text request

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/OtpServiceImpl.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/OtpServiceImpl.java
@@ -108,7 +108,7 @@ public class OtpServiceImpl extends CommonOtpService {
             logger.warn("Resend OTP functionality is not available yet (due to resend period), process ID: {}", processId);
             throw new OnboardingOtpDeliveryException();
         }
-        final OnboardingOtpEntity existingOtp = onboardingOtpRepository.findLastOtp(processId, otpType).orElseThrow(() ->
+        final OnboardingOtpEntity existingOtp = onboardingOtpRepository.findNewestByProcessIdAndType(processId, otpType).orElseThrow(() ->
                 new OnboardingProcessException("Onboarding OTP not found, process ID: " + processId));
 
         if (existingOtp.getStatus() != OtpStatus.FAILED) {
@@ -129,7 +129,7 @@ public class OtpServiceImpl extends CommonOtpService {
     public void cancelOtp(OnboardingProcessEntity process, OtpType otpType) {
         final String processId = process.getId();
         // Fail current OTP, if it is present
-        onboardingOtpRepository.findLastOtp(processId, otpType).ifPresent(otp -> {
+        onboardingOtpRepository.findNewestByProcessIdAndType(processId, otpType).ifPresent(otp -> {
             final Date now = new Date();
             if (otp.getStatus() != OtpStatus.FAILED) {
                 otp.setStatus(OtpStatus.FAILED);

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/PresenceCheckLimitService.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/PresenceCheckLimitService.java
@@ -98,7 +98,7 @@ public class PresenceCheckLimitService {
      * @throws RemoteCommunicationException Thrown when communication with PowerAuth server fails.
      */
     public void checkPresenceCheckMaxAttemptLimit(OwnerId ownerId, String processId) throws IdentityVerificationException, PresenceCheckLimitException, RemoteCommunicationException {
-        final int otpCount = otpRepository.getOtpCount(processId, OtpType.USER_VERIFICATION);
+        final int otpCount = otpRepository.countByProcessIdAndType(processId, OtpType.USER_VERIFICATION);
         if (otpCount > identityVerificationConfig.getPresenceCheckMaxFailedAttempts()) {
             final Optional<IdentityVerificationEntity> identityVerificationOptional = identityVerificationRepository.findFirstByActivationIdOrderByTimestampCreatedDesc(ownerId.getActivationId());
             if (identityVerificationOptional.isEmpty()) {

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/document/DocumentProcessingService.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/document/DocumentProcessingService.java
@@ -219,7 +219,7 @@ public class DocumentProcessingService {
         }
 
         // The results are available, lock the onboarding process until the end of the transaction
-        onboardingProcessRepository.findProcessByIdWithLock(documentResultEntity.getDocumentVerification().getIdentityVerification().getProcessId());
+        onboardingProcessRepository.findByIdWithLock(documentResultEntity.getDocumentVerification().getIdentityVerification().getProcessId());
 
         if (StringUtils.isNotBlank(docSubmitResult.getErrorDetail())) {
             documentResultEntity.setErrorDetail(docSubmitResult.getErrorDetail());

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/document/DocumentProcessingService.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/document/DocumentProcessingService.java
@@ -218,8 +218,9 @@ public class DocumentProcessingService {
             docSubmitResult.setErrorDetail(e.getMessage());
         }
 
-        // The results are available, lock the onboarding process until the end of the transaction
-        onboardingProcessRepository.findByIdWithLock(documentResultEntity.getDocumentVerification().getIdentityVerification().getProcessId());
+        final String processId = documentResultEntity.getDocumentVerification().getIdentityVerification().getProcessId();
+        logger.debug("Onboarding process will be locked using PESSIMISTIC_WRITE lock, {}", processId);
+        onboardingProcessRepository.findByIdWithLock(processId);
 
         if (StringUtils.isNotBlank(docSubmitResult.getErrorDetail())) {
             documentResultEntity.setErrorDetail(docSubmitResult.getErrorDetail());

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/validation/OnboardingConsentApprovalRequestValidator.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/validation/OnboardingConsentApprovalRequestValidator.java
@@ -14,8 +14,9 @@
  *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
  */
-package com.wultra.app.onboardingserver.controller.api;
+package com.wultra.app.onboardingserver.impl.service.validation;
 
 import com.wultra.app.enrollmentserver.api.model.onboarding.request.OnboardingConsentApprovalRequest;
 import org.apache.commons.lang3.StringUtils;
@@ -27,7 +28,7 @@ import javax.validation.ValidationException;
  *
  * @author Lubos Racansky, lubos.racansky@wultra.com
  */
-class OnboardingConsentApprovalRequestValidator {
+public class OnboardingConsentApprovalRequestValidator {
 
     /**
      * Validate the given request.

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/validation/OnboardingConsentTextRequestValidator.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/validation/OnboardingConsentTextRequestValidator.java
@@ -14,8 +14,9 @@
  *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
  */
-package com.wultra.app.onboardingserver.controller.api;
+package com.wultra.app.onboardingserver.impl.service.validation;
 
 import com.wultra.app.enrollmentserver.api.model.onboarding.request.OnboardingConsentTextRequest;
 import org.apache.commons.lang3.StringUtils;
@@ -27,7 +28,7 @@ import javax.validation.ValidationException;
  *
  * @author Lubos Racansky, lubos.racansky@wultra.com
  */
-class OnboardingConsentTextRequestValidator {
+public class OnboardingConsentTextRequestValidator {
 
     /**
      * Validate the given request.

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/verification/VerificationProcessingBatchService.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/verification/VerificationProcessingBatchService.java
@@ -121,7 +121,7 @@ public class VerificationProcessingBatchService {
                 }
 
                 // The results are available, lock the onboarding process until the end of the transaction
-                onboardingProcessRepository.findProcessByIdWithLock(docVerification.getIdentityVerification().getProcessId());
+                onboardingProcessRepository.findByIdWithLock(docVerification.getIdentityVerification().getProcessId());
 
                 verificationProcessingService.processVerificationResult(ownerId, List.of(docVerification), docVerificationResult);
 

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/verification/VerificationProcessingBatchService.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/verification/VerificationProcessingBatchService.java
@@ -120,8 +120,9 @@ public class VerificationProcessingBatchService {
                     return;
                 }
 
-                // The results are available, lock the onboarding process until the end of the transaction
-                onboardingProcessRepository.findByIdWithLock(docVerification.getIdentityVerification().getProcessId());
+                final String processId = docVerification.getIdentityVerification().getProcessId();
+                logger.debug("Onboarding process will be locked using PESSIMISTIC_WRITE lock, {}", processId);
+                onboardingProcessRepository.findByIdWithLock(processId);
 
                 verificationProcessingService.processVerificationResult(ownerId, List.of(docVerification), docVerificationResult);
 

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/provider/EmptyOnboardingProvider.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/provider/EmptyOnboardingProvider.java
@@ -52,8 +52,8 @@ class EmptyOnboardingProvider implements OnboardingProvider {
     }
 
     @Override
-    public Mono<EvaluateClientResponse> evaluateClient(EvaluateClientRequest request) {
-        return Mono.error(createException());
+    public EvaluateClientResponse evaluateClient(EvaluateClientRequest request) throws OnboardingProviderException {
+        throw createException();
     }
 
     private static OnboardingProviderException createException() {

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/provider/OnboardingProvider.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/provider/OnboardingProvider.java
@@ -74,5 +74,5 @@ public interface OnboardingProvider {
      * @param request evaluation request
      * @return mono with evaluation response
      */
-    Mono<EvaluateClientResponse> evaluateClient(EvaluateClientRequest request);
+    EvaluateClientResponse evaluateClient(EvaluateClientRequest request) throws OnboardingProviderException;
 }

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/provider/rest/RestOnboardingProvider.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/provider/rest/RestOnboardingProvider.java
@@ -153,7 +153,7 @@ class RestOnboardingProvider implements OnboardingProvider {
                     .build();
 
         } catch (RestClientException e) {
-            throw new OnboardingProviderException("Unable to evaluate client for " + request);
+            throw new OnboardingProviderException("Unable to evaluate client for " + request, e);
         }
     }
 

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/statemachine/StateMachineConfig.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/statemachine/StateMachineConfig.java
@@ -243,7 +243,9 @@ public class StateMachineConfig extends EnumStateMachineConfigurerAdapter<Onboar
                 .withExternal()
                 .source(OnboardingState.DOCUMENT_UPLOAD_IN_PROGRESS)
                 .event(OnboardingEvent.EVENT_NEXT_STATE)
-                .guard(documentsVerificationPendingGuard)
+                .guard(
+                        context -> processIdentifierGuard.evaluate(context) && documentsVerificationPendingGuard.evaluate(context)
+                )
                 .action(moveToDocumentUploadVerificationPendingAction)
                 .target(OnboardingState.CHOICE_DOCUMENT_UPLOAD)
 
@@ -260,7 +262,9 @@ public class StateMachineConfig extends EnumStateMachineConfigurerAdapter<Onboar
                 .source(OnboardingState.DOCUMENT_UPLOAD_VERIFICATION_PENDING)
                 .event(OnboardingEvent.EVENT_NEXT_STATE)
                 .action(verificationDocumentStartAction)
-                .guard(documentsVerificationPendingGuard)
+                .guard(
+                        context -> processIdentifierGuard.evaluate(context) && documentsVerificationPendingGuard.evaluate(context)
+                )
                 .target(OnboardingState.CHOICE_DOCUMENT_VERIFICATION_PROCESSING)
 
                 .and()
@@ -276,6 +280,7 @@ public class StateMachineConfig extends EnumStateMachineConfigurerAdapter<Onboar
                 .withExternal()
                 .source(OnboardingState.DOCUMENT_VERIFICATION_ACCEPTED)
                 .event(OnboardingEvent.EVENT_NEXT_STATE)
+                .guard(processIdentifierGuard)
                 .action(clientEvaluationInitAction)
                 .target(OnboardingState.CLIENT_EVALUATION_IN_PROGRESS);
     }
@@ -286,6 +291,7 @@ public class StateMachineConfig extends EnumStateMachineConfigurerAdapter<Onboar
                 .source(OnboardingState.CLIENT_EVALUATION_IN_PROGRESS)
                 .event(OnboardingEvent.EVENT_NEXT_STATE)
                 .action(clientEvaluationAction)
+                .guard(processIdentifierGuard)
                 .target(OnboardingState.CHOICE_CLIENT_EVALUATION_PROCESSING)
 
                 .and()
@@ -301,6 +307,7 @@ public class StateMachineConfig extends EnumStateMachineConfigurerAdapter<Onboar
                 .withExternal()
                 .source(OnboardingState.CLIENT_EVALUATION_ACCEPTED)
                 .event(OnboardingEvent.EVENT_NEXT_STATE)
+                .guard(processIdentifierGuard)
                 .target(OnboardingState.CHOICE_CLIENT_EVALUATION_ACCEPTED)
 
                 .and()
@@ -327,7 +334,8 @@ public class StateMachineConfig extends EnumStateMachineConfigurerAdapter<Onboar
                 .source(OnboardingState.PRESENCE_CHECK_IN_PROGRESS)
                 .event(OnboardingEvent.PRESENCE_CHECK_INIT)
                 .guard(context ->
-                        processIdentifierGuard.evaluate(context) && presenceCheckEnabledGuard.evaluate(context))
+                        processIdentifierGuard.evaluate(context) && presenceCheckEnabledGuard.evaluate(context)
+                )
                 .action(presenceCheckInitAction)
                 .target(OnboardingState.PRESENCE_CHECK_IN_PROGRESS)
 
@@ -335,6 +343,7 @@ public class StateMachineConfig extends EnumStateMachineConfigurerAdapter<Onboar
                 .withExternal()
                 .source(OnboardingState.PRESENCE_CHECK_IN_PROGRESS)
                 .event(OnboardingEvent.PRESENCE_CHECK_SUBMITTED)
+                .guard(processIdentifierGuard)
                 .action(moveToPresenceCheckVerificationPendingAction)
                 .target(OnboardingState.PRESENCE_CHECK_VERIFICATION_PENDING)
 
@@ -343,6 +352,7 @@ public class StateMachineConfig extends EnumStateMachineConfigurerAdapter<Onboar
                 .source(OnboardingState.PRESENCE_CHECK_VERIFICATION_PENDING)
                 .action(presenceCheckVerificationAction)
                 .event(OnboardingEvent.EVENT_NEXT_STATE)
+                .guard(processIdentifierGuard)
                 .target(OnboardingState.CHOICE_PRESENCE_CHECK_PROCESSING)
 
                 .and()
@@ -389,6 +399,7 @@ public class StateMachineConfig extends EnumStateMachineConfigurerAdapter<Onboar
                 .withExternal()
                 .source(OnboardingState.OTP_VERIFICATION_PENDING)
                 .event(OnboardingEvent.EVENT_NEXT_STATE)
+                .guard(processIdentifierGuard)
                 .target(OnboardingState.CHOICE_OTP_VERIFICATION)
 
                 .and()

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/statemachine/StateMachineConfig.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/statemachine/StateMachineConfig.java
@@ -243,9 +243,7 @@ public class StateMachineConfig extends EnumStateMachineConfigurerAdapter<Onboar
                 .withExternal()
                 .source(OnboardingState.DOCUMENT_UPLOAD_IN_PROGRESS)
                 .event(OnboardingEvent.EVENT_NEXT_STATE)
-                .guard(
-                        context -> processIdentifierGuard.evaluate(context) && documentsVerificationPendingGuard.evaluate(context)
-                )
+                .guard(documentsVerificationPendingGuard)
                 .action(moveToDocumentUploadVerificationPendingAction)
                 .target(OnboardingState.CHOICE_DOCUMENT_UPLOAD)
 

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/statemachine/guard/ProcessIdentifierGuard.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/statemachine/guard/ProcessIdentifierGuard.java
@@ -56,25 +56,24 @@ public class ProcessIdentifierGuard implements Guard<OnboardingState, Onboarding
         final OwnerId ownerId = (OwnerId) context.getMessageHeader(EventHeaderName.OWNER_ID);
         final String processId = (String) context.getMessageHeader(EventHeaderName.PROCESS_ID);
 
-        // Lock onboarding process
-        final Optional<OnboardingProcessEntity> processOptional = onboardingProcessRepository.findExistingProcessForActivationWithLock(ownerId.getActivationId(), OnboardingStatus.VERIFICATION_IN_PROGRESS);
+        logger.debug("Onboarding process will be locked using PESSIMISTIC_WRITE lock, {}", processId);
+        final Optional<OnboardingProcessEntity> processOptional = onboardingProcessRepository.findByActivationIdAndStatusWithLock(ownerId.getActivationId(), OnboardingStatus.VERIFICATION_IN_PROGRESS);
         if (processOptional.isEmpty()) {
-            logger.error("Onboarding process not found, {}", ownerId);
-            fail(context);
+            fail(context, processId, ownerId);
             return false;
         }
         final String expectedProcessId = processOptional.get().getId();
 
         if (!expectedProcessId.equals(processId)) {
-            logger.warn("Invalid process ID received in request: {}, {}", processId, ownerId);
-            fail(context);
+            fail(context, processId, ownerId);
             return false;
         }
         return true;
     }
 
-    private void fail(StateContext<OnboardingState, OnboardingEvent> context) {
-        context.getStateMachine().setStateMachineError(new OnboardingProcessException());
+    private void fail(StateContext<OnboardingState, OnboardingEvent> context, String processId, OwnerId ownerId) {
+        final Exception ex = new OnboardingProcessException(String.format("Invalid process ID received in request: %s, %s", processId, ownerId));
+        context.getStateMachine().setStateMachineError(ex);
     }
 
 }

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/statemachine/guard/ProcessIdentifierGuard.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/statemachine/guard/ProcessIdentifierGuard.java
@@ -16,6 +16,7 @@
  */
 package com.wultra.app.onboardingserver.statemachine.guard;
 
+import com.wultra.app.enrollmentserver.model.enumeration.OnboardingStatus;
 import com.wultra.app.enrollmentserver.model.integration.OwnerId;
 import com.wultra.app.onboardingserver.common.database.OnboardingProcessRepository;
 import com.wultra.app.onboardingserver.common.database.entity.OnboardingProcessEntity;
@@ -52,16 +53,17 @@ public class ProcessIdentifierGuard implements Guard<OnboardingState, Onboarding
      */
     @Override
     public boolean evaluate(StateContext<OnboardingState, OnboardingEvent> context) {
-        OwnerId ownerId = (OwnerId) context.getMessageHeader(EventHeaderName.OWNER_ID);
-        String processId = (String) context.getMessageHeader(EventHeaderName.PROCESS_ID);
+        final OwnerId ownerId = (OwnerId) context.getMessageHeader(EventHeaderName.OWNER_ID);
+        final String processId = (String) context.getMessageHeader(EventHeaderName.PROCESS_ID);
 
-        Optional<OnboardingProcessEntity> processOptional = onboardingProcessRepository.findProcessByActivationId(ownerId.getActivationId());
+        // Lock onboarding process
+        final Optional<OnboardingProcessEntity> processOptional = onboardingProcessRepository.findExistingProcessForActivationWithLock(ownerId.getActivationId(), OnboardingStatus.VERIFICATION_IN_PROGRESS);
         if (processOptional.isEmpty()) {
             logger.error("Onboarding process not found, {}", ownerId);
             fail(context);
             return false;
         }
-        String expectedProcessId = processOptional.get().getId();
+        final String expectedProcessId = processOptional.get().getId();
 
         if (!expectedProcessId.equals(processId)) {
             logger.warn("Invalid process ID received in request: {}, {}", processId, ownerId);

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/DocumentSubmitSyncTask.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/DocumentSubmitSyncTask.java
@@ -18,6 +18,7 @@
 package com.wultra.app.onboardingserver.task;
 
 import com.wultra.app.onboardingserver.impl.service.document.DocumentProcessingBatchService;
+import com.wultra.app.onboardingserver.task.consts.SchedulerLockNames;
 import lombok.extern.slf4j.Slf4j;
 import net.javacrumbs.shedlock.core.LockAssert;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
@@ -43,7 +44,7 @@ public class DocumentSubmitSyncTask {
      * Scheduled task to check in progress document submits at the target provider
      */
     @Scheduled(cron = "${enrollment-server-onboarding.document-verification.checkInProgressDocumentSubmits.cron:0/5 * * * * *}", zone = "UTC")
-    @SchedulerLock(name = "documentSubmitCheckLock", lockAtLeastFor = "100ms", lockAtMostFor = "5m")
+    @SchedulerLock(name = SchedulerLockNames.DOCUMENT_SUBMIT_SYNC_LOCK, lockAtLeastFor = "100ms", lockAtMostFor = "5m")
     public void checkInProgressDocumentSubmits() {
         LockAssert.assertLocked();
         logger.debug("checkInProgressDocumentSubmits");

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/DocumentSubmitSyncTask.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/DocumentSubmitSyncTask.java
@@ -44,7 +44,7 @@ public class DocumentSubmitSyncTask {
      * Scheduled task to check in progress document submits at the target provider
      */
     @Scheduled(cron = "${enrollment-server-onboarding.document-verification.checkInProgressDocumentSubmits.cron:0/5 * * * * *}", zone = "UTC")
-    @SchedulerLock(name = SchedulerLockNames.DOCUMENT_SUBMIT_SYNC_LOCK, lockAtLeastFor = "100ms", lockAtMostFor = "5m")
+    @SchedulerLock(name = SchedulerLockNames.DOCUMENT_SUBMIT_SYNC_LOCK, lockAtMostFor = "5m")
     public void checkInProgressDocumentSubmits() {
         LockAssert.assertLocked();
         logger.debug("checkInProgressDocumentSubmits");

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/DocumentSubmitSyncTask.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/DocumentSubmitSyncTask.java
@@ -40,7 +40,7 @@ public class DocumentSubmitSyncTask {
      * Scheduled task to check in progress document submits at the target provider
      */
     @Scheduled(cron = "${enrollment-server-onboarding.document-verification.checkInProgressDocumentSubmits.cron:0/5 * * * * *}", zone = "UTC")
-    @SchedulerLock(name = "checkInProgressDocumentSubmits", lockAtLeastFor = "1s", lockAtMostFor = "5m")
+    @SchedulerLock(name = "documentVerificationLock", lockAtLeastFor = "1s", lockAtMostFor = "5m")
     public void checkInProgressDocumentSubmits() {
         documentProcessingBatchService.checkInProgressDocumentSubmits();
     }

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/DocumentSubmitSyncTask.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/DocumentSubmitSyncTask.java
@@ -43,7 +43,7 @@ public class DocumentSubmitSyncTask {
      * Scheduled task to check in progress document submits at the target provider
      */
     @Scheduled(cron = "${enrollment-server-onboarding.document-verification.checkInProgressDocumentSubmits.cron:0/5 * * * * *}", zone = "UTC")
-    @SchedulerLock(name = "documentVerificationLock", lockAtLeastFor = "100ms", lockAtMostFor = "5m")
+    @SchedulerLock(name = "documentSubmitCheckLock", lockAtLeastFor = "100ms", lockAtMostFor = "5m")
     public void checkInProgressDocumentSubmits() {
         LockAssert.assertLocked();
         logger.debug("checkInProgressDocumentSubmits");

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/DocumentSubmitSyncTask.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/DocumentSubmitSyncTask.java
@@ -18,6 +18,8 @@
 package com.wultra.app.onboardingserver.task;
 
 import com.wultra.app.onboardingserver.impl.service.document.DocumentProcessingBatchService;
+import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.core.LockAssert;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -28,6 +30,7 @@ import org.springframework.stereotype.Component;
  * @author Lukas Lukovsky, lukas.lukovsky@wultra.com
  */
 @Component
+@Slf4j
 public class DocumentSubmitSyncTask {
 
     private final DocumentProcessingBatchService documentProcessingBatchService;
@@ -40,8 +43,10 @@ public class DocumentSubmitSyncTask {
      * Scheduled task to check in progress document submits at the target provider
      */
     @Scheduled(cron = "${enrollment-server-onboarding.document-verification.checkInProgressDocumentSubmits.cron:0/5 * * * * *}", zone = "UTC")
-    @SchedulerLock(name = "documentVerificationLock", lockAtLeastFor = "1s", lockAtMostFor = "5m")
+    @SchedulerLock(name = "documentVerificationLock", lockAtLeastFor = "100ms", lockAtMostFor = "5m")
     public void checkInProgressDocumentSubmits() {
+        LockAssert.assertLocked();
+        logger.debug("checkInProgressDocumentSubmits");
         documentProcessingBatchService.checkInProgressDocumentSubmits();
     }
 

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/DocumentSubmitVerificationSyncTask.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/DocumentSubmitVerificationSyncTask.java
@@ -44,7 +44,7 @@ public class DocumentSubmitVerificationSyncTask {
      * Scheduled task to check document submit verifications at the target provider
      */
     @Scheduled(cron = "${enrollment-server-onboarding.document-verification.checkDocumentSubmitVerifications.cron:0/5 * * * * *}", zone = "UTC")
-    @SchedulerLock(name = SchedulerLockNames.DOCUMENT_SUBMIT_VERIFICATION_LOCK, lockAtLeastFor = "100ms", lockAtMostFor = "5m")
+    @SchedulerLock(name = SchedulerLockNames.DOCUMENT_SUBMIT_VERIFICATION_LOCK, lockAtMostFor = "5m")
     public void checkDocumentSubmitVerifications() {
         LockAssert.assertLocked();
         logger.debug("checkDocumentSubmitVerifications");

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/DocumentSubmitVerificationSyncTask.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/DocumentSubmitVerificationSyncTask.java
@@ -18,6 +18,7 @@
 package com.wultra.app.onboardingserver.task;
 
 import com.wultra.app.onboardingserver.impl.service.verification.VerificationProcessingBatchService;
+import com.wultra.app.onboardingserver.task.consts.SchedulerLockNames;
 import lombok.extern.slf4j.Slf4j;
 import net.javacrumbs.shedlock.core.LockAssert;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
@@ -43,7 +44,7 @@ public class DocumentSubmitVerificationSyncTask {
      * Scheduled task to check document submit verifications at the target provider
      */
     @Scheduled(cron = "${enrollment-server-onboarding.document-verification.checkDocumentSubmitVerifications.cron:0/5 * * * * *}", zone = "UTC")
-    @SchedulerLock(name = "documentSubmitVerificationsLock", lockAtLeastFor = "100ms", lockAtMostFor = "5m")
+    @SchedulerLock(name = SchedulerLockNames.DOCUMENT_SUBMIT_VERIFICATION_LOCK, lockAtLeastFor = "100ms", lockAtMostFor = "5m")
     public void checkDocumentSubmitVerifications() {
         LockAssert.assertLocked();
         logger.debug("checkDocumentSubmitVerifications");

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/DocumentSubmitVerificationSyncTask.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/DocumentSubmitVerificationSyncTask.java
@@ -40,7 +40,7 @@ public class DocumentSubmitVerificationSyncTask {
      * Scheduled task to check document submit verifications at the target provider
      */
     @Scheduled(cron = "${enrollment-server-onboarding.document-verification.checkDocumentSubmitVerifications.cron:0/5 * * * * *}", zone = "UTC")
-    @SchedulerLock(name = "checkDocumentSubmitVerifications", lockAtLeastFor = "1s", lockAtMostFor = "5m")
+    @SchedulerLock(name = "documentVerificationLock", lockAtLeastFor = "1s", lockAtMostFor = "5m")
     public void checkDocumentSubmitVerifications() {
         verificationProcessingBatchService.checkDocumentSubmitVerifications();
     }

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/DocumentSubmitVerificationSyncTask.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/DocumentSubmitVerificationSyncTask.java
@@ -43,7 +43,7 @@ public class DocumentSubmitVerificationSyncTask {
      * Scheduled task to check document submit verifications at the target provider
      */
     @Scheduled(cron = "${enrollment-server-onboarding.document-verification.checkDocumentSubmitVerifications.cron:0/5 * * * * *}", zone = "UTC")
-    @SchedulerLock(name = "documentVerificationLock", lockAtLeastFor = "100ms", lockAtMostFor = "5m")
+    @SchedulerLock(name = "documentSubmitVerificationsLock", lockAtLeastFor = "100ms", lockAtMostFor = "5m")
     public void checkDocumentSubmitVerifications() {
         LockAssert.assertLocked();
         logger.debug("checkDocumentSubmitVerifications");

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/DocumentSubmitVerificationSyncTask.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/DocumentSubmitVerificationSyncTask.java
@@ -18,6 +18,8 @@
 package com.wultra.app.onboardingserver.task;
 
 import com.wultra.app.onboardingserver.impl.service.verification.VerificationProcessingBatchService;
+import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.core.LockAssert;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -28,6 +30,7 @@ import org.springframework.stereotype.Component;
  * @author Lukas Lukovsky, lukas.lukovsky@wultra.com
  */
 @Component
+@Slf4j
 public class DocumentSubmitVerificationSyncTask {
 
     private final VerificationProcessingBatchService verificationProcessingBatchService;
@@ -40,8 +43,10 @@ public class DocumentSubmitVerificationSyncTask {
      * Scheduled task to check document submit verifications at the target provider
      */
     @Scheduled(cron = "${enrollment-server-onboarding.document-verification.checkDocumentSubmitVerifications.cron:0/5 * * * * *}", zone = "UTC")
-    @SchedulerLock(name = "documentVerificationLock", lockAtLeastFor = "1s", lockAtMostFor = "5m")
+    @SchedulerLock(name = "documentVerificationLock", lockAtLeastFor = "100ms", lockAtMostFor = "5m")
     public void checkDocumentSubmitVerifications() {
+        LockAssert.assertLocked();
+        logger.debug("checkDocumentSubmitVerifications");
         verificationProcessingBatchService.checkDocumentSubmitVerifications();
     }
 

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/DocumentsVerificationSyncTask.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/DocumentsVerificationSyncTask.java
@@ -18,6 +18,7 @@
 package com.wultra.app.onboardingserver.task;
 
 import com.wultra.app.onboardingserver.impl.service.verification.VerificationProcessingBatchService;
+import com.wultra.app.onboardingserver.task.consts.SchedulerLockNames;
 import lombok.extern.slf4j.Slf4j;
 import net.javacrumbs.shedlock.core.LockAssert;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
@@ -43,7 +44,7 @@ public class DocumentsVerificationSyncTask {
      * Scheduled task to check documents verifications at the target provider
      */
     @Scheduled(cron = "${enrollment-server-onboarding.document-verification.checkDocumentsVerifications.cron:0/5 * * * * *}", zone = "UTC")
-    @SchedulerLock(name = "documentSubmitVerificationsLock", lockAtLeastFor = "100ms", lockAtMostFor = "5m")
+    @SchedulerLock(name = SchedulerLockNames.DOCUMENT_VERIFICATION_LOCK, lockAtLeastFor = "100ms", lockAtMostFor = "5m")
     public void checkDocumentSubmitVerifications() {
         LockAssert.assertLocked();
         logger.debug("checkDocumentSubmitVerifications");

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/DocumentsVerificationSyncTask.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/DocumentsVerificationSyncTask.java
@@ -44,7 +44,7 @@ public class DocumentsVerificationSyncTask {
      * Scheduled task to check documents verifications at the target provider
      */
     @Scheduled(cron = "${enrollment-server-onboarding.document-verification.checkDocumentsVerifications.cron:0/5 * * * * *}", zone = "UTC")
-    @SchedulerLock(name = SchedulerLockNames.DOCUMENT_VERIFICATION_LOCK, lockAtLeastFor = "100ms", lockAtMostFor = "5m")
+    @SchedulerLock(name = SchedulerLockNames.DOCUMENT_VERIFICATION_LOCK, lockAtMostFor = "5m")
     public void checkDocumentSubmitVerifications() {
         LockAssert.assertLocked();
         logger.debug("checkDocumentSubmitVerifications");

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/DocumentsVerificationSyncTask.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/DocumentsVerificationSyncTask.java
@@ -18,6 +18,8 @@
 package com.wultra.app.onboardingserver.task;
 
 import com.wultra.app.onboardingserver.impl.service.verification.VerificationProcessingBatchService;
+import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.core.LockAssert;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -28,6 +30,7 @@ import org.springframework.stereotype.Component;
  * @author Lukas Lukovsky, lukas.lukovsky@wultra.com
  */
 @Component
+@Slf4j
 public class DocumentsVerificationSyncTask {
 
     private final VerificationProcessingBatchService verificationProcessingBatchService;
@@ -40,8 +43,10 @@ public class DocumentsVerificationSyncTask {
      * Scheduled task to check documents verifications at the target provider
      */
     @Scheduled(cron = "${enrollment-server-onboarding.document-verification.checkDocumentsVerifications.cron:0/5 * * * * *}", zone = "UTC")
-    @SchedulerLock(name = "documentVerificationLock", lockAtLeastFor = "1s", lockAtMostFor = "5m")
+    @SchedulerLock(name = "documentVerificationLock", lockAtLeastFor = "100ms", lockAtMostFor = "5m")
     public void checkDocumentSubmitVerifications() {
+        LockAssert.assertLocked();
+        logger.debug("checkDocumentSubmitVerifications");
         verificationProcessingBatchService.checkDocumentsVerifications();
     }
 

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/DocumentsVerificationSyncTask.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/DocumentsVerificationSyncTask.java
@@ -43,7 +43,7 @@ public class DocumentsVerificationSyncTask {
      * Scheduled task to check documents verifications at the target provider
      */
     @Scheduled(cron = "${enrollment-server-onboarding.document-verification.checkDocumentsVerifications.cron:0/5 * * * * *}", zone = "UTC")
-    @SchedulerLock(name = "documentVerificationLock", lockAtLeastFor = "100ms", lockAtMostFor = "5m")
+    @SchedulerLock(name = "documentSubmitVerificationsLock", lockAtLeastFor = "100ms", lockAtMostFor = "5m")
     public void checkDocumentSubmitVerifications() {
         LockAssert.assertLocked();
         logger.debug("checkDocumentSubmitVerifications");

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/DocumentsVerificationSyncTask.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/DocumentsVerificationSyncTask.java
@@ -40,7 +40,7 @@ public class DocumentsVerificationSyncTask {
      * Scheduled task to check documents verifications at the target provider
      */
     @Scheduled(cron = "${enrollment-server-onboarding.document-verification.checkDocumentsVerifications.cron:0/5 * * * * *}", zone = "UTC")
-    @SchedulerLock(name = "checkDocumentsVerifications", lockAtLeastFor = "1s", lockAtMostFor = "5m")
+    @SchedulerLock(name = "documentVerificationLock", lockAtLeastFor = "1s", lockAtMostFor = "5m")
     public void checkDocumentSubmitVerifications() {
         verificationProcessingBatchService.checkDocumentsVerifications();
     }

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/StateMachineTask.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/StateMachineTask.java
@@ -48,7 +48,7 @@ public class StateMachineTask {
      * Scheduled task to change machine state.
      */
     @Scheduled(cron = "${enrollment-server-onboarding.state-machine.changeMachineState.cron:0/3 * * * * *}", zone = "UTC")
-    @SchedulerLock(name = SchedulerLockNames.ONBOARDING_PROCESS_LOCK, lockAtLeastFor = "100ms", lockAtMostFor = "5m")
+    @SchedulerLock(name = SchedulerLockNames.ONBOARDING_PROCESS_LOCK, lockAtMostFor = "5m")
     public void changeMachineState() {
         LockAssert.assertLocked();
         logger.debug("Changing machine states in batch");

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/StateMachineTask.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/StateMachineTask.java
@@ -18,6 +18,7 @@
 package com.wultra.app.onboardingserver.task;
 
 import com.wultra.app.onboardingserver.statemachine.service.StateMachineService;
+import com.wultra.app.onboardingserver.task.consts.SchedulerLockNames;
 import lombok.extern.slf4j.Slf4j;
 import net.javacrumbs.shedlock.core.LockAssert;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
@@ -47,7 +48,7 @@ public class StateMachineTask {
      * Scheduled task to change machine state.
      */
     @Scheduled(cron = "${enrollment-server-onboarding.state-machine.changeMachineState.cron:0/3 * * * * *}", zone = "UTC")
-    @SchedulerLock(name = "onboardingProcessLock", lockAtLeastFor = "100ms", lockAtMostFor = "5m")
+    @SchedulerLock(name = SchedulerLockNames.ONBOARDING_PROCESS_LOCK, lockAtLeastFor = "100ms", lockAtMostFor = "5m")
     public void changeMachineState() {
         LockAssert.assertLocked();
         logger.debug("Changing machine states in batch");

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/StateMachineTask.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/StateMachineTask.java
@@ -47,7 +47,7 @@ public class StateMachineTask {
      * Scheduled task to change machine state.
      */
     @Scheduled(cron = "${enrollment-server-onboarding.state-machine.changeMachineState.cron:0/3 * * * * *}", zone = "UTC")
-    @SchedulerLock(name = "changeMachineState", lockAtLeastFor = "1s", lockAtMostFor = "5m")
+    @SchedulerLock(name = "onboardingProcessLock", lockAtLeastFor = "1s", lockAtMostFor = "5m")
     public void changeMachineState() {
         LockAssert.assertLocked();
         logger.debug("Changing machine states in batch");

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/StateMachineTask.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/StateMachineTask.java
@@ -47,7 +47,7 @@ public class StateMachineTask {
      * Scheduled task to change machine state.
      */
     @Scheduled(cron = "${enrollment-server-onboarding.state-machine.changeMachineState.cron:0/3 * * * * *}", zone = "UTC")
-    @SchedulerLock(name = "onboardingProcessLock", lockAtLeastFor = "1s", lockAtMostFor = "5m")
+    @SchedulerLock(name = "onboardingProcessLock", lockAtLeastFor = "100ms", lockAtMostFor = "5m")
     public void changeMachineState() {
         LockAssert.assertLocked();
         logger.debug("Changing machine states in batch");

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/cleaning/ActivationCleaningService.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/cleaning/ActivationCleaningService.java
@@ -26,9 +26,7 @@ import com.wultra.security.powerauth.client.v3.ActivationStatus;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.support.TransactionTemplate;
 
 /**
  * Service to cleaning activations.
@@ -61,7 +59,7 @@ class ActivationCleaningService {
      */
     @Transactional
     public void cleanupActivations() {
-        onboardingProcessRepository.findProcessesToRemoveActivationWithLock()
+        onboardingProcessRepository.findAllToRemoveActivationWithLock()
                 .forEach(this::cleanupActivation);
     }
 

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/cleaning/CleaningService.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/cleaning/CleaningService.java
@@ -96,7 +96,7 @@ class CleaningService {
     public void terminateExpiredProcessActivations() {
         final Duration activationExpiration = onboardingConfig.getActivationExpirationTime();
         final Date createdDateExpiredActivations = DateUtil.convertExpirationToCreatedDate(activationExpiration);
-        final List<String> ids = onboardingProcessRepository.findExpiredProcessIdsByStatusAndCreatedDate(createdDateExpiredActivations, OnboardingStatus.ACTIVATION_IN_PROGRESS);
+        final List<String> ids = onboardingProcessRepository.findExpiredProcessIdsByStatusWithLock(createdDateExpiredActivations, OnboardingStatus.ACTIVATION_IN_PROGRESS);
         terminateProcessesAndRelatedEntities(ids, OnboardingProcessEntity.ERROR_PROCESS_EXPIRED_ACTIVATION);
     }
 
@@ -107,7 +107,7 @@ class CleaningService {
     public void terminateExpiredProcessVerifications() {
         final Duration verificationExpiration = identityVerificationConfig.getVerificationExpirationTime();
         final Date createdDateExpiredVerifications = DateUtil.convertExpirationToCreatedDate(verificationExpiration);
-        final List<String> ids = onboardingProcessRepository.findExpiredProcessIdsByStatusAndCreatedDate(createdDateExpiredVerifications, OnboardingStatus.VERIFICATION_IN_PROGRESS);
+        final List<String> ids = onboardingProcessRepository.findExpiredProcessIdsByStatusWithLock(createdDateExpiredVerifications, OnboardingStatus.VERIFICATION_IN_PROGRESS);
         terminateProcessesAndRelatedEntities(ids, OnboardingProcessEntity.ERROR_PROCESS_EXPIRED_IDENTITY_VERIFICATION);
     }
 
@@ -133,7 +133,7 @@ class CleaningService {
         final Date now = new Date();
         final Duration processExpiration = onboardingConfig.getProcessExpirationTime();
         final Date createdDateExpiredProcesses = DateUtil.convertExpirationToCreatedDate(processExpiration);
-        final List<String> ids = onboardingProcessRepository.findExpiredProcessIdsByCreatedDate(createdDateExpiredProcesses);
+        final List<String> ids = onboardingProcessRepository.findExpiredProcessIdsWithLock(createdDateExpiredProcesses);
         if (ids.isEmpty()) {
             logger.debug("No expired process to terminate");
             return;

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/cleaning/CleaningService.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/cleaning/CleaningService.java
@@ -96,7 +96,7 @@ class CleaningService {
     public void terminateExpiredProcessActivations() {
         final Duration activationExpiration = onboardingConfig.getActivationExpirationTime();
         final Date createdDateExpiredActivations = DateUtil.convertExpirationToCreatedDate(activationExpiration);
-        final List<String> ids = onboardingProcessRepository.findExpiredProcessIdsByStatusWithLock(createdDateExpiredActivations, OnboardingStatus.ACTIVATION_IN_PROGRESS);
+        final List<String> ids = onboardingProcessRepository.findByTimestampAndStatusWithLock(createdDateExpiredActivations, OnboardingStatus.ACTIVATION_IN_PROGRESS);
         terminateProcessesAndRelatedEntities(ids, OnboardingProcessEntity.ERROR_PROCESS_EXPIRED_ACTIVATION);
     }
 
@@ -107,7 +107,7 @@ class CleaningService {
     public void terminateExpiredProcessVerifications() {
         final Duration verificationExpiration = identityVerificationConfig.getVerificationExpirationTime();
         final Date createdDateExpiredVerifications = DateUtil.convertExpirationToCreatedDate(verificationExpiration);
-        final List<String> ids = onboardingProcessRepository.findExpiredProcessIdsByStatusWithLock(createdDateExpiredVerifications, OnboardingStatus.VERIFICATION_IN_PROGRESS);
+        final List<String> ids = onboardingProcessRepository.findByTimestampAndStatusWithLock(createdDateExpiredVerifications, OnboardingStatus.VERIFICATION_IN_PROGRESS);
         terminateProcessesAndRelatedEntities(ids, OnboardingProcessEntity.ERROR_PROCESS_EXPIRED_IDENTITY_VERIFICATION);
     }
 
@@ -118,7 +118,7 @@ class CleaningService {
     public void terminateExpiredOtpCodes() {
         final Duration otpExpiration = onboardingConfig.getOtpExpirationTime();
         final Date createdDateExpiredOtp = DateUtil.convertExpirationToCreatedDate(otpExpiration);
-        final List<String> otpIds = onboardingOtpRepository.findExpiredOtps(createdDateExpiredOtp);
+        final List<String> otpIds = onboardingOtpRepository.findExpiredIds(createdDateExpiredOtp);
         final Date now = new Date();
         for (List<String> otpIdChunk : Lists.partition(otpIds, BATCH_SIZE)) {
             terminateAndAuditOtps(otpIdChunk, now);
@@ -133,7 +133,7 @@ class CleaningService {
         final Date now = new Date();
         final Duration processExpiration = onboardingConfig.getProcessExpirationTime();
         final Date createdDateExpiredProcesses = DateUtil.convertExpirationToCreatedDate(processExpiration);
-        final List<String> ids = onboardingProcessRepository.findExpiredProcessIdsWithLock(createdDateExpiredProcesses);
+        final List<String> ids = onboardingProcessRepository.findActiveByTimestampWithLock(createdDateExpiredProcesses);
         if (ids.isEmpty()) {
             logger.debug("No expired process to terminate");
             return;

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/cleaning/CleaningTask.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/cleaning/CleaningTask.java
@@ -48,7 +48,7 @@ public class CleaningTask {
      * Terminate processes with activation in progress.
      */
     @Scheduled(fixedDelayString = "PT15S", initialDelayString = "PT10S")
-    @SchedulerLock(name = SchedulerLockNames.ONBOARDING_PROCESS_LOCK, lockAtLeastFor = "100ms", lockAtMostFor = "5m")
+    @SchedulerLock(name = SchedulerLockNames.ONBOARDING_PROCESS_LOCK, lockAtMostFor = "5m")
     public void terminateExpiredProcessActivations() {
         LockAssert.assertLocked();
         logger.debug("terminateExpiredProcessActivations");
@@ -59,7 +59,7 @@ public class CleaningTask {
      * Terminate processes with verifications in progress.
      */
     @Scheduled(fixedDelayString = "PT15S", initialDelayString = "PT15S")
-    @SchedulerLock(name = SchedulerLockNames.ONBOARDING_PROCESS_LOCK, lockAtLeastFor = "100ms", lockAtMostFor = "5m")
+    @SchedulerLock(name = SchedulerLockNames.ONBOARDING_PROCESS_LOCK, lockAtMostFor = "5m")
     public void terminateProcessesWithVerificationsInProgress() {
         LockAssert.assertLocked();
         logger.debug("terminateExpiredProcessVerifications");
@@ -70,7 +70,7 @@ public class CleaningTask {
      * Terminate expired OTP codes.
      */
     @Scheduled(fixedDelayString = "PT15S", initialDelayString = "PT10S")
-    @SchedulerLock(name = SchedulerLockNames.ONBOARDING_OTP_LOCK, lockAtLeastFor = "100ms", lockAtMostFor = "5m")
+    @SchedulerLock(name = SchedulerLockNames.ONBOARDING_OTP_LOCK, lockAtMostFor = "5m")
     public void terminateExpiredOtpCodes() {
         LockAssert.assertLocked();
         logger.debug("terminateExpiredOtpCodes");
@@ -81,7 +81,7 @@ public class CleaningTask {
      * Terminate expired processes.
      */
     @Scheduled(fixedDelayString = "PT15S", initialDelayString = "PT20S")
-    @SchedulerLock(name = SchedulerLockNames.ONBOARDING_PROCESS_LOCK, lockAtLeastFor = "100ms", lockAtMostFor = "5m")
+    @SchedulerLock(name = SchedulerLockNames.ONBOARDING_PROCESS_LOCK, lockAtMostFor = "5m")
     public void terminateExpiredProcesses() {
         LockAssert.assertLocked();
         logger.debug("terminateExpiredProcesses");
@@ -92,7 +92,7 @@ public class CleaningTask {
      * Cleanup of large documents older than retention time.
      */
     @Scheduled(fixedDelayString = "PT10M", initialDelayString = "PT15S")
-    @SchedulerLock(name = SchedulerLockNames.LARGE_DOCUMENT_DATA_LOCK, lockAtLeastFor = "100ms", lockAtMostFor = "5m")
+    @SchedulerLock(name = SchedulerLockNames.LARGE_DOCUMENT_DATA_LOCK, lockAtMostFor = "5m")
     public void cleanupLargeDocuments() {
         LockAssert.assertLocked();
         logger.debug("cleanupLargeDocuments");
@@ -100,7 +100,7 @@ public class CleaningTask {
     }
 
     @Scheduled(fixedDelayString = "PT10M", initialDelayString = "PT20S")
-    @SchedulerLock(name = SchedulerLockNames.EXPIRE_DOCUMENT_VERIFICATION_LOCK, lockAtLeastFor = "100ms", lockAtMostFor = "5m")
+    @SchedulerLock(name = SchedulerLockNames.EXPIRE_DOCUMENT_VERIFICATION_LOCK, lockAtMostFor = "5m")
     public void terminateExpiredDocumentVerifications() {
         LockAssert.assertLocked();
         logger.debug("terminateExpiredDocumentVerifications");
@@ -108,7 +108,7 @@ public class CleaningTask {
     }
 
     @Scheduled(fixedDelayString = "PT10M", initialDelayString = "PT25S")
-    @SchedulerLock(name = SchedulerLockNames.ONBOARDING_PROCESS_LOCK, lockAtLeastFor = "100ms", lockAtMostFor = "5m")
+    @SchedulerLock(name = SchedulerLockNames.ONBOARDING_PROCESS_LOCK, lockAtMostFor = "5m")
     public void terminateExpiredIdentityVerifications() {
         LockAssert.assertLocked();
         logger.debug("terminateExpiredIdentityVerifications");
@@ -119,7 +119,7 @@ public class CleaningTask {
      * Cleanup activations of failed onboarding processes.
      */
     @Scheduled(fixedDelayString = "PT60S", initialDelayString = "PT30S")
-    @SchedulerLock(name = SchedulerLockNames.CLEANUP_ACTIVATIONS_LOCK, lockAtLeastFor = "100ms", lockAtMostFor = "5m")
+    @SchedulerLock(name = SchedulerLockNames.CLEANUP_ACTIVATIONS_LOCK, lockAtMostFor = "5m")
     public void cleanupActivations() {
         LockAssert.assertLocked();
         logger.debug("cleanupActivations");

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/cleaning/CleaningTask.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/cleaning/CleaningTask.java
@@ -17,6 +17,7 @@
  */
 package com.wultra.app.onboardingserver.task.cleaning;
 
+import com.wultra.app.onboardingserver.task.consts.SchedulerLockNames;
 import lombok.extern.slf4j.Slf4j;
 import net.javacrumbs.shedlock.core.LockAssert;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
@@ -47,7 +48,7 @@ public class CleaningTask {
      * Terminate processes with activation in progress.
      */
     @Scheduled(fixedDelayString = "PT15S", initialDelayString = "PT10S")
-    @SchedulerLock(name = "onboardingProcessLock", lockAtLeastFor = "100ms", lockAtMostFor = "5m")
+    @SchedulerLock(name = SchedulerLockNames.ONBOARDING_PROCESS_LOCK, lockAtLeastFor = "100ms", lockAtMostFor = "5m")
     public void terminateExpiredProcessActivations() {
         LockAssert.assertLocked();
         logger.debug("terminateExpiredProcessActivations");
@@ -58,7 +59,7 @@ public class CleaningTask {
      * Terminate processes with verifications in progress.
      */
     @Scheduled(fixedDelayString = "PT15S", initialDelayString = "PT15S")
-    @SchedulerLock(name = "onboardingProcessLock", lockAtLeastFor = "100ms", lockAtMostFor = "5m")
+    @SchedulerLock(name = SchedulerLockNames.ONBOARDING_PROCESS_LOCK, lockAtLeastFor = "100ms", lockAtMostFor = "5m")
     public void terminateProcessesWithVerificationsInProgress() {
         LockAssert.assertLocked();
         logger.debug("terminateExpiredProcessVerifications");
@@ -69,7 +70,7 @@ public class CleaningTask {
      * Terminate expired OTP codes.
      */
     @Scheduled(fixedDelayString = "PT15S", initialDelayString = "PT10S")
-    @SchedulerLock(name = "otpLock", lockAtLeastFor = "100ms", lockAtMostFor = "5m")
+    @SchedulerLock(name = SchedulerLockNames.ONBOARDING_OTP_LOCK, lockAtLeastFor = "100ms", lockAtMostFor = "5m")
     public void terminateExpiredOtpCodes() {
         LockAssert.assertLocked();
         logger.debug("terminateExpiredOtpCodes");
@@ -80,7 +81,7 @@ public class CleaningTask {
      * Terminate expired processes.
      */
     @Scheduled(fixedDelayString = "PT15S", initialDelayString = "PT20S")
-    @SchedulerLock(name = "onboardingProcessLock", lockAtLeastFor = "100ms", lockAtMostFor = "5m")
+    @SchedulerLock(name = SchedulerLockNames.ONBOARDING_PROCESS_LOCK, lockAtLeastFor = "100ms", lockAtMostFor = "5m")
     public void terminateExpiredProcesses() {
         LockAssert.assertLocked();
         logger.debug("terminateExpiredProcesses");
@@ -91,7 +92,7 @@ public class CleaningTask {
      * Cleanup of large documents older than retention time.
      */
     @Scheduled(fixedDelayString = "PT10M", initialDelayString = "PT15S")
-    @SchedulerLock(name = "largeDocumentDataLock", lockAtLeastFor = "100ms", lockAtMostFor = "5m")
+    @SchedulerLock(name = SchedulerLockNames.LARGE_DOCUMENT_DATA_LOCK, lockAtLeastFor = "100ms", lockAtMostFor = "5m")
     public void cleanupLargeDocuments() {
         LockAssert.assertLocked();
         logger.debug("cleanupLargeDocuments");
@@ -99,7 +100,7 @@ public class CleaningTask {
     }
 
     @Scheduled(fixedDelayString = "PT10M", initialDelayString = "PT20S")
-    @SchedulerLock(name = "expireDocumentVerificationLock", lockAtLeastFor = "100ms", lockAtMostFor = "5m")
+    @SchedulerLock(name = SchedulerLockNames.EXPIRE_DOCUMENT_VERIFICATION_LOCK, lockAtLeastFor = "100ms", lockAtMostFor = "5m")
     public void terminateExpiredDocumentVerifications() {
         LockAssert.assertLocked();
         logger.debug("terminateExpiredDocumentVerifications");
@@ -107,7 +108,7 @@ public class CleaningTask {
     }
 
     @Scheduled(fixedDelayString = "PT10M", initialDelayString = "PT25S")
-    @SchedulerLock(name = "onboardingProcessLock", lockAtLeastFor = "100ms", lockAtMostFor = "5m")
+    @SchedulerLock(name = SchedulerLockNames.ONBOARDING_PROCESS_LOCK, lockAtLeastFor = "100ms", lockAtMostFor = "5m")
     public void terminateExpiredIdentityVerifications() {
         LockAssert.assertLocked();
         logger.debug("terminateExpiredIdentityVerifications");
@@ -118,7 +119,7 @@ public class CleaningTask {
      * Cleanup activations of failed onboarding processes.
      */
     @Scheduled(fixedDelayString = "PT60S", initialDelayString = "PT30S")
-    @SchedulerLock(name = "cleanupActivationsLock", lockAtLeastFor = "100ms", lockAtMostFor = "5m")
+    @SchedulerLock(name = SchedulerLockNames.CLEANUP_ACTIVATIONS_LOCK, lockAtLeastFor = "100ms", lockAtMostFor = "5m")
     public void cleanupActivations() {
         LockAssert.assertLocked();
         logger.debug("cleanupActivations");

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/cleaning/CleaningTask.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/cleaning/CleaningTask.java
@@ -46,7 +46,7 @@ public class CleaningTask {
     /**
      * Terminate processes with activation in progress.
      */
-    @Scheduled(fixedDelayString = "PT15S", initialDelayString = "PT15S")
+    @Scheduled(fixedDelayString = "PT15S", initialDelayString = "PT10S")
     @SchedulerLock(name = "onboardingProcessLock", lockAtLeastFor = "100ms", lockAtMostFor = "5m")
     public void terminateExpiredProcessActivations() {
         LockAssert.assertLocked();
@@ -57,7 +57,7 @@ public class CleaningTask {
     /**
      * Terminate processes with verifications in progress.
      */
-    @Scheduled(fixedDelayString = "PT15S", initialDelayString = "PT15S")
+    @Scheduled(fixedDelayString = "PT15S", initialDelayString = "PT11S")
     @SchedulerLock(name = "onboardingProcessLock", lockAtLeastFor = "100ms", lockAtMostFor = "5m")
     public void terminateProcessesWithVerificationsInProgress() {
         LockAssert.assertLocked();
@@ -68,7 +68,7 @@ public class CleaningTask {
     /**
      * Terminate expired OTP codes.
      */
-    @Scheduled(fixedDelayString = "PT15S", initialDelayString = "PT15S")
+    @Scheduled(fixedDelayString = "PT15S", initialDelayString = "PT12S")
     @SchedulerLock(name = "otpLock", lockAtLeastFor = "100ms", lockAtMostFor = "5m")
     public void terminateExpiredOtpCodes() {
         LockAssert.assertLocked();
@@ -79,7 +79,7 @@ public class CleaningTask {
     /**
      * Terminate expired processes.
      */
-    @Scheduled(fixedDelayString = "PT15S", initialDelayString = "PT15S")
+    @Scheduled(fixedDelayString = "PT15S", initialDelayString = "PT13S")
     @SchedulerLock(name = "onboardingProcessLock", lockAtLeastFor = "100ms", lockAtMostFor = "5m")
     public void terminateExpiredProcesses() {
         LockAssert.assertLocked();
@@ -90,23 +90,23 @@ public class CleaningTask {
     /**
      * Cleanup of large documents older than retention time.
      */
-    @Scheduled(fixedDelayString = "PT10M", initialDelayString = "PT10M")
-    @SchedulerLock(name = "documentDataLock", lockAtLeastFor = "100ms", lockAtMostFor = "5m")
+    @Scheduled(fixedDelayString = "PT10M", initialDelayString = "PT14S")
+    @SchedulerLock(name = "largeDocumentDataLock", lockAtLeastFor = "100ms", lockAtMostFor = "5m")
     public void cleanupLargeDocuments() {
         LockAssert.assertLocked();
         logger.debug("cleanupLargeDocuments");
         cleaningService.cleanupLargeDocuments();
     }
 
-    @Scheduled(fixedDelayString = "PT10M", initialDelayString = "PT10M")
-    @SchedulerLock(name = "documentVerificationLock", lockAtLeastFor = "100ms", lockAtMostFor = "5m")
+    @Scheduled(fixedDelayString = "PT10M", initialDelayString = "PT15S")
+    @SchedulerLock(name = "expireDocumentVerificationLock", lockAtLeastFor = "100ms", lockAtMostFor = "5m")
     public void terminateExpiredDocumentVerifications() {
         LockAssert.assertLocked();
         logger.debug("terminateExpiredDocumentVerifications");
         cleaningService.terminateExpiredDocumentVerifications();
     }
 
-    @Scheduled(fixedDelayString = "PT10M", initialDelayString = "PT10M")
+    @Scheduled(fixedDelayString = "PT10M", initialDelayString = "PT16S")
     @SchedulerLock(name = "onboardingProcessLock", lockAtLeastFor = "100ms", lockAtMostFor = "5m")
     public void terminateExpiredIdentityVerifications() {
         LockAssert.assertLocked();
@@ -117,7 +117,7 @@ public class CleaningTask {
     /**
      * Cleanup activations of failed onboarding processes.
      */
-    @Scheduled(fixedDelayString = "PT60S", initialDelayString = "PT60S")
+    @Scheduled(fixedDelayString = "PT60S", initialDelayString = "PT17S")
     @SchedulerLock(name = "onboardingProcessLock", lockAtLeastFor = "100ms", lockAtMostFor = "5m")
     public void cleanupActivations() {
         LockAssert.assertLocked();

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/cleaning/CleaningTask.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/cleaning/CleaningTask.java
@@ -47,7 +47,7 @@ public class CleaningTask {
      * Terminate processes with activation in progress.
      */
     @Scheduled(fixedDelayString = "PT15S", initialDelayString = "PT15S")
-    @SchedulerLock(name = "onboardingProcessLock", lockAtLeastFor = "1s", lockAtMostFor = "5m")
+    @SchedulerLock(name = "onboardingProcessLock", lockAtLeastFor = "100ms", lockAtMostFor = "5m")
     public void terminateExpiredProcessActivations() {
         LockAssert.assertLocked();
         logger.debug("terminateExpiredProcessActivations");
@@ -58,7 +58,7 @@ public class CleaningTask {
      * Terminate processes with verifications in progress.
      */
     @Scheduled(fixedDelayString = "PT15S", initialDelayString = "PT15S")
-    @SchedulerLock(name = "onboardingProcessLock", lockAtLeastFor = "1s", lockAtMostFor = "5m")
+    @SchedulerLock(name = "onboardingProcessLock", lockAtLeastFor = "100ms", lockAtMostFor = "5m")
     public void terminateProcessesWithVerificationsInProgress() {
         LockAssert.assertLocked();
         logger.debug("terminateExpiredProcessVerifications");
@@ -69,7 +69,7 @@ public class CleaningTask {
      * Terminate expired OTP codes.
      */
     @Scheduled(fixedDelayString = "PT15S", initialDelayString = "PT15S")
-    @SchedulerLock(name = "otpLock", lockAtLeastFor = "1s", lockAtMostFor = "5m")
+    @SchedulerLock(name = "otpLock", lockAtLeastFor = "100ms", lockAtMostFor = "5m")
     public void terminateExpiredOtpCodes() {
         LockAssert.assertLocked();
         logger.debug("terminateExpiredOtpCodes");
@@ -80,7 +80,7 @@ public class CleaningTask {
      * Terminate expired processes.
      */
     @Scheduled(fixedDelayString = "PT15S", initialDelayString = "PT15S")
-    @SchedulerLock(name = "onboardingProcessLock", lockAtLeastFor = "1s", lockAtMostFor = "5m")
+    @SchedulerLock(name = "onboardingProcessLock", lockAtLeastFor = "100ms", lockAtMostFor = "5m")
     public void terminateExpiredProcesses() {
         LockAssert.assertLocked();
         logger.debug("terminateExpiredProcesses");
@@ -91,7 +91,7 @@ public class CleaningTask {
      * Cleanup of large documents older than retention time.
      */
     @Scheduled(fixedDelayString = "PT10M", initialDelayString = "PT10M")
-    @SchedulerLock(name = "documentDataLock", lockAtLeastFor = "1s", lockAtMostFor = "5m")
+    @SchedulerLock(name = "documentDataLock", lockAtLeastFor = "100ms", lockAtMostFor = "5m")
     public void cleanupLargeDocuments() {
         LockAssert.assertLocked();
         logger.debug("cleanupLargeDocuments");
@@ -99,7 +99,7 @@ public class CleaningTask {
     }
 
     @Scheduled(fixedDelayString = "PT10M", initialDelayString = "PT10M")
-    @SchedulerLock(name = "documentVerificationLock", lockAtLeastFor = "1s", lockAtMostFor = "5m")
+    @SchedulerLock(name = "documentVerificationLock", lockAtLeastFor = "100ms", lockAtMostFor = "5m")
     public void terminateExpiredDocumentVerifications() {
         LockAssert.assertLocked();
         logger.debug("terminateExpiredDocumentVerifications");
@@ -107,7 +107,7 @@ public class CleaningTask {
     }
 
     @Scheduled(fixedDelayString = "PT10M", initialDelayString = "PT10M")
-    @SchedulerLock(name = "onboardingProcessLock", lockAtLeastFor = "1s", lockAtMostFor = "5m")
+    @SchedulerLock(name = "onboardingProcessLock", lockAtLeastFor = "100ms", lockAtMostFor = "5m")
     public void terminateExpiredIdentityVerifications() {
         LockAssert.assertLocked();
         logger.debug("terminateExpiredIdentityVerifications");
@@ -118,7 +118,7 @@ public class CleaningTask {
      * Cleanup activations of failed onboarding processes.
      */
     @Scheduled(fixedDelayString = "PT60S", initialDelayString = "PT60S")
-    @SchedulerLock(name = "onboardingProcessLock", lockAtLeastFor = "1s", lockAtMostFor = "5m")
+    @SchedulerLock(name = "onboardingProcessLock", lockAtLeastFor = "100ms", lockAtMostFor = "5m")
     public void cleanupActivations() {
         LockAssert.assertLocked();
         logger.debug("cleanupActivations");

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/cleaning/CleaningTask.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/cleaning/CleaningTask.java
@@ -57,7 +57,7 @@ public class CleaningTask {
     /**
      * Terminate processes with verifications in progress.
      */
-    @Scheduled(fixedDelayString = "PT15S", initialDelayString = "PT11S")
+    @Scheduled(fixedDelayString = "PT15S", initialDelayString = "PT15S")
     @SchedulerLock(name = "onboardingProcessLock", lockAtLeastFor = "100ms", lockAtMostFor = "5m")
     public void terminateProcessesWithVerificationsInProgress() {
         LockAssert.assertLocked();
@@ -68,7 +68,7 @@ public class CleaningTask {
     /**
      * Terminate expired OTP codes.
      */
-    @Scheduled(fixedDelayString = "PT15S", initialDelayString = "PT12S")
+    @Scheduled(fixedDelayString = "PT15S", initialDelayString = "PT10S")
     @SchedulerLock(name = "otpLock", lockAtLeastFor = "100ms", lockAtMostFor = "5m")
     public void terminateExpiredOtpCodes() {
         LockAssert.assertLocked();
@@ -79,7 +79,7 @@ public class CleaningTask {
     /**
      * Terminate expired processes.
      */
-    @Scheduled(fixedDelayString = "PT15S", initialDelayString = "PT13S")
+    @Scheduled(fixedDelayString = "PT15S", initialDelayString = "PT20S")
     @SchedulerLock(name = "onboardingProcessLock", lockAtLeastFor = "100ms", lockAtMostFor = "5m")
     public void terminateExpiredProcesses() {
         LockAssert.assertLocked();
@@ -90,7 +90,7 @@ public class CleaningTask {
     /**
      * Cleanup of large documents older than retention time.
      */
-    @Scheduled(fixedDelayString = "PT10M", initialDelayString = "PT14S")
+    @Scheduled(fixedDelayString = "PT10M", initialDelayString = "PT15S")
     @SchedulerLock(name = "largeDocumentDataLock", lockAtLeastFor = "100ms", lockAtMostFor = "5m")
     public void cleanupLargeDocuments() {
         LockAssert.assertLocked();
@@ -98,7 +98,7 @@ public class CleaningTask {
         cleaningService.cleanupLargeDocuments();
     }
 
-    @Scheduled(fixedDelayString = "PT10M", initialDelayString = "PT15S")
+    @Scheduled(fixedDelayString = "PT10M", initialDelayString = "PT20S")
     @SchedulerLock(name = "expireDocumentVerificationLock", lockAtLeastFor = "100ms", lockAtMostFor = "5m")
     public void terminateExpiredDocumentVerifications() {
         LockAssert.assertLocked();
@@ -106,7 +106,7 @@ public class CleaningTask {
         cleaningService.terminateExpiredDocumentVerifications();
     }
 
-    @Scheduled(fixedDelayString = "PT10M", initialDelayString = "PT16S")
+    @Scheduled(fixedDelayString = "PT10M", initialDelayString = "PT25S")
     @SchedulerLock(name = "onboardingProcessLock", lockAtLeastFor = "100ms", lockAtMostFor = "5m")
     public void terminateExpiredIdentityVerifications() {
         LockAssert.assertLocked();
@@ -117,8 +117,8 @@ public class CleaningTask {
     /**
      * Cleanup activations of failed onboarding processes.
      */
-    @Scheduled(fixedDelayString = "PT60S", initialDelayString = "PT17S")
-    @SchedulerLock(name = "onboardingProcessLock", lockAtLeastFor = "100ms", lockAtMostFor = "5m")
+    @Scheduled(fixedDelayString = "PT60S", initialDelayString = "PT30S")
+    @SchedulerLock(name = "cleanupActivationsLock", lockAtLeastFor = "100ms", lockAtMostFor = "5m")
     public void cleanupActivations() {
         LockAssert.assertLocked();
         logger.debug("cleanupActivations");

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/cleaning/CleaningTask.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/cleaning/CleaningTask.java
@@ -47,7 +47,7 @@ public class CleaningTask {
      * Terminate processes with activation in progress.
      */
     @Scheduled(fixedDelayString = "PT15S", initialDelayString = "PT15S")
-    @SchedulerLock(name = "terminateExpiredProcessActivations", lockAtLeastFor = "1s", lockAtMostFor = "5m")
+    @SchedulerLock(name = "onboardingProcessLock", lockAtLeastFor = "1s", lockAtMostFor = "5m")
     public void terminateExpiredProcessActivations() {
         LockAssert.assertLocked();
         logger.debug("terminateExpiredProcessActivations");
@@ -58,7 +58,7 @@ public class CleaningTask {
      * Terminate processes with verifications in progress.
      */
     @Scheduled(fixedDelayString = "PT15S", initialDelayString = "PT15S")
-    @SchedulerLock(name = "terminateExpiredProcessVerifications", lockAtLeastFor = "1s", lockAtMostFor = "5m")
+    @SchedulerLock(name = "onboardingProcessLock", lockAtLeastFor = "1s", lockAtMostFor = "5m")
     public void terminateProcessesWithVerificationsInProgress() {
         LockAssert.assertLocked();
         logger.debug("terminateExpiredProcessVerifications");
@@ -69,7 +69,7 @@ public class CleaningTask {
      * Terminate expired OTP codes.
      */
     @Scheduled(fixedDelayString = "PT15S", initialDelayString = "PT15S")
-    @SchedulerLock(name = "terminateExpiredOtpCodes", lockAtLeastFor = "1s", lockAtMostFor = "5m")
+    @SchedulerLock(name = "otpLock", lockAtLeastFor = "1s", lockAtMostFor = "5m")
     public void terminateExpiredOtpCodes() {
         LockAssert.assertLocked();
         logger.debug("terminateExpiredOtpCodes");
@@ -80,7 +80,7 @@ public class CleaningTask {
      * Terminate expired processes.
      */
     @Scheduled(fixedDelayString = "PT15S", initialDelayString = "PT15S")
-    @SchedulerLock(name = "terminateExpiredProcesses", lockAtLeastFor = "1s", lockAtMostFor = "5m")
+    @SchedulerLock(name = "onboardingProcessLock", lockAtLeastFor = "1s", lockAtMostFor = "5m")
     public void terminateExpiredProcesses() {
         LockAssert.assertLocked();
         logger.debug("terminateExpiredProcesses");
@@ -91,7 +91,7 @@ public class CleaningTask {
      * Cleanup of large documents older than retention time.
      */
     @Scheduled(fixedDelayString = "PT10M", initialDelayString = "PT10M")
-    @SchedulerLock(name = "cleanupLargeDocuments", lockAtLeastFor = "1s", lockAtMostFor = "5m")
+    @SchedulerLock(name = "documentDataLock", lockAtLeastFor = "1s", lockAtMostFor = "5m")
     public void cleanupLargeDocuments() {
         LockAssert.assertLocked();
         logger.debug("cleanupLargeDocuments");
@@ -99,7 +99,7 @@ public class CleaningTask {
     }
 
     @Scheduled(fixedDelayString = "PT10M", initialDelayString = "PT10M")
-    @SchedulerLock(name = "terminateExpiredDocumentVerifications", lockAtLeastFor = "1s", lockAtMostFor = "5m")
+    @SchedulerLock(name = "documentVerificationLock", lockAtLeastFor = "1s", lockAtMostFor = "5m")
     public void terminateExpiredDocumentVerifications() {
         LockAssert.assertLocked();
         logger.debug("terminateExpiredDocumentVerifications");
@@ -107,7 +107,7 @@ public class CleaningTask {
     }
 
     @Scheduled(fixedDelayString = "PT10M", initialDelayString = "PT10M")
-    @SchedulerLock(name = "terminateExpiredIdentityVerifications", lockAtLeastFor = "1s", lockAtMostFor = "5m")
+    @SchedulerLock(name = "onboardingProcessLock", lockAtLeastFor = "1s", lockAtMostFor = "5m")
     public void terminateExpiredIdentityVerifications() {
         LockAssert.assertLocked();
         logger.debug("terminateExpiredIdentityVerifications");
@@ -118,7 +118,7 @@ public class CleaningTask {
      * Cleanup activations of failed onboarding processes.
      */
     @Scheduled(fixedDelayString = "PT60S", initialDelayString = "PT60S")
-    @SchedulerLock(name = "cleanupActivations", lockAtLeastFor = "1s", lockAtMostFor = "5m")
+    @SchedulerLock(name = "onboardingProcessLock", lockAtLeastFor = "1s", lockAtMostFor = "5m")
     public void cleanupActivations() {
         LockAssert.assertLocked();
         logger.debug("cleanupActivations");

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/consts/SchedulerLockNames.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/consts/SchedulerLockNames.java
@@ -1,0 +1,45 @@
+/*
+ * PowerAuth Enrollment Server
+ * Copyright (C) 2022 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.wultra.app.onboardingserver.task.consts;
+
+/**
+ * Lock names for @SchedulerLock.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+public class SchedulerLockNames {
+
+    public static final String ONBOARDING_PROCESS_LOCK = "onboardingProcessLock";
+
+    public static final String ONBOARDING_OTP_LOCK = "onboardingOtpLock";
+
+    public static final String DOCUMENT_SUBMIT_SYNC_LOCK = "documentSubmitCheckLock";
+
+    public static final String DOCUMENT_SUBMIT_VERIFICATION_LOCK = "documentSubmitVerificationsLock";
+
+    public static final String DOCUMENT_VERIFICATION_LOCK = "documentSubmitVerificationsLock";
+
+    public static final String LARGE_DOCUMENT_DATA_LOCK = "largeDocumentDataLock";
+
+    public static final String EXPIRE_DOCUMENT_VERIFICATION_LOCK = "expireDocumentVerificationLock";
+
+    public static final String CLEANUP_ACTIVATIONS_LOCK = "cleanupActivationsLock";
+
+}

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/consts/SchedulerLockNames.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/consts/SchedulerLockNames.java
@@ -24,7 +24,11 @@ package com.wultra.app.onboardingserver.task.consts;
  *
  * @author Roman Strobl, roman.strobl@wultra.com
  */
-public class SchedulerLockNames {
+public final class SchedulerLockNames {
+
+    private SchedulerLockNames() {
+        throw new IllegalStateException("Class with constants");
+    }
 
     public static final String ONBOARDING_PROCESS_LOCK = "onboardingProcessLock";
 

--- a/enrollment-server-onboarding/src/test/java/com/wultra/app/onboardingserver/statemachine/ClientEvaluationTransitionsTest.java
+++ b/enrollment-server-onboarding/src/test/java/com/wultra/app/onboardingserver/statemachine/ClientEvaluationTransitionsTest.java
@@ -53,6 +53,7 @@ import static org.mockito.Mockito.*;
 @SpringBootTest(classes = {EnrollmentServerTestApplication.class})
 @ActiveProfiles("test-onboarding")
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@Transactional
 class ClientEvaluationTransitionsTest extends AbstractStateMachineTest {
 
     @MockBean
@@ -74,31 +75,26 @@ class ClientEvaluationTransitionsTest extends AbstractStateMachineTest {
     private OnboardingProcessRepository onboardingProcessRepository;
 
     @Test
-    @Transactional
     void testClientEvaluationAccepted() throws Exception {
         testClientVerificationStatus(IdentityVerificationStatus.ACCEPTED, OnboardingState.CLIENT_EVALUATION_ACCEPTED);
     }
 
     @Test
-    @Transactional
     void testClientEvaluationInProgress() throws Exception {
         testClientVerificationStatus(IdentityVerificationStatus.IN_PROGRESS, OnboardingState.CLIENT_EVALUATION_IN_PROGRESS);
     }
 
     @Test
-    @Transactional
     void testClientEvaluationFailed() throws Exception {
         testClientVerificationStatus(IdentityVerificationStatus.FAILED, OnboardingState.CLIENT_EVALUATION_FAILED);
     }
 
     @Test
-    @Transactional
     void testClientEvaluationRejected() throws Exception {
         testClientVerificationStatus(IdentityVerificationStatus.REJECTED, OnboardingState.CLIENT_EVALUATION_REJECTED);
     }
 
     @Test
-    @Transactional
     void testClientEvaluationAcceptedToPresenceCheckInit() throws Exception {
         IdentityVerificationEntity idVerification = createIdentityVerification(IdentityVerificationStatus.ACCEPTED);
         StateMachine<OnboardingState, OnboardingEvent> stateMachine = createStateMachine(idVerification);
@@ -119,7 +115,6 @@ class ClientEvaluationTransitionsTest extends AbstractStateMachineTest {
     }
 
     @Test
-    @Transactional
     void testDocumentVerificationTransitionToSendingOtp() throws Exception {
         IdentityVerificationEntity idVerification = createIdentityVerification(IdentityVerificationStatus.ACCEPTED);
         StateMachine<OnboardingState, OnboardingEvent> stateMachine = createStateMachine(idVerification);
@@ -148,7 +143,6 @@ class ClientEvaluationTransitionsTest extends AbstractStateMachineTest {
     }
 
     @Test
-    @Transactional
     void testDocumentVerificationTransitionCompleted() throws Exception {
         IdentityVerificationEntity idVerification = createIdentityVerification(IdentityVerificationStatus.ACCEPTED);
         StateMachine<OnboardingState, OnboardingEvent> stateMachine = createStateMachine(idVerification);
@@ -202,7 +196,7 @@ class ClientEvaluationTransitionsTest extends AbstractStateMachineTest {
     private IdentityVerificationEntity createIdentityVerification(IdentityVerificationStatus status) {
         IdentityVerificationEntity idVerification =
                 createIdentityVerification(IdentityVerificationPhase.CLIENT_EVALUATION, status);
-        when(onboardingProcessRepository.findExistingProcessForActivationWithLock(idVerification.getActivationId(), OnboardingStatus.VERIFICATION_IN_PROGRESS))
+        when(onboardingProcessRepository.findByActivationIdAndStatusWithLock(idVerification.getActivationId(), OnboardingStatus.VERIFICATION_IN_PROGRESS))
                 .thenReturn(Optional.of(createOnboardingProcessEntity()));
         return idVerification;
     }

--- a/enrollment-server-onboarding/src/test/java/com/wultra/app/onboardingserver/statemachine/DocumentUploadTransitionsTest.java
+++ b/enrollment-server-onboarding/src/test/java/com/wultra/app/onboardingserver/statemachine/DocumentUploadTransitionsTest.java
@@ -91,7 +91,7 @@ class DocumentUploadTransitionsTest extends AbstractStateMachineTest {
         when(documentVerificationRepository.findAllUsedForVerification(idVerification))
                 .thenReturn(List.of(documentVerification));
 
-        when(onboardingProcessRepository.findExistingProcessForActivationWithLock(idVerification.getActivationId(), OnboardingStatus.VERIFICATION_IN_PROGRESS))
+        when(onboardingProcessRepository.findByActivationIdAndStatusWithLock(idVerification.getActivationId(), OnboardingStatus.VERIFICATION_IN_PROGRESS))
                 .thenReturn(Optional.of(createOnboardingProcessEntity()));
 
         Message<OnboardingEvent> message =

--- a/enrollment-server-onboarding/src/test/java/com/wultra/app/onboardingserver/statemachine/DocumentVerificationTransitionsTest.java
+++ b/enrollment-server-onboarding/src/test/java/com/wultra/app/onboardingserver/statemachine/DocumentVerificationTransitionsTest.java
@@ -54,6 +54,7 @@ import static org.mockito.Mockito.when;
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 @MockBean(IdentityVerificationOtpService.class)
 @MockBean(VerificationProcessResultAction.class)
+@Transactional
 class DocumentVerificationTransitionsTest extends AbstractStateMachineTest {
 
     @MockBean
@@ -69,39 +70,34 @@ class DocumentVerificationTransitionsTest extends AbstractStateMachineTest {
     private OnboardingProcessRepository onboardingProcessRepository;
 
     @Test
-    @Transactional
     void testDocumentVerificationAccepted() throws Exception {
         createIdentityVerificationLocal(IdentityVerificationPhase.DOCUMENT_VERIFICATION, IdentityVerificationStatus.VERIFICATION_PENDING);
         testDocumentVerificationStatus(IdentityVerificationStatus.ACCEPTED, OnboardingState.DOCUMENT_VERIFICATION_ACCEPTED);
     }
 
     @Test
-    @Transactional
     void testDocumentVerificationInProgress() throws Exception {
         createIdentityVerificationLocal(IdentityVerificationPhase.DOCUMENT_VERIFICATION, IdentityVerificationStatus.VERIFICATION_PENDING);
         testDocumentVerificationStatus(IN_PROGRESS, OnboardingState.DOCUMENT_VERIFICATION_IN_PROGRESS);
     }
 
     @Test
-    @Transactional
     void testDocumentVerificationRejected() throws Exception {
         createIdentityVerificationLocal(IdentityVerificationPhase.DOCUMENT_VERIFICATION, IdentityVerificationStatus.VERIFICATION_PENDING);
         testDocumentVerificationStatus(IdentityVerificationStatus.REJECTED, OnboardingState.DOCUMENT_VERIFICATION_REJECTED);
     }
 
     @Test
-    @Transactional
     void testDocumentVerificationFailed() throws Exception {
         createIdentityVerificationLocal(IdentityVerificationPhase.DOCUMENT_VERIFICATION, IdentityVerificationStatus.VERIFICATION_PENDING);
         testDocumentVerificationStatus(IdentityVerificationStatus.FAILED, OnboardingState.DOCUMENT_VERIFICATION_FAILED);
     }
 
     @Test
-    @Transactional
     void testDocumentVerificationTransitionToClientEvaluation() throws Exception {
         IdentityVerificationEntity idVerification =
                 createIdentityVerificationLocal(IdentityVerificationPhase.DOCUMENT_VERIFICATION, IdentityVerificationStatus.ACCEPTED);
-        when(onboardingProcessRepository.findExistingProcessForActivationWithLock(idVerification.getActivationId(), OnboardingStatus.VERIFICATION_IN_PROGRESS))
+        when(onboardingProcessRepository.findByActivationIdAndStatusWithLock(idVerification.getActivationId(), OnboardingStatus.VERIFICATION_IN_PROGRESS))
                 .thenReturn(Optional.of(createOnboardingProcessEntity()));
         StateMachine<OnboardingState, OnboardingEvent> stateMachine = createStateMachine(idVerification);
 
@@ -146,7 +142,7 @@ class DocumentVerificationTransitionsTest extends AbstractStateMachineTest {
     private IdentityVerificationEntity createIdentityVerificationLocal(IdentityVerificationPhase phase, IdentityVerificationStatus status) {
         IdentityVerificationEntity idVerification =
                 super.createIdentityVerification(phase, status);
-        when(onboardingProcessRepository.findExistingProcessForActivationWithLock(idVerification.getActivationId(), OnboardingStatus.VERIFICATION_IN_PROGRESS))
+        when(onboardingProcessRepository.findByActivationIdAndStatusWithLock(idVerification.getActivationId(), OnboardingStatus.VERIFICATION_IN_PROGRESS))
                 .thenReturn(Optional.of(createOnboardingProcessEntity()));
         return idVerification;
     }

--- a/enrollment-server-onboarding/src/test/java/com/wultra/app/onboardingserver/statemachine/DocumentVerificationTransitionsTest.java
+++ b/enrollment-server-onboarding/src/test/java/com/wultra/app/onboardingserver/statemachine/DocumentVerificationTransitionsTest.java
@@ -18,7 +18,9 @@ package com.wultra.app.onboardingserver.statemachine;
 
 import com.wultra.app.enrollmentserver.model.enumeration.IdentityVerificationPhase;
 import com.wultra.app.enrollmentserver.model.enumeration.IdentityVerificationStatus;
+import com.wultra.app.enrollmentserver.model.enumeration.OnboardingStatus;
 import com.wultra.app.onboardingserver.EnrollmentServerTestApplication;
+import com.wultra.app.onboardingserver.common.database.OnboardingProcessRepository;
 import com.wultra.app.onboardingserver.common.database.entity.IdentityVerificationEntity;
 import com.wultra.app.onboardingserver.configuration.IdentityVerificationConfig;
 import com.wultra.app.onboardingserver.impl.service.IdentityVerificationOtpService;
@@ -34,6 +36,9 @@ import org.springframework.messaging.Message;
 import org.springframework.statemachine.StateMachine;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 import static com.wultra.app.enrollmentserver.model.enumeration.IdentityVerificationPhase.CLIENT_EVALUATION;
 import static com.wultra.app.enrollmentserver.model.enumeration.IdentityVerificationStatus.IN_PROGRESS;
@@ -60,30 +65,44 @@ class DocumentVerificationTransitionsTest extends AbstractStateMachineTest {
     @MockBean
     private DocumentsVerificationPendingGuard documentsVerificationPendingGuard;
 
+    @MockBean
+    private OnboardingProcessRepository onboardingProcessRepository;
+
     @Test
+    @Transactional
     void testDocumentVerificationAccepted() throws Exception {
+        createIdentityVerificationLocal(IdentityVerificationPhase.DOCUMENT_VERIFICATION, IdentityVerificationStatus.VERIFICATION_PENDING);
         testDocumentVerificationStatus(IdentityVerificationStatus.ACCEPTED, OnboardingState.DOCUMENT_VERIFICATION_ACCEPTED);
     }
 
     @Test
+    @Transactional
     void testDocumentVerificationInProgress() throws Exception {
+        createIdentityVerificationLocal(IdentityVerificationPhase.DOCUMENT_VERIFICATION, IdentityVerificationStatus.VERIFICATION_PENDING);
         testDocumentVerificationStatus(IN_PROGRESS, OnboardingState.DOCUMENT_VERIFICATION_IN_PROGRESS);
     }
 
     @Test
+    @Transactional
     void testDocumentVerificationRejected() throws Exception {
+        createIdentityVerificationLocal(IdentityVerificationPhase.DOCUMENT_VERIFICATION, IdentityVerificationStatus.VERIFICATION_PENDING);
         testDocumentVerificationStatus(IdentityVerificationStatus.REJECTED, OnboardingState.DOCUMENT_VERIFICATION_REJECTED);
     }
 
     @Test
+    @Transactional
     void testDocumentVerificationFailed() throws Exception {
+        createIdentityVerificationLocal(IdentityVerificationPhase.DOCUMENT_VERIFICATION, IdentityVerificationStatus.VERIFICATION_PENDING);
         testDocumentVerificationStatus(IdentityVerificationStatus.FAILED, OnboardingState.DOCUMENT_VERIFICATION_FAILED);
     }
 
     @Test
+    @Transactional
     void testDocumentVerificationTransitionToClientEvaluation() throws Exception {
         IdentityVerificationEntity idVerification =
-                createIdentityVerification(IdentityVerificationPhase.DOCUMENT_VERIFICATION, IdentityVerificationStatus.ACCEPTED);
+                createIdentityVerificationLocal(IdentityVerificationPhase.DOCUMENT_VERIFICATION, IdentityVerificationStatus.ACCEPTED);
+        when(onboardingProcessRepository.findExistingProcessForActivationWithLock(idVerification.getActivationId(), OnboardingStatus.VERIFICATION_IN_PROGRESS))
+                .thenReturn(Optional.of(createOnboardingProcessEntity()));
         StateMachine<OnboardingState, OnboardingEvent> stateMachine = createStateMachine(idVerification);
 
         when(identityVerificationConfig.isPresenceCheckEnabled()).thenReturn(true);
@@ -103,7 +122,7 @@ class DocumentVerificationTransitionsTest extends AbstractStateMachineTest {
 
     private void testDocumentVerificationStatus(IdentityVerificationStatus identityStatus, OnboardingState expectedState) throws Exception {
         IdentityVerificationEntity idVerification =
-                createIdentityVerification(IdentityVerificationPhase.DOCUMENT_UPLOAD, IdentityVerificationStatus.VERIFICATION_PENDING);
+                createIdentityVerificationLocal(IdentityVerificationPhase.DOCUMENT_UPLOAD, IdentityVerificationStatus.VERIFICATION_PENDING);
         StateMachine<OnboardingState, OnboardingEvent> stateMachine = createStateMachine(idVerification);
 
         doAnswer(args -> {
@@ -122,6 +141,14 @@ class DocumentVerificationTransitionsTest extends AbstractStateMachineTest {
                 .and()
                 .build()
                 .test();
+    }
+
+    private IdentityVerificationEntity createIdentityVerificationLocal(IdentityVerificationPhase phase, IdentityVerificationStatus status) {
+        IdentityVerificationEntity idVerification =
+                super.createIdentityVerification(phase, status);
+        when(onboardingProcessRepository.findExistingProcessForActivationWithLock(idVerification.getActivationId(), OnboardingStatus.VERIFICATION_IN_PROGRESS))
+                .thenReturn(Optional.of(createOnboardingProcessEntity()));
+        return idVerification;
     }
 
 }

--- a/enrollment-server-onboarding/src/test/java/com/wultra/app/onboardingserver/statemachine/InitialTransitionTest.java
+++ b/enrollment-server-onboarding/src/test/java/com/wultra/app/onboardingserver/statemachine/InitialTransitionTest.java
@@ -61,7 +61,7 @@ public class InitialTransitionTest extends AbstractStateMachineTest {
         StateMachine<OnboardingState, OnboardingEvent> stateMachine =
                 stateMachineService.prepareStateMachine(PROCESS_ID, OnboardingState.INITIAL, null);
 
-        when(onboardingProcessRepository.findExistingProcessForActivationWithLock(ACTIVATION_ID, OnboardingStatus.VERIFICATION_IN_PROGRESS))
+        when(onboardingProcessRepository.findByActivationIdAndStatusWithLock(ACTIVATION_ID, OnboardingStatus.VERIFICATION_IN_PROGRESS))
                 .thenReturn(Optional.of(ONBOARDING_PROCESS_ENTITY));
 
         doAnswer(args ->

--- a/enrollment-server-onboarding/src/test/java/com/wultra/app/onboardingserver/statemachine/InitialTransitionTest.java
+++ b/enrollment-server-onboarding/src/test/java/com/wultra/app/onboardingserver/statemachine/InitialTransitionTest.java
@@ -18,6 +18,7 @@ package com.wultra.app.onboardingserver.statemachine;
 
 import com.wultra.app.enrollmentserver.model.enumeration.IdentityVerificationPhase;
 import com.wultra.app.enrollmentserver.model.enumeration.IdentityVerificationStatus;
+import com.wultra.app.enrollmentserver.model.enumeration.OnboardingStatus;
 import com.wultra.app.onboardingserver.EnrollmentServerTestApplication;
 import com.wultra.app.onboardingserver.common.database.OnboardingProcessRepository;
 import com.wultra.app.onboardingserver.impl.service.IdentityVerificationCreateService;
@@ -60,7 +61,7 @@ public class InitialTransitionTest extends AbstractStateMachineTest {
         StateMachine<OnboardingState, OnboardingEvent> stateMachine =
                 stateMachineService.prepareStateMachine(PROCESS_ID, OnboardingState.INITIAL, null);
 
-        when(onboardingProcessRepository.findProcessByActivationId(ACTIVATION_ID))
+        when(onboardingProcessRepository.findExistingProcessForActivationWithLock(ACTIVATION_ID, OnboardingStatus.VERIFICATION_IN_PROGRESS))
                 .thenReturn(Optional.of(ONBOARDING_PROCESS_ENTITY));
 
         doAnswer(args ->

--- a/enrollment-server-onboarding/src/test/java/com/wultra/app/onboardingserver/statemachine/OtpTransitionsTest.java
+++ b/enrollment-server-onboarding/src/test/java/com/wultra/app/onboardingserver/statemachine/OtpTransitionsTest.java
@@ -51,6 +51,7 @@ import static org.mockito.Mockito.*;
 @SpringBootTest(classes = {EnrollmentServerTestApplication.class})
 @ActiveProfiles("test-onboarding")
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@Transactional
 class OtpTransitionsTest extends AbstractStateMachineTest {
 
     @MockBean
@@ -66,7 +67,6 @@ class OtpTransitionsTest extends AbstractStateMachineTest {
     private VerificationProcessResultAction verificationProcessResultAction;
 
     @Test
-    @Transactional
     void testOtpResend() throws Exception {
         IdentityVerificationEntity idVerification = createIdentityVerification();
         StateMachine<OnboardingState, OnboardingEvent> stateMachine = createStateMachine(idVerification);
@@ -89,7 +89,6 @@ class OtpTransitionsTest extends AbstractStateMachineTest {
     }
 
     @Test
-    @Transactional
     void testOtpVerified() throws Exception {
         IdentityVerificationEntity idVerification = createIdentityVerification();
         StateMachine<OnboardingState, OnboardingEvent> stateMachine = createStateMachine(idVerification);
@@ -120,7 +119,6 @@ class OtpTransitionsTest extends AbstractStateMachineTest {
     }
 
     @Test
-    @Transactional
     void testOtpNotVerified() throws Exception {
         IdentityVerificationEntity idVerification = createIdentityVerification();
         StateMachine<OnboardingState, OnboardingEvent> stateMachine = createStateMachine(idVerification);
@@ -144,7 +142,7 @@ class OtpTransitionsTest extends AbstractStateMachineTest {
         IdentityVerificationEntity idVerification = super.createIdentityVerification(
                 IdentityVerificationPhase.OTP_VERIFICATION, IdentityVerificationStatus.VERIFICATION_PENDING
         );
-        when(onboardingProcessRepository.findExistingProcessForActivationWithLock(idVerification.getActivationId(), OnboardingStatus.VERIFICATION_IN_PROGRESS))
+        when(onboardingProcessRepository.findByActivationIdAndStatusWithLock(idVerification.getActivationId(), OnboardingStatus.VERIFICATION_IN_PROGRESS))
                 .thenReturn(Optional.of(ONBOARDING_PROCESS_ENTITY));
         return idVerification;
     }

--- a/enrollment-server-onboarding/src/test/java/com/wultra/app/onboardingserver/statemachine/PresenceCheckTransitionsTest.java
+++ b/enrollment-server-onboarding/src/test/java/com/wultra/app/onboardingserver/statemachine/PresenceCheckTransitionsTest.java
@@ -41,6 +41,7 @@ import org.springframework.statemachine.StateContext;
 import org.springframework.statemachine.StateMachine;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
@@ -53,6 +54,7 @@ import static org.mockito.Mockito.*;
 @SpringBootTest(classes = {EnrollmentServerTestApplication.class})
 @ActiveProfiles("test-onboarding")
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@Transactional
 class PresenceCheckTransitionsTest extends AbstractStateMachineTest {
 
     @MockBean
@@ -78,7 +80,7 @@ class PresenceCheckTransitionsTest extends AbstractStateMachineTest {
         IdentityVerificationEntity idVerification = createIdentityVerification(IdentityVerificationStatus.NOT_INITIALIZED);
         StateMachine<OnboardingState, OnboardingEvent> stateMachine = createStateMachine(idVerification);
 
-        when(onboardingProcessRepository.findExistingProcessForActivationWithLock(idVerification.getActivationId(), OnboardingStatus.VERIFICATION_IN_PROGRESS))
+        when(onboardingProcessRepository.findByActivationIdAndStatusWithLock(idVerification.getActivationId(), OnboardingStatus.VERIFICATION_IN_PROGRESS))
                 .thenReturn(Optional.of(ONBOARDING_PROCESS_ENTITY));
         when(identityVerificationConfig.isPresenceCheckEnabled()).thenReturn(true);
         doAnswer(args -> {
@@ -206,7 +208,7 @@ class PresenceCheckTransitionsTest extends AbstractStateMachineTest {
     private IdentityVerificationEntity createIdentityVerification(IdentityVerificationStatus status) {
         IdentityVerificationEntity idVerification =
                 createIdentityVerification(IdentityVerificationPhase.PRESENCE_CHECK, status);
-        when(onboardingProcessRepository.findExistingProcessForActivationWithLock(idVerification.getActivationId(), OnboardingStatus.VERIFICATION_IN_PROGRESS))
+        when(onboardingProcessRepository.findByActivationIdAndStatusWithLock(idVerification.getActivationId(), OnboardingStatus.VERIFICATION_IN_PROGRESS))
                 .thenReturn(Optional.of(createOnboardingProcessEntity()));
         return idVerification;
     }


### PR DESCRIPTION
This pull request brings two data integrity improvements:

- Decrease probability of an accidental data overwrite due to scheduling of jobs which work on the same database tables at different time.
- Fix #415

The locking should eliminate main reasons for data overwrites:
- App vs. backend jobs - process DB rows are locked both in frontend and backend services.
- State machine vs. cleaning jobs - the schedule is no longer conflicting for most of the jobs, furthermore DB rows are locked.

We cannot lock data for the whole processing in following cases which continue to run in separate transactions as defined using `Propagation.REQUIRES_NEW`:
- state machine - data is read, then written later on and the lock is applied for the state transition
- document verification tasks - communication with the provider may take long, lock is applied after results are available

I will analyze these two scenarios to check if there are any pending issues, but we should be in much better shape than when no locking was done at all.

Performance is out of scope of this work right now, the main problem is with the state machine `ProcessIdentifierGuard`. This will need to be addressed, probably separately, ideally with some tests which measure the performance.

Note that the scheduling change does not try to eliminate all possible conflicts because this would mean basically using just 1 global lock which would be quite bad for performance. However this change should decrease significantly probability of a conflict on same data. Rare conflicts are not a problem because beside the scheduling change the DB row locks are applied, too. So current implementation is a compromise between performance and conflict avoidance.