### PR TITLE
Kill verify on submit

### DIFF
--- a/docs/onboarding/Configuration-Properties.md
+++ b/docs/onboarding/Configuration-Properties.md
@@ -78,7 +78,6 @@ The Onboarding Server uses the following public configuration properties:
 | `enrollment-server-onboarding.document-verification.provider` | `mock` | Document verification provider (`mock`, `zenid`). |
 | `enrollment-server-onboarding.document-verification.cleanupEnabled` | `false` | Whether document cleanup is enabled for the provider. |
 | `enrollment-server-onboarding.document-verification.checkInProgressDocumentSubmits` | `0/5 * * * * *` | Cron scheduler for checking status of submitted documents. |
-| `enrollment-server-onboarding.document-verification.verificationOnSubmitEnabled` | `false` | Whether document verification on submit is enabled. It verifies each document side separately. However, verification may fail because the verification system does not have the whole document yet. |
 | `enrollment-server-onboarding.document-verification.checkDocumentsVerifications.cron` | `0/5 * * * * *` | Cron scheduler for checking pending document verifications. |
 | `enrollment-server-onboarding.document-verification.checkDocumentSubmitVerifications.cron` | `0/5 * * * * *` | Cron scheduler for checking document submit verifications. |
 

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/configuration/IdentityVerificationConfig.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/configuration/IdentityVerificationConfig.java
@@ -37,9 +37,6 @@ public class IdentityVerificationConfig {
     @Value("${enrollment-server-onboarding.document-verification.provider:mock}")
     private String documentVerificationProvider;
 
-    @Value("${enrollment-server-onboarding.document-verification.verificationOnSubmitEnabled:false}")
-    private boolean documentVerificationOnSubmitEnabled;
-
     @Value("${enrollment-server-onboarding.document-verification.cleanupEnabled:false}")
     private boolean documentVerificationCleanupEnabled;
 

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/document/DocumentProcessingService.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/document/DocumentProcessingService.java
@@ -418,30 +418,10 @@ public class DocumentProcessingService {
             } else if (docSubmitResult.getExtractedData() == null) { // only finished upload contains extracted data
                 docVerification.setStatus(DocumentStatus.UPLOAD_IN_PROGRESS);
                 auditService.auditDebug(docVerification, "Document upload in progress for user: {}", ownerId.getUserId());
-            } else if (identityVerificationConfig.isDocumentVerificationOnSubmitEnabled()) {
-                verifyDocumentWithUpload(ownerId, docVerification, docSubmitResult.getUploadId());
-                docVerification.setStatus(DocumentStatus.UPLOAD_IN_PROGRESS);
-                auditService.auditDebug(docVerification, "Document upload in progress for user: {}", ownerId.getUserId());
             } else { // no document verification during upload, wait for the final all documents verification
                 docVerification.setStatus(DocumentStatus.VERIFICATION_PENDING);
                 auditService.audit(docVerification, "Document verification pending for user: {}", ownerId.getUserId());
             }
-        }
-    }
-
-    private void verifyDocumentWithUpload(OwnerId ownerId, DocumentVerificationEntity docVerification, String uploadId) {
-        try {
-            final DocumentsVerificationResult result = documentVerificationProvider.verifyDocuments(ownerId, List.of(uploadId));
-            final String verificationId = result.getVerificationId();
-            final DocumentVerificationStatus status = result.getStatus();
-            logger.info("Verified document upload ID: {}, verification ID: {}, status: {}, {}", uploadId, verificationId, status, ownerId);
-            docVerification.setVerificationId(verificationId);
-        } catch (DocumentVerificationException | RemoteCommunicationException e) {
-            logger.debug("Unable to verify document with uploadId: {}, {}", uploadId, ownerId, e);
-            logger.warn("Unable to verify document with uploadId: {}, reason: {}, {}", uploadId, e.getMessage(), ownerId);
-            docVerification.setStatus(DocumentStatus.FAILED);
-            docVerification.setErrorDetail(e.getMessage());
-            docVerification.setErrorOrigin(ErrorOrigin.DOCUMENT_VERIFICATION);
         }
     }
 

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/document/DocumentProcessingService.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/document/DocumentProcessingService.java
@@ -148,6 +148,9 @@ public class DocumentProcessingService {
 
             DocumentSubmitResult docSubmitResult = submitDocumentToProvider(ownerId, docVerification, submittedDoc);
 
+            // TODO - after synchronous submission to document verification provider the document state should be
+            // set to VERIFICATION_PENDING, for asynchronous processing the UPLOAD_IN_PROGRESS state should remain
+
             DocumentResultEntity docResult = createDocumentResult(docVerification, docSubmitResult);
             docResult.setTimestampCreated(ownerId.getTimestamp());
 

--- a/enrollment-server-onboarding/src/main/resources/application.properties
+++ b/enrollment-server-onboarding/src/main/resources/application.properties
@@ -111,7 +111,6 @@ enrollment-server-onboarding.identity-verification.max-failed-attempts-document-
 enrollment-server-onboarding.document-verification.provider=mock
 enrollment-server-onboarding.document-verification.cleanupEnabled=false
 enrollment-server-onboarding.document-verification.checkInProgressDocumentSubmits.cron=0/5 * * * * *
-enrollment-server-onboarding.document-verification.verificationOnSubmitEnabled=false
 enrollment-server-onboarding.document-verification.checkDocumentsVerifications.cron=0/5 * * * * *
 enrollment-server-onboarding.document-verification.checkDocumentSubmitVerifications.cron=0/5 * * * * *
 


### PR DESCRIPTION
I am done with parameter `documentVerificationOnSubmitEnabled`, this is causing neverending confusion and invalid configuration issues.

I added a TODO for synchronous processing which we can fix in another issue. The document state does not currently reflect exactly what happened on server (document is already uploaded). I added similar TODO into tests.