### PR TITLE
Fix #722: Enrollment server does not start on Tomcat 10 with Java 17

### DIFF
--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/docverify/zenid/config/ZenidConfigProps.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/docverify/zenid/config/ZenidConfigProps.java
@@ -36,7 +36,7 @@ import java.util.Optional;
  */
 @ConditionalOnProperty(value = "enrollment-server-onboarding.document-verification.provider", havingValue = "zenid")
 @Configuration
-@ConfigurationProperties(prefix = "enrollment-server-onboarding.document-verification.zenid")
+@ConfigurationProperties(prefix = "enrollment-server-onboarding.document-verification.zenid", ignoreInvalidFields = true)
 @Getter @Setter
 public class ZenidConfigProps {
 

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/presencecheck/iproov/config/IProovConfigProps.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/presencecheck/iproov/config/IProovConfigProps.java
@@ -33,7 +33,7 @@ import org.springframework.context.annotation.Configuration;
  */
 @ConditionalOnProperty(value = "enrollment-server-onboarding.presence-check.provider", havingValue = "iproov")
 @Configuration
-@ConfigurationProperties(prefix = "enrollment-server-onboarding.presence-check.iproov")
+@ConfigurationProperties(prefix = "enrollment-server-onboarding.presence-check.iproov", ignoreInvalidFields = true)
 @Getter @Setter
 public class IProovConfigProps {
 

--- a/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/configuration/UserInfoProviderConfiguration.java
+++ b/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/configuration/UserInfoProviderConfiguration.java
@@ -71,7 +71,7 @@ public class UserInfoProviderConfiguration {
         return new RestUserInfoProvider(restUserInfoProviderConfiguration.restClientConfig, restUserInfoProviderConfiguration.getAllowedStages());
     }
 
-    @ConfigurationProperties(prefix = "enrollment-server.user-info.rest-provider")
+    @ConfigurationProperties(prefix = "enrollment-server.user-info.rest-provider", ignoreInvalidFields = true)
     @Component
     @Getter
     @Setter


### PR DESCRIPTION
This is a workaround for the configuration binding problem. Let's find a proper solution later when in are not under time pressure.