### PR TITLE
Fix #995: Filter out errors from document verification in onboarding

### DIFF
--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/IdentityVerificationService.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/IdentityVerificationService.java
@@ -534,12 +534,12 @@ public class IdentityVerificationService {
         entities.forEach(entity -> {
             DocumentMetadataResponseDto docMetadata = toDocumentMetadata(entity);
 
-            if (DocumentStatus.REJECTED.equals(entity.getStatus())) {
-                List<String> errors = collectRejectionErrors(entity);
-                if (docMetadata.getErrors() == null) {
-                    docMetadata.setErrors(new ArrayList<>());
+            if (DocumentStatus.REJECTED == entity.getStatus()) {
+                final List<String> errors = collectRejectionErrors(entity);
+                // Hide specific reasons for rejection if any.
+                if (!errors.isEmpty()) {
+                    docMetadata.setErrors(List.of("Error verifying the document."));
                 }
-                docMetadata.getErrors().addAll(errors);
             }
 
             docsMetadata.add(docMetadata);
@@ -616,8 +616,9 @@ public class IdentityVerificationService {
     private DocumentMetadataResponseDto toDocumentMetadata(DocumentVerificationEntity entity) {
         DocumentMetadataResponseDto docMetadata = new DocumentMetadataResponseDto();
         docMetadata.setId(entity.getId());
+        // Hide specific error reason if any.
         if (StringUtils.isNotBlank(entity.getErrorDetail())) {
-            docMetadata.setErrors(List.of(entity.getErrorDetail()));
+            docMetadata.setErrors(List.of("Error verifying the document."));
         }
         docMetadata.setFilename(entity.getFilename());
         docMetadata.setSide(entity.getSide());

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/IdentityVerificationService.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/IdentityVerificationService.java
@@ -530,21 +530,9 @@ public class IdentityVerificationService {
     }
 
     public List<DocumentMetadataResponseDto> createDocsMetadata(List<DocumentVerificationEntity> entities) {
-        List<DocumentMetadataResponseDto> docsMetadata = new ArrayList<>();
-        entities.forEach(entity -> {
-            DocumentMetadataResponseDto docMetadata = toDocumentMetadata(entity);
-
-            if (DocumentStatus.REJECTED == entity.getStatus()) {
-                final List<String> errors = collectRejectionErrors(entity);
-                // Hide specific reasons for rejection if any.
-                if (!errors.isEmpty()) {
-                    docMetadata.setErrors(List.of("Error verifying the document."));
-                }
-            }
-
-            docsMetadata.add(docMetadata);
-        });
-        return docsMetadata;
+        return entities.stream()
+                .map(this::toDocumentMetadata)
+                .toList();
     }
 
     /**
@@ -617,7 +605,7 @@ public class IdentityVerificationService {
         DocumentMetadataResponseDto docMetadata = new DocumentMetadataResponseDto();
         docMetadata.setId(entity.getId());
         // Hide specific error reason if any.
-        if (StringUtils.isNotBlank(entity.getErrorDetail())) {
+        if (StringUtils.isNotBlank(entity.getErrorDetail()) || StringUtils.isNotBlank(entity.getRejectReason())) {
             docMetadata.setErrors(List.of("Error verifying the document."));
         }
         docMetadata.setFilename(entity.getFilename());

--- a/enrollment-server-onboarding/src/test/java/com/wultra/app/onboardingserver/impl/service/IdentityVerificationServiceTest.java
+++ b/enrollment-server-onboarding/src/test/java/com/wultra/app/onboardingserver/impl/service/IdentityVerificationServiceTest.java
@@ -130,22 +130,6 @@ class IdentityVerificationServiceTest {
     }
 
     @Test
-    void testCreateDocsMetadata_hideParsedRejectionReason() throws Exception {
-        final DocumentResultEntity docResult = new DocumentResultEntity();
-        when(documentVerificationProvider.parseRejectionReasons(docResult))
-                .thenReturn(List.of("Hide parsed reason 1.", "Hide parsed reason 2."));
-
-        final DocumentVerificationEntity doc = new DocumentVerificationEntity();
-        doc.setStatus(DocumentStatus.REJECTED);
-        doc.setResults(Set.of(docResult));
-        doc.setIdentityVerification(new IdentityVerificationEntity());
-        docResult.setDocumentVerification(doc);
-
-        final List<String> errors = tested.createDocsMetadata(List.of(doc)).get(0).getErrors();
-        assertHidden(errors);
-    }
-
-    @Test
     void testCreateDocsMetadata_hideFailedErrorDetail() {
         final DocumentVerificationEntity doc = new DocumentVerificationEntity();
         doc.setStatus(DocumentStatus.FAILED);

--- a/enrollment-server-onboarding/src/test/java/com/wultra/app/onboardingserver/impl/service/IdentityVerificationServiceTest.java
+++ b/enrollment-server-onboarding/src/test/java/com/wultra/app/onboardingserver/impl/service/IdentityVerificationServiceTest.java
@@ -17,9 +17,13 @@
  */
 package com.wultra.app.onboardingserver.impl.service;
 
+import com.wultra.app.enrollmentserver.model.enumeration.DocumentStatus;
 import com.wultra.app.enrollmentserver.model.enumeration.ErrorOrigin;
 import com.wultra.app.enrollmentserver.model.integration.OwnerId;
+import com.wultra.app.onboardingserver.api.provider.DocumentVerificationProvider;
 import com.wultra.app.onboardingserver.common.database.IdentityVerificationRepository;
+import com.wultra.app.onboardingserver.common.database.entity.DocumentResultEntity;
+import com.wultra.app.onboardingserver.common.database.entity.DocumentVerificationEntity;
 import com.wultra.app.onboardingserver.common.database.entity.IdentityVerificationEntity;
 import com.wultra.app.onboardingserver.common.service.AuditService;
 import org.junit.jupiter.api.Test;
@@ -28,6 +32,10 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.util.CollectionUtils;
+
+import java.util.List;
+import java.util.Set;
 
 import static com.wultra.app.enrollmentserver.model.enumeration.IdentityVerificationPhase.COMPLETED;
 import static com.wultra.app.enrollmentserver.model.enumeration.IdentityVerificationPhase.OTP_VERIFICATION;
@@ -35,6 +43,7 @@ import static com.wultra.app.enrollmentserver.model.enumeration.IdentityVerifica
 import static com.wultra.app.enrollmentserver.model.enumeration.IdentityVerificationStatus.FAILED;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 /**
@@ -53,6 +62,9 @@ class IdentityVerificationServiceTest {
 
     @Mock
     private IdentityVerificationPrecompleteCheck identityVerificationPrecompleteCheck;
+
+    @Mock
+    private DocumentVerificationProvider documentVerificationProvider;
 
     @InjectMocks
     private IdentityVerificationService tested;
@@ -96,4 +108,65 @@ class IdentityVerificationServiceTest {
         assertThat(savedIdentityVerification.getErrorDetail(), equalTo("documentVerificationFailed"));
         assertThat(savedIdentityVerification.getErrorOrigin(), equalTo(ErrorOrigin.FINAL_VALIDATION));
     }
+
+    @Test
+    void testCreateDocsMetadata_hideRejectedErrorDetail() {
+        final DocumentVerificationEntity doc = new DocumentVerificationEntity();
+        doc.setStatus(DocumentStatus.REJECTED);
+        doc.setErrorDetail("Hide specific error occurred.");
+
+        final List<String> errors = tested.createDocsMetadata(List.of(doc)).get(0).getErrors();
+        assertHidden(errors);
+    }
+
+    @Test
+    void testCreateDocsMetadata_hideRejectedRejectReason() {
+        final DocumentVerificationEntity doc = new DocumentVerificationEntity();
+        doc.setStatus(DocumentStatus.REJECTED);
+        doc.setRejectReason("Hide specific rejection reason.");
+
+        final List<String> errors = tested.createDocsMetadata(List.of(doc)).get(0).getErrors();
+        assertHidden(errors);
+    }
+
+    @Test
+    void testCreateDocsMetadata_hideParsedRejectionReason() throws Exception {
+        final DocumentResultEntity docResult = new DocumentResultEntity();
+        when(documentVerificationProvider.parseRejectionReasons(docResult))
+                .thenReturn(List.of("Hide parsed reason 1.", "Hide parsed reason 2."));
+
+        final DocumentVerificationEntity doc = new DocumentVerificationEntity();
+        doc.setStatus(DocumentStatus.REJECTED);
+        doc.setResults(Set.of(docResult));
+        doc.setIdentityVerification(new IdentityVerificationEntity());
+        docResult.setDocumentVerification(doc);
+
+        final List<String> errors = tested.createDocsMetadata(List.of(doc)).get(0).getErrors();
+        assertHidden(errors);
+    }
+
+    @Test
+    void testCreateDocsMetadata_hideFailedErrorDetail() {
+        final DocumentVerificationEntity doc = new DocumentVerificationEntity();
+        doc.setStatus(DocumentStatus.FAILED);
+        doc.setErrorDetail("Hide some error occurred.");
+
+        final List<String> errors = tested.createDocsMetadata(List.of(doc)).get(0).getErrors();
+        assertHidden(errors);
+    }
+
+    @Test
+    void testCreateDocsMetadata_accepted() {
+        final DocumentVerificationEntity doc = new DocumentVerificationEntity();
+        doc.setStatus(DocumentStatus.ACCEPTED);
+
+        final List<String> errors = tested.createDocsMetadata(List.of(doc)).get(0).getErrors();
+        assertTrue(CollectionUtils.isEmpty(errors));
+    }
+
+    private static void assertHidden(final List<String> errors) {
+        assertEquals(1, errors.size());
+        assertEquals("Error verifying the document.", errors.get(0));
+    }
+
 }


### PR DESCRIPTION
Fix #995 by modifying the process of mapping `DocumentVerificationEntity` to `DocumentMetadataResponseDto` (`/document/status` endpoint response). Now, if an entity contains some specific error or rejection reasons, they are mapped to single generic reason "Error verifying the document."