### PR TITLE
Backport of fix #634: swagger-ui/index.html returns 500

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
         <h2.version>2.1.214</h2.version>
         <shedlock-spring.version>4.43.0</shedlock-spring.version>
         <spring-statemachine.version>3.2.0</spring-statemachine.version>
-        <swagger-annotations.version>2.2.0</swagger-annotations.version>
+        <swagger-annotations.version>2.2.8</swagger-annotations.version>
         <springdoc-openapi.version>1.6.14</springdoc-openapi.version>
         <wultra-rest-client.version>1.6.0</wultra-rest-client.version>
         <wultra-audit.version>1.6.0</wultra-audit.version>


### PR DESCRIPTION
- Update swagger-annotations to 2.2.8

(cherry picked from commit 7ec1eb8e30c57892fdd04f05b935896e980945d7)