### PR TITLE
Fix #993: Warning: Using generated security password

### DIFF
--- a/enrollment-server/src/main/resources/application.properties
+++ b/enrollment-server/src/main/resources/application.properties
@@ -94,3 +94,5 @@ powerauth.service.correlation-header.value.validation-regexp=[a-zA-Z0-9\\-]{8,10
 #management.endpoints.web.exposure.include=health, prometheus
 #management.endpoint.prometheus.enabled=true
 #management.prometheus.metrics.export.enabled=true
+
+spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration


### PR DESCRIPTION
- Exclude `UserDetailsServiceAutoConfiguration`