### PR TITLE
Fix #922: EvaluateClientRequest should contain extracted data

### DIFF
--- a/docs/onboarding/Configuration-Properties.md
+++ b/docs/onboarding/Configuration-Properties.md
@@ -46,7 +46,6 @@ The Onboarding Server uses the following public configuration properties:
 | `enrollment-server-onboarding.identity-verification.otp.enabled` | `true` | Whether OTP verification is enabled during identity verification. |
 | `enrollment-server-onboarding.identity-verification.max-failed-attempts` | `5` | Maximum failed attempts for identity verification. |
 | `enrollment-server-onboarding.identity-verification.max-failed-attempts-document-upload` | `5` | Maximum failed attempts for document upload. |
-| `enrollment-server-onboarding.client-evaluation.max-failed-attempts` | `5` | Maximum failed attempts for client evaluation. |
 
 ## Digital Onboarding Adapter Configuration
 
@@ -69,6 +68,7 @@ The Onboarding Server uses the following public configuration properties:
 | Property | Default | Note |
 |---|---|---|
 | `enrollment-server-onboarding.client-evaluation.max-failed-attempts` | 5 | Number of maximum failed attempts for client evaluation. |
+| `enrollment-server-onboarding.client-evaluation.include-extracted-data` | `false` | Include extracted data to the evaluate client request. The format of extracted data is defined by the provider of document verification. |
 
 ## Document Verification Provider Configuration
 

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/configuration/IdentityVerificationConfig.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/configuration/IdentityVerificationConfig.java
@@ -79,6 +79,9 @@ public class IdentityVerificationConfig {
     @Value("${enrollment-server-onboarding.client-evaluation.max-failed-attempts:5}")
     private int clientEvaluationMaxFailedAttempts;
 
+    @Value("${enrollment-server-onboarding.client-evaluation.include-extracted-data:false}")
+    private boolean sendingExtractedDataEnabled;
+
     @PostConstruct
     void validate() {
         // Once in the future, we may replace OTP in SCA by NFC document reading

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/ClientEvaluationService.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/ClientEvaluationService.java
@@ -109,12 +109,13 @@ public class ClientEvaluationService {
         if (config.isSendingExtractedDataEnabled()) {
             requestBuilder.extractedData(fetchDocumentsExtractedData(acceptedDocuments, identityVerification));
         }
+        final EvaluateClientRequest request = requestBuilder.build();
 
         final int maxFailedAttempts = config.getClientEvaluationMaxFailedAttempts();
         for (int i = 0; i < maxFailedAttempts; i++) {
             final int attempt = i + 1;
             try {
-                final EvaluateClientResponse response = onboardingProvider.evaluateClient(requestBuilder.build());
+                final EvaluateClientResponse response = onboardingProvider.evaluateClient(request);
                 processEvaluationSuccess(identityVerification, ownerId, response);
                 logger.debug("Client evaluation finished for {}, attempt: {}", identityVerification, attempt);
                 return;

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/ClientEvaluationService.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/ClientEvaluationService.java
@@ -99,23 +99,22 @@ public class ClientEvaluationService {
             return;
         }
 
-        final EvaluateClientRequest request = EvaluateClientRequest.builder()
+        final EvaluateClientRequest.EvaluateClientRequestBuilder requestBuilder = EvaluateClientRequest.builder()
                 .processId(identityVerification.getProcessId())
                 .userId(identityVerification.getUserId())
                 .identityVerificationId(identityVerification.getId())
                 .verificationId(verificationId)
-                .provider(config.getDocumentVerificationProvider())
-                .build();
+                .provider(config.getDocumentVerificationProvider());
 
         if (config.isSendingExtractedDataEnabled()) {
-            request.setExtractedData(getExtractedData(acceptedDocuments, identityVerification));
+            requestBuilder.extractedData(getExtractedData(acceptedDocuments, identityVerification));
         }
 
         final int maxFailedAttempts = config.getClientEvaluationMaxFailedAttempts();
         for (int i = 0; i < maxFailedAttempts; i++) {
             final int attempt = i + 1;
             try {
-                final EvaluateClientResponse response = onboardingProvider.evaluateClient(request);
+                final EvaluateClientResponse response = onboardingProvider.evaluateClient(requestBuilder.build());
                 processEvaluationSuccess(identityVerification, ownerId, response);
                 logger.debug("Client evaluation finished for {}, attempt: {}", identityVerification, attempt);
                 return;

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/provider/model/request/EvaluateClientRequest.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/provider/model/request/EvaluateClientRequest.java
@@ -31,7 +31,6 @@ import java.util.List;
  */
 @Builder
 @Getter
-@Setter
 @ToString
 @PublicApi
 @EqualsAndHashCode

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/provider/model/request/EvaluateClientRequest.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/provider/model/request/EvaluateClientRequest.java
@@ -22,6 +22,8 @@ import com.wultra.app.onboardingserver.provider.OnboardingProvider;
 import com.wultra.core.annotations.PublicApi;
 import lombok.*;
 
+import java.util.List;
+
 /**
  * Request object for {@link OnboardingProvider#evaluateClient(EvaluateClientRequest)}.
  *
@@ -29,6 +31,7 @@ import lombok.*;
  */
 @Builder
 @Getter
+@Setter
 @ToString
 @PublicApi
 @EqualsAndHashCode
@@ -45,4 +48,11 @@ public final class EvaluateClientRequest {
 
     @NonNull
     private String verificationId;
+
+    private String provider;
+
+    /**
+     * Data extracted from each document/page. Format is defined by the document verification provider used.
+     */
+    private List<String> extractedData;
 }

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/provider/rest/ClientEvaluateRequestDto.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/provider/rest/ClientEvaluateRequestDto.java
@@ -19,6 +19,8 @@ package com.wultra.app.onboardingserver.provider.rest;
 
 import lombok.Data;
 
+import java.util.List;
+
 /**
  * Request object for client evaluation.
  *
@@ -39,4 +41,9 @@ class ClientEvaluateRequestDto {
     private String verificationId;
 
     private String provider;
+
+    /**
+     * Data extracted from each document/page. Format is defined by the document verification provider used.
+     */
+    private List<String> extractedData;
 }

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/provider/rest/RestOnboardingProvider.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/provider/rest/RestOnboardingProvider.java
@@ -245,6 +245,8 @@ class RestOnboardingProvider implements OnboardingProvider {
         target.setIdentityVerificationId(source.getIdentityVerificationId());
         target.setUserId(source.getUserId());
         target.setVerificationId(source.getVerificationId());
+        target.setProvider(source.getProvider());
+        target.setExtractedData(source.getExtractedData());
         return target;
     }
 }

--- a/enrollment-server-onboarding/src/main/resources/application.properties
+++ b/enrollment-server-onboarding/src/main/resources/application.properties
@@ -90,6 +90,7 @@ enrollment-server-onboarding.onboarding-process.max-error-score=15
 
 # Client Evaluation Configuration
 enrollment-server-onboarding.client-evaluation.max-failed-attempts=5
+enrollment-server-onboarding.client-evaluation.include-extracted-data=false
 
 # Identity Verification Configuration
 enrollment-server-onboarding.identity-verification.enabled=false


### PR DESCRIPTION
Fix #922:

Evaluate Client Request now contains list of serialised extracted data. Each element of the list corresponds to a document/page uploaded and its format depends on the document provider used. The list of extracted data is filled only when `include-extracted-data` property is set to true. Default is false, so the default behaviour is not changed.

Verification result data are not included in the request. It does not seem beneficial as those were already checked during the onboarding process and the verification strictness is partially configurable.

**In case of Innovatrics** the extracted data also contains links to document photos or portrait photo, hence can be revisited using Innovatrics API. It does not contain reference to a selfie photo, which does not seem as a problem as previous document portrait to selfie matching was already done during the onboarding process.

**In case of ZenID** the extracted data also contains image hash which can be used to identify a portrait photo in ZenID API. The verificationId still available to revisit the onboarding process in Zen ID.

It does not seem beneficial to also include portrait or selfie directly as a payload. It would significantly increase the request size and the recipient would need a dedicated service to compare the faces anyway. Reference to provider resources seems sufficient.

Finally the document provider name in the request was never set before, although the request contained the property. As of now, we are preparing our service for another provider, and so it could be beneficial to actually include the name in the request.