### PR TITLE
Fix #827: Expose OTP resent period

### DIFF
--- a/enrollment-server-onboarding-api-model/src/main/java/com/wultra/app/enrollmentserver/api/model/onboarding/response/OnboardingStartResponse.java
+++ b/enrollment-server-onboarding-api-model/src/main/java/com/wultra/app/enrollmentserver/api/model/onboarding/response/OnboardingStartResponse.java
@@ -31,6 +31,6 @@ public class OnboardingStartResponse {
 
     private String processId;
     private OnboardingStatus onboardingStatus;
-    private ConfigurationDataDto configurationDataDto;
+    private ConfigurationDataDto config;
 
 }

--- a/enrollment-server-onboarding-api-model/src/main/java/com/wultra/app/enrollmentserver/api/model/onboarding/response/OnboardingStartResponse.java
+++ b/enrollment-server-onboarding-api-model/src/main/java/com/wultra/app/enrollmentserver/api/model/onboarding/response/OnboardingStartResponse.java
@@ -17,6 +17,7 @@
  */
 package com.wultra.app.enrollmentserver.api.model.onboarding.response;
 
+import com.wultra.app.enrollmentserver.api.model.onboarding.response.data.ConfigurationDataDto;
 import com.wultra.app.enrollmentserver.model.enumeration.OnboardingStatus;
 import lombok.Data;
 
@@ -30,5 +31,6 @@ public class OnboardingStartResponse {
 
     private String processId;
     private OnboardingStatus onboardingStatus;
+    private ConfigurationDataDto configurationDataDto;
 
 }

--- a/enrollment-server-onboarding-api-model/src/main/java/com/wultra/app/enrollmentserver/api/model/onboarding/response/OnboardingStatusResponse.java
+++ b/enrollment-server-onboarding-api-model/src/main/java/com/wultra/app/enrollmentserver/api/model/onboarding/response/OnboardingStatusResponse.java
@@ -17,6 +17,7 @@
  */
 package com.wultra.app.enrollmentserver.api.model.onboarding.response;
 
+import com.wultra.app.enrollmentserver.api.model.onboarding.response.data.ConfigurationDataDto;
 import com.wultra.app.enrollmentserver.model.enumeration.OnboardingStatus;
 import lombok.Data;
 
@@ -30,5 +31,6 @@ public class OnboardingStatusResponse {
 
     private String processId;
     private OnboardingStatus onboardingStatus;
+    private ConfigurationDataDto configurationDataDto;
 
 }

--- a/enrollment-server-onboarding-api-model/src/main/java/com/wultra/app/enrollmentserver/api/model/onboarding/response/OnboardingStatusResponse.java
+++ b/enrollment-server-onboarding-api-model/src/main/java/com/wultra/app/enrollmentserver/api/model/onboarding/response/OnboardingStatusResponse.java
@@ -31,6 +31,6 @@ public class OnboardingStatusResponse {
 
     private String processId;
     private OnboardingStatus onboardingStatus;
-    private ConfigurationDataDto configurationDataDto;
+    private ConfigurationDataDto config;
 
 }

--- a/enrollment-server-onboarding-api-model/src/main/java/com/wultra/app/enrollmentserver/api/model/onboarding/response/data/ConfigurationDataDto.java
+++ b/enrollment-server-onboarding-api-model/src/main/java/com/wultra/app/enrollmentserver/api/model/onboarding/response/data/ConfigurationDataDto.java
@@ -31,4 +31,9 @@ public class ConfigurationDataDto {
      */
     private String otpResendPeriod;
 
+    /**
+     * OTP resend period in seconds for easier parsing on mobile platforms.
+     */
+    private long otpResendPeriodSeconds;
+
 }

--- a/enrollment-server-onboarding-api-model/src/main/java/com/wultra/app/enrollmentserver/api/model/onboarding/response/data/ConfigurationDataDto.java
+++ b/enrollment-server-onboarding-api-model/src/main/java/com/wultra/app/enrollmentserver/api/model/onboarding/response/data/ConfigurationDataDto.java
@@ -16,6 +16,7 @@
  */
 package com.wultra.app.enrollmentserver.api.model.onboarding.response.data;
 
+import lombok.Builder;
 import lombok.Data;
 
 /**
@@ -24,11 +25,19 @@ import lombok.Data;
  * @author Lukas Lukovsky, lukas.lukovsky@wultra.com
  */
 @Data
+@Builder
 public class ConfigurationDataDto {
 
     /**
-     * OTP resend period (ISO 8601 format)
+     * OTP resend period (ISO 8601 format).
+     *
+     * @deprecated ISO 8601 format does not have native support on mobile platforms,
+     * leading to complexities in mobile client processing. Use {@link #otpResendPeriodSeconds}
+     * for a simpler representation in seconds. Scheduled for removal in future versions.
+     * See https://github.com/wultra/enrollment-server/issues/829 for more details.
+     * TODO (@jandusil, 2023-08-12, #829)
      */
+    @Deprecated
     private String otpResendPeriod;
 
     /**

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/IdentityVerificationRestService.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/IdentityVerificationRestService.java
@@ -127,6 +127,7 @@ public class IdentityVerificationRestService {
 
         this.integrationConfigDto = new ConfigurationDataDto();
         integrationConfigDto.setOtpResendPeriod(onboardingConfig.getOtpResendPeriod().toString());
+        integrationConfigDto.setOtpResendPeriodSeconds(onboardingConfig.getOtpResendPeriod().toSeconds());
     }
 
     /**

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/IdentityVerificationRestService.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/IdentityVerificationRestService.java
@@ -125,9 +125,10 @@ public class IdentityVerificationRestService {
         this.presenceCheckService = presenceCheckService;
         this.stateMachineService = stateMachineService;
 
-        this.integrationConfigDto = new ConfigurationDataDto();
-        integrationConfigDto.setOtpResendPeriod(onboardingConfig.getOtpResendPeriod().toString());
-        integrationConfigDto.setOtpResendPeriodSeconds(onboardingConfig.getOtpResendPeriod().toSeconds());
+        this.integrationConfigDto = ConfigurationDataDto.builder()
+                .otpResendPeriod(onboardingConfig.getOtpResendPeriod().toString())
+                .otpResendPeriodSeconds(onboardingConfig.getOtpResendPeriod().toSeconds())
+                .build();
     }
 
     /**

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/OnboardingServiceImpl.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/OnboardingServiceImpl.java
@@ -127,9 +127,9 @@ public class OnboardingServiceImpl extends CommonOnboardingService {
         this.otpService = otpService;
         this.activationService = activationService;
         this.onboardingProvider = onboardingProvider;
-        this.integrationConfigDto = new ConfigurationDataDto();
-        integrationConfigDto.setOtpResendPeriod(onboardingConfig.getOtpResendPeriod().toString());
-        integrationConfigDto.setOtpResendPeriodSeconds(onboardingConfig.getOtpResendPeriod().toSeconds());
+        this.integrationConfigDto = ConfigurationDataDto.builder()
+                .otpResendPeriod(onboardingConfig.getOtpResendPeriod().toString())
+                .otpResendPeriodSeconds(onboardingConfig.getOtpResendPeriod().toSeconds()).build();
     }
 
     /**
@@ -184,7 +184,7 @@ public class OnboardingServiceImpl extends CommonOnboardingService {
         OnboardingStartResponse response = new OnboardingStartResponse();
         response.setProcessId(process.getId());
         response.setOnboardingStatus(process.getStatus());
-        response.setConfigurationDataDto(integrationConfigDto);
+        response.setConfig(integrationConfigDto);
         return response;
     }
 
@@ -233,7 +233,7 @@ public class OnboardingServiceImpl extends CommonOnboardingService {
         }
 
         response.setOnboardingStatus(process.getStatus());
-        response.setConfigurationDataDto(integrationConfigDto);
+        response.setConfig(integrationConfigDto);
         return response;
     }
 

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/OnboardingServiceImpl.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/OnboardingServiceImpl.java
@@ -27,6 +27,7 @@ import com.wultra.app.enrollmentserver.api.model.onboarding.request.*;
 import com.wultra.app.enrollmentserver.api.model.onboarding.response.OnboardingConsentTextResponse;
 import com.wultra.app.enrollmentserver.api.model.onboarding.response.OnboardingStartResponse;
 import com.wultra.app.enrollmentserver.api.model.onboarding.response.OnboardingStatusResponse;
+import com.wultra.app.enrollmentserver.api.model.onboarding.response.data.ConfigurationDataDto;
 import com.wultra.app.enrollmentserver.model.enumeration.ErrorOrigin;
 import com.wultra.app.enrollmentserver.model.enumeration.OnboardingStatus;
 import com.wultra.app.enrollmentserver.model.enumeration.OtpType;
@@ -84,6 +85,11 @@ public class OnboardingServiceImpl extends CommonOnboardingService {
 
     private final ActivationService activationService;
 
+    /**
+     * Configuration data for client integration
+     */
+    private final ConfigurationDataDto integrationConfigDto;
+
     // Special instance of ObjectMapper for normalized serialization of identification data
     private final ObjectMapper normalizedMapper = JsonMapper
             .builder()
@@ -121,6 +127,9 @@ public class OnboardingServiceImpl extends CommonOnboardingService {
         this.otpService = otpService;
         this.activationService = activationService;
         this.onboardingProvider = onboardingProvider;
+        this.integrationConfigDto = new ConfigurationDataDto();
+        integrationConfigDto.setOtpResendPeriod(onboardingConfig.getOtpResendPeriod().toString());
+        integrationConfigDto.setOtpResendPeriodSeconds(onboardingConfig.getOtpResendPeriod().toSeconds());
     }
 
     /**
@@ -175,6 +184,7 @@ public class OnboardingServiceImpl extends CommonOnboardingService {
         OnboardingStartResponse response = new OnboardingStartResponse();
         response.setProcessId(process.getId());
         response.setOnboardingStatus(process.getStatus());
+        response.setConfigurationDataDto(integrationConfigDto);
         return response;
     }
 
@@ -223,6 +233,7 @@ public class OnboardingServiceImpl extends CommonOnboardingService {
         }
 
         response.setOnboardingStatus(process.getStatus());
+        response.setConfigurationDataDto(integrationConfigDto);
         return response;
     }
 


### PR DESCRIPTION
- Update ConfigurationDataDto to expose otpResendPeriodSeconds
- Expose the Dto to responses of api/onboarding/start and api/onboarding/status endpoints
- Fill the config in services