### PR TITLE
Fix #449: Cleaning task may not expire all records

### DIFF
--- a/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/database/DocumentVerificationRepository.java
+++ b/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/database/DocumentVerificationRepository.java
@@ -49,7 +49,7 @@ public interface DocumentVerificationRepository extends JpaRepository<DocumentVe
     int failVerifications(String activationId, Date timestamp, List<DocumentStatus> statuses);
 
     @Query("SELECT d.id FROM DocumentVerificationEntity d " +
-            "WHERE d.timestampLastUpdated < :cleanupDate " +
+            "WHERE d.timestampCreated < :cleanupDate " +
             "AND d.status IN :statuses")
     List<String> findExpiredVerifications(Date cleanupDate, List<DocumentStatus> statuses);
 

--- a/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/database/IdentityVerificationRepository.java
+++ b/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/database/IdentityVerificationRepository.java
@@ -95,13 +95,14 @@ public interface IdentityVerificationRepository extends CrudRepository<IdentityV
     List<String> findNotCompletedIdentityVerifications(Collection<String> processIds);
 
     /**
-     * Return identity verification IDs last updated before the given timestamp. Include only not yet finished entities.
+     * Return identity verification IDs created before the given timestamp.
+     * Include only not yet finished entities.
      *
-     * @param timestamp last updated older than timestamp
+     * @param timestamp created timestamp must be older than the given timestamp
      * @return identity verification IDs
      */
     @Query("SELECT i.id FROM IdentityVerificationEntity i " +
-            "WHERE i.timestampLastUpdated < :timestamp " +
+            "WHERE i.timestampCreated < :timestamp " +
             "AND i.phase <> com.wultra.app.enrollmentserver.model.enumeration.IdentityVerificationPhase.COMPLETED")
     List<String> findNotCompletedIdentityVerifications(Date timestamp);
 

--- a/enrollment-server-onboarding/src/test/resources/com/wultra/app/onboardingserver/task/cleaning/CleaningServiceTest.testTerminateExpiredDocumentVerifications.sql
+++ b/enrollment-server-onboarding/src/test/resources/com/wultra/app/onboardingserver/task/cleaning/CleaningServiceTest.testTerminateExpiredDocumentVerifications.sql
@@ -1,9 +1,9 @@
 INSERT INTO es_identity_verification(id, activation_id, user_id, process_id, status, phase, timestamp_created, timestamp_last_updated) VALUES
     ('a6055e8b-4ac0-45dd-b68e-29f4cd991a5c', 'a1', 'u1', 'p1', 'IN_PROGRESS', 'PRESENCE_CHECK', now(), now()),
-    ('8d036a18-f51f-4a30-92cd-04876172ebca', 'a2', 'u2', 'p2', 'IN_PROGRESS', 'PRESENCE_CHECK', now() - 1, now() - 1), -- to be terminated
-    ('c918e1c4-5ca7-47da-8765-afc92082f717', 'a3', 'u3', 'p3', 'ACCEPTED', 'COMPLETED', now() - 1, now() - 1);
+    ('8d036a18-f51f-4a30-92cd-04876172ebca', 'a2', 'u2', 'p2', 'IN_PROGRESS', 'PRESENCE_CHECK', now() - interval '1' day, now()), -- to be terminated
+    ('c918e1c4-5ca7-47da-8765-afc92082f717', 'a3', 'u3', 'p3', 'ACCEPTED', 'COMPLETED', now() - interval '1' day, now());
 
 INSERT INTO es_document_verification(id, activation_id, identity_verification_id, type, status, filename, used_for_verification, timestamp_created, timestamp_last_updated) VALUES
     ('16055e8b-4ac0-45dd-b68e-29f4cd991a5c', 'a1', 'a6055e8b-4ac0-45dd-b68e-29f4cd991a5c', 'ID_CARD', 'UPLOAD_IN_PROGRESS', 'f1', false, now(), now()),
-    ('2d036a18-f51f-4a30-92cd-04876172ebca', 'a2', '8d036a18-f51f-4a30-92cd-04876172ebca', 'ID_CARD', 'UPLOAD_IN_PROGRESS', 'f2', false, now() - 1, now() - 1), -- to be terminated
-    ('3918e1c4-5ca7-47da-8765-afc92082f717', 'a3', 'c918e1c4-5ca7-47da-8765-afc92082f717', 'ID_CARD', 'ACCEPTED', 'f3', true, now() - 1, now() - 1);
+    ('2d036a18-f51f-4a30-92cd-04876172ebca', 'a2', '8d036a18-f51f-4a30-92cd-04876172ebca', 'ID_CARD', 'UPLOAD_IN_PROGRESS', 'f2', false, now() - interval '1' day, now()), -- to be terminated
+    ('3918e1c4-5ca7-47da-8765-afc92082f717', 'a3', 'c918e1c4-5ca7-47da-8765-afc92082f717', 'ID_CARD', 'ACCEPTED', 'f3', true, now() - interval '1' day, now());

--- a/enrollment-server-onboarding/src/test/resources/com/wultra/app/onboardingserver/task/cleaning/CleaningServiceTest.testTerminateExpiredIdentityVerifications.sql
+++ b/enrollment-server-onboarding/src/test/resources/com/wultra/app/onboardingserver/task/cleaning/CleaningServiceTest.testTerminateExpiredIdentityVerifications.sql
@@ -1,4 +1,4 @@
 INSERT INTO es_identity_verification(id, activation_id, user_id, process_id, status, phase, timestamp_created, timestamp_last_updated) VALUES
     ('a6055e8b-4ac0-45dd-b68e-29f4cd991a5c', 'a1', 'u1', 'p1', 'IN_PROGRESS', 'PRESENCE_CHECK', now(), now()),
-    ('8d036a18-f51f-4a30-92cd-04876172ebca', 'a2', 'u2', 'p2', 'IN_PROGRESS', 'PRESENCE_CHECK', now() - 1, now() - 1), -- to be terminated
-    ('c918e1c4-5ca7-47da-8765-afc92082f717', 'a3', 'u3', 'p3', 'ACCEPTED', 'COMPLETED', now() - 1, now() - 1);
+    ('8d036a18-f51f-4a30-92cd-04876172ebca', 'a2', 'u2', 'p2', 'IN_PROGRESS', 'PRESENCE_CHECK', now() - interval '1' day, now()), -- to be terminated
+    ('c918e1c4-5ca7-47da-8765-afc92082f717', 'a3', 'u3', 'p3', 'ACCEPTED', 'COMPLETED', now() - interval '1' day, now());


### PR DESCRIPTION
Replace nullable timestampLastUpdated by timestampCreated in the where condition for expiration queries