### PR TITLE
Fix #1235: Add possibility to transfer additional data during the operation approval (#1236)

### DIFF
--- a/docs/PowerAuth-Enrollment-Server-1.10.0.md
+++ b/docs/PowerAuth-Enrollment-Server-1.10.0.md
@@ -20,6 +20,12 @@ The allowed values of the `environment` parameter are:
 
 For platforms other than APNs the parameter is not used, `null` value is allowed.
 
+### Additional Data for the Operation Approval
+
+It is now possible to specify `mobileTokenData` attribute at `POST /api/auth/token/app/operation/authorize` request.
+The structure is customer-specific.
+Could be used, for example, for passing FDS data.
+
 ## Internal Changes
 
 Operation claim now uses the new `POST /rest/v3/operation/claim` for claiming operations instead of `POST /rest/v3/operation/detail` to separate operation claim action from obtaining operation detail.

--- a/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/controller/api/MobileTokenController.java
+++ b/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/controller/api/MobileTokenController.java
@@ -354,6 +354,7 @@ public class MobileTokenController {
                         .requestContext(requestContext)
                         .activationFlags(activationFlags)
                         .proximityCheckOtp(fetchProximityCheckOtp(requestObject))
+                        .mobileTokenData(requestObject.getMobileTokenData())
                         .build();
 
                 return mobileTokenService.operationApprove(serviceRequest);

--- a/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/impl/service/MobileTokenService.java
+++ b/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/impl/service/MobileTokenService.java
@@ -28,10 +28,7 @@ import com.wultra.security.powerauth.client.PowerAuthClient;
 import com.wultra.security.powerauth.client.model.enumeration.SignatureType;
 import com.wultra.security.powerauth.client.model.enumeration.UserActionResult;
 import com.wultra.security.powerauth.client.model.error.PowerAuthClientException;
-import com.wultra.security.powerauth.client.model.request.OperationClaimRequest;
-import com.wultra.security.powerauth.client.model.request.OperationDetailRequest;
-import com.wultra.security.powerauth.client.model.request.OperationFailApprovalRequest;
-import com.wultra.security.powerauth.client.model.request.OperationListForUserRequest;
+import com.wultra.security.powerauth.client.model.request.*;
 import com.wultra.security.powerauth.client.model.response.OperationDetailResponse;
 import com.wultra.security.powerauth.client.model.response.OperationUserActionResponse;
 import com.wultra.security.powerauth.lib.mtoken.model.entity.Operation;
@@ -46,6 +43,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.MultiValueMap;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -58,13 +56,15 @@ import java.util.Optional;
 public class MobileTokenService {
 
     private static final int OPERATION_LIST_LIMIT = 100;
+
     private static final String ATTR_ACTIVATION_ID = "activationId";
     private static final String ATTR_APPLICATION_ID = "applicationId";
     private static final String ATTR_IP_ADDRESS = "ipAddress";
     private static final String ATTR_USER_AGENT = "userAgent";
     private static final String ATTR_AUTH_FACTOR = "authFactor";
     private static final String ATTR_REJECT_REASON = "rejectReason";
-    private static final String PROXIMITY_OTP = "proximity_otp";
+    private static final String ATTR_PROXIMITY_OTP = "proximity_otp";
+    private static final String ATTR_MOBILE_TOKEN_DATA = "mobileTokenData";
 
     private final PowerAuthClient powerAuthClient;
     private final MobileTokenConverter mobileTokenConverter;
@@ -158,16 +158,8 @@ public class MobileTokenService {
         approveRequest.setUserId(request.getUserId());
         approveRequest.setSignatureType(SignatureType.enumFromString(request.getSignatureFactors().name())); // 'toString' would perform additional toLowerCase() call
         approveRequest.setApplicationId(request.getApplicationId());
-        // Prepare additional data
-        approveRequest.getAdditionalData().put(ATTR_ACTIVATION_ID, request.getActivationId());
-        approveRequest.getAdditionalData().put(ATTR_APPLICATION_ID, request.getApplicationId());
-        approveRequest.getAdditionalData().put(ATTR_IP_ADDRESS, request.getRequestContext().getIpAddress());
-        approveRequest.getAdditionalData().put(ATTR_USER_AGENT, request.getRequestContext().getUserAgent());
-        approveRequest.getAdditionalData().put(ATTR_AUTH_FACTOR, request.getSignatureFactors().toString());
 
-        if (request.getProximityCheckOtp() != null) {
-            approveRequest.getAdditionalData().put(PROXIMITY_OTP, request.getProximityCheckOtp());
-        }
+        fillAdditionalData(request, approveRequest);
 
         final OperationUserActionResponse approveResponse = powerAuthClient.operationApprove(
                 approveRequest,
@@ -182,6 +174,23 @@ public class MobileTokenService {
             final OperationDetailResponse operation = approveResponse.getOperation();
             handleStatus(operation);
             throw new MobileTokenAuthException(ErrorCode.OPERATION_FAILED, "PowerAuth server operation approval fails");
+        }
+    }
+
+    private static void fillAdditionalData(final OperationApproveParameterObject source, final OperationApproveRequest target) {
+        final Map<String, Object> additionalData = target.getAdditionalData();
+
+        additionalData.put(ATTR_ACTIVATION_ID, source.getActivationId());
+        additionalData.put(ATTR_APPLICATION_ID, source.getApplicationId());
+        additionalData.put(ATTR_IP_ADDRESS, source.getRequestContext().getIpAddress());
+        additionalData.put(ATTR_USER_AGENT, source.getRequestContext().getUserAgent());
+        additionalData.put(ATTR_AUTH_FACTOR, source.getSignatureFactors().toString());
+
+        if (source.getProximityCheckOtp() != null) {
+            additionalData.put(ATTR_PROXIMITY_OTP, source.getProximityCheckOtp());
+        }
+        if (source.getMobileTokenData() != null) {
+            additionalData.put(ATTR_MOBILE_TOKEN_DATA, source.getMobileTokenData());
         }
     }
 

--- a/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/impl/service/OperationApproveParameterObject.java
+++ b/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/impl/service/OperationApproveParameterObject.java
@@ -24,6 +24,7 @@ import lombok.Getter;
 import lombok.NonNull;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * Parameter object for {@link MobileTokenService#operationApprove(OperationApproveParameterObject)}.
@@ -58,4 +59,6 @@ public class OperationApproveParameterObject {
     private List<String> activationFlags;
 
     private String proximityCheckOtp;
+
+    private Map<String, Object> mobileTokenData;
 }

--- a/mtoken-model/src/main/java/com/wultra/security/powerauth/lib/mtoken/model/request/OperationApproveRequest.java
+++ b/mtoken-model/src/main/java/com/wultra/security/powerauth/lib/mtoken/model/request/OperationApproveRequest.java
@@ -24,6 +24,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
 import java.time.Instant;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -36,6 +37,11 @@ public class OperationApproveRequest {
 
     @NotEmpty
     private String id;
+
+    /**
+     * Operation data to approve.
+     */
+    @Schema(description = "Operation data to approve.", example = "A1*A100CZK*Q238400856\\/0300**D20190629*NUtility Bill Payment - 05\\/2019")
     @NotNull
     private String data;
 
@@ -44,6 +50,12 @@ public class OperationApproveRequest {
      */
     @Schema(description = "Optional proximity check data." )
     private ProximityCheck proximityCheck;
+
+    /**
+     * Optional mobile token data, structure is customer-specific. Could be used, for example, for passing FDS data.
+     */
+    @Schema(description = "Optional mobile token data, structure is customer-specific. Could be used, for example, for storing FDS data.")
+    private Map<String, Object> mobileTokenData;
 
     public Optional<ProximityCheck> getProximityCheck() {
         return Optional.ofNullable(proximityCheck);


### PR DESCRIPTION
* Fix #1235: Add possibility to transfer additional data during the operation approval

(cherry picked from commit 76e57a1a6eca354505da9bfc5cabe4d93cd8a8a0)