### PR TITLE
Fix #628: Do not deploy onboarding-adapter-mock

### DIFF
--- a/enrollment-server-onboarding-adapter-mock/pom.xml
+++ b/enrollment-server-onboarding-adapter-mock/pom.xml
@@ -32,6 +32,7 @@
     <description>Onboarding adapter mock for enrollment server.</description>
 
     <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
         <wiremock.version>2.33.2</wiremock.version>
     </properties>
 


### PR DESCRIPTION
It is an internal helper module for testing. There is no need to deploy the jar.