### PR TITLE
Fix #805: Add timestamps to proximity anti-fraud check

### DIFF
--- a/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/controller/api/MobileTokenController.java
+++ b/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/controller/api/MobileTokenController.java
@@ -226,7 +226,7 @@ public class MobileTokenController {
             return null;
         }
         final var proximityCheck = requestObject.getProximityCheck().get();
-        logger.info("Operation ID: {} using proximity check OTP, timestampObtained: {}, timestampSigned: {}", requestObject.getId(), proximityCheck.getTimestampObtained(), proximityCheck.getTimestampSigned());
+        logger.info("Operation ID: {} using proximity check OTP, timestampRequested: {}, timestampSigned: {}", requestObject.getId(), proximityCheck.getTimestampObtained(), proximityCheck.getTimestampSigned());
         return proximityCheck.getOtp();
     }
 

--- a/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/controller/api/MobileTokenController.java
+++ b/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/controller/api/MobileTokenController.java
@@ -226,7 +226,7 @@ public class MobileTokenController {
             return null;
         }
         final var proximityCheck = requestObject.getProximityCheck().get();
-        logger.info("Operation ID: {} using proximity check OTP, timestampReceived: {}, timestampSent: {}", requestObject.getId(), proximityCheck.getTimestampReceived(), proximityCheck.getTimestampSent());
+        logger.info("Operation ID: {} using proximity check OTP, timestampObtained: {}, timestampSigned: {}", requestObject.getId(), proximityCheck.getTimestampObtained(), proximityCheck.getTimestampSigned());
         return proximityCheck.getOtp();
     }
 

--- a/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/controller/api/MobileTokenController.java
+++ b/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/controller/api/MobileTokenController.java
@@ -205,7 +205,7 @@ public class MobileTokenController {
                         .signatureFactors(signatureFactors)
                         .requestContext(requestContext)
                         .activationFlags(activationFlags)
-                        .proximityCheckOtp(requestObject.getProximityCheckOtp())
+                        .proximityCheckOtp(fetchProximityCheckOtp(requestObject))
                         .build();
 
                 return mobileTokenService.operationApprove(serviceRequest);
@@ -219,6 +219,15 @@ public class MobileTokenController {
             logger.error("Unable to call upstream service.", e);
             throw new MobileTokenAuthException();
         }
+    }
+
+    private static String fetchProximityCheckOtp(OperationApproveRequest requestObject) {
+        if (requestObject.getProximityCheck().isEmpty()) {
+            return null;
+        }
+        final var proximityCheck = requestObject.getProximityCheck().get();
+        logger.info("Operation ID: {} using proximity check OTP, timestampReceived: {}, timestampSent: {}", requestObject.getId(), proximityCheck.getTimestampReceived(), proximityCheck.getTimestampSent());
+        return proximityCheck.getOtp();
     }
 
     /**

--- a/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/controller/api/MobileTokenController.java
+++ b/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/controller/api/MobileTokenController.java
@@ -226,7 +226,7 @@ public class MobileTokenController {
             return null;
         }
         final var proximityCheck = requestObject.getProximityCheck().get();
-        logger.info("Operation ID: {} using proximity check OTP, timestampRequested: {}, timestampSigned: {}", requestObject.getId(), proximityCheck.getTimestampObtained(), proximityCheck.getTimestampSigned());
+        logger.info("Operation ID: {} using proximity check OTP, timestampRequested: {}, timestampSigned: {}", requestObject.getId(), proximityCheck.getTimestampRequested(), proximityCheck.getTimestampSigned());
         return proximityCheck.getOtp();
     }
 

--- a/mtoken-model/pom.xml
+++ b/mtoken-model/pom.xml
@@ -38,6 +38,11 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>io.swagger.core.v3</groupId>
+            <artifactId>swagger-annotations-jakarta</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/mtoken-model/src/main/java/com/wultra/security/powerauth/lib/mtoken/model/request/OperationApproveRequest.java
+++ b/mtoken-model/src/main/java/com/wultra/security/powerauth/lib/mtoken/model/request/OperationApproveRequest.java
@@ -58,8 +58,8 @@ public class OperationApproveRequest {
         /**
          * When OTP obtained by the client. An optional hint for possible better estimation of the time shift correction.
          */
-        @Schema(description = "When OTP obtained by the client. An optional hint for possible better estimation of the time shift correction.")
-        private Instant timestampObtained;
+        @Schema(description = "When OTP requested by the client. An optional hint for possible better estimation of the time shift correction.")
+        private Instant timestampRequested;
 
         /**
          * When OTP signed by the client. An optional hint for possible better estimation of the time shift correction.

--- a/mtoken-model/src/main/java/com/wultra/security/powerauth/lib/mtoken/model/request/OperationApproveRequest.java
+++ b/mtoken-model/src/main/java/com/wultra/security/powerauth/lib/mtoken/model/request/OperationApproveRequest.java
@@ -18,6 +18,7 @@
 package com.wultra.security.powerauth.lib.mtoken.model.request;
 
 import com.wultra.security.powerauth.lib.mtoken.model.entity.PreApprovalScreen;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
@@ -40,6 +41,7 @@ public class OperationApproveRequest {
     /**
      * Optional proximity check data. User is instructed by {@link PreApprovalScreen.ScreenType#QR_SCAN}.
      */
+    @Schema(description = "Optional proximity check data." )
     private ProximityCheck proximityCheck;
 
     public Optional<ProximityCheck> getProximityCheck() {
@@ -47,19 +49,22 @@ public class OperationApproveRequest {
     }
 
     @Data
-    public class ProximityCheck {
+    public static class ProximityCheck {
 
         @NotNull
+        @Schema(description = "OTP used for proximity check.")
         private String otp;
 
         /**
          * When OTP received by the client. An optional hint for possible better estimation of the time shift correction.
          */
+        @Schema(description = "When OTP received by the client. An optional hint for possible better estimation of the time shift correction.")
         private Instant timestampReceived;
 
         /**
          * When OTP sent by the client. An optional hint for possible better estimation of the time shift correction.
          */
+        @Schema(description = "When OTP sent by the client. An optional hint for possible better estimation of the time shift correction.")
         private Instant timestampSent;
     }
 }

--- a/mtoken-model/src/main/java/com/wultra/security/powerauth/lib/mtoken/model/request/OperationApproveRequest.java
+++ b/mtoken-model/src/main/java/com/wultra/security/powerauth/lib/mtoken/model/request/OperationApproveRequest.java
@@ -56,15 +56,15 @@ public class OperationApproveRequest {
         private String otp;
 
         /**
-         * When OTP received by the client. An optional hint for possible better estimation of the time shift correction.
+         * When OTP obtained by the client. An optional hint for possible better estimation of the time shift correction.
          */
-        @Schema(description = "When OTP received by the client. An optional hint for possible better estimation of the time shift correction.")
-        private Instant timestampReceived;
+        @Schema(description = "When OTP obtained by the client. An optional hint for possible better estimation of the time shift correction.")
+        private Instant timestampObtained;
 
         /**
-         * When OTP sent by the client. An optional hint for possible better estimation of the time shift correction.
+         * When OTP signed by the client. An optional hint for possible better estimation of the time shift correction.
          */
-        @Schema(description = "When OTP sent by the client. An optional hint for possible better estimation of the time shift correction.")
-        private Instant timestampSent;
+        @Schema(description = "When OTP signed by the client. An optional hint for possible better estimation of the time shift correction.")
+        private Instant timestampSigned;
     }
 }

--- a/mtoken-model/src/main/java/com/wultra/security/powerauth/lib/mtoken/model/request/OperationApproveRequest.java
+++ b/mtoken-model/src/main/java/com/wultra/security/powerauth/lib/mtoken/model/request/OperationApproveRequest.java
@@ -55,6 +55,9 @@ public class OperationApproveRequest {
         @Schema(description = "OTP used for proximity check.")
         private String otp;
 
+        @Schema(description = "Source from where the OTP has been gained.")
+        private Type type;
+
         /**
          * When OTP obtained by the client. An optional hint for possible better estimation of the time shift correction.
          */
@@ -66,5 +69,10 @@ public class OperationApproveRequest {
          */
         @Schema(description = "When OTP signed by the client. An optional hint for possible better estimation of the time shift correction.")
         private Instant timestampSigned;
+
+        public enum Type {
+            QR_CODE,
+            DEEPLINK
+        }
     }
 }

--- a/mtoken-model/src/main/java/com/wultra/security/powerauth/lib/mtoken/model/request/OperationApproveRequest.java
+++ b/mtoken-model/src/main/java/com/wultra/security/powerauth/lib/mtoken/model/request/OperationApproveRequest.java
@@ -21,6 +21,9 @@ import com.wultra.security.powerauth.lib.mtoken.model.entity.PreApprovalScreen;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
+import java.time.Instant;
+import java.util.Optional;
+
 /**
  * Request for online token signature verification.
  *
@@ -35,7 +38,28 @@ public class OperationApproveRequest {
     private String data;
 
     /**
-     * Optional OTP used for proximity check. User is instructed by {@link PreApprovalScreen.ScreenType#QR_SCAN}.
+     * Optional proximity check data. User is instructed by {@link PreApprovalScreen.ScreenType#QR_SCAN}.
      */
-    private String proximityCheckOtp;
+    private ProximityCheck proximityCheck;
+
+    public Optional<ProximityCheck> getProximityCheck() {
+        return Optional.ofNullable(proximityCheck);
+    }
+
+    @Data
+    public class ProximityCheck {
+
+        @NotNull
+        private String otp;
+
+        /**
+         * When OTP received by the client. An optional hint for possible better estimation of the time shift correction.
+         */
+        private Instant timestampReceived;
+
+        /**
+         * When OTP sent by the client. An optional hint for possible better estimation of the time shift correction.
+         */
+        private Instant timestampSent;
+    }
 }


### PR DESCRIPTION
```json
{
  "requestObject": {
    "id": "string",
    "data": "string",
    "proximityCheck": {
      "otp": "string",
      "type": "QR_CODE",
      "timestampRequested": "2023-07-18T07:56:49.516Z",
      "timestampSigned": "2023-07-18T07:56:49.516Z"
    }
  }
}
```