### PR TITLE
Fix #1272: Allow disabling Bouncy Castle initialization

### DIFF
--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/BouncyCastleProviderInitializer.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/BouncyCastleProviderInitializer.java
@@ -1,0 +1,50 @@
+/*
+ * PowerAuth Enrollment Server
+ * Copyright (C) 2025 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.wultra.app.onboardingserver;
+
+import lombok.extern.slf4j.Slf4j;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.stereotype.Component;
+
+import java.security.Security;
+
+/**
+ * Bouncy Castle provider initializer.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+@Component
+@Slf4j
+@ConditionalOnProperty(
+        name = "bouncycastle.provider.initialization.enabled",
+        havingValue = "true"
+)
+public class BouncyCastleProviderInitializer implements ApplicationListener<ApplicationReadyEvent> {
+
+    @Override
+    public void onApplicationEvent(ApplicationReadyEvent event) {
+        if (Security.getProvider("BC") == null) {
+            Security.addProvider(new BouncyCastleProvider());
+            logger.info("BouncyCastle provider initialized after application ready.");
+        }
+    }
+}

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/OnboardingServerApplication.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/OnboardingServerApplication.java
@@ -32,7 +32,6 @@ import java.security.Security;
 public class OnboardingServerApplication {
 
     public static void main(String[] args) {
-        Security.addProvider(new BouncyCastleProvider());
         SpringApplication.run(OnboardingServerApplication.class, args);
     }
 

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/ServletInitializer.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/ServletInitializer.java
@@ -29,9 +29,6 @@ public class ServletInitializer extends SpringBootServletInitializer {
     @Override
     protected SpringApplicationBuilder configure(SpringApplicationBuilder application) {
 
-        // Register BC provider and tell PowerAuth components to use it.
-        Security.addProvider(new BouncyCastleProvider());
-
         return application.sources(OnboardingServerApplication.class);
     }
 

--- a/enrollment-server-onboarding/src/main/resources/application.properties
+++ b/enrollment-server-onboarding/src/main/resources/application.properties
@@ -41,6 +41,9 @@ spring.jpa.properties.hibernate.connection.useUnicode=true
 # Hibernate Configuration
 spring.jpa.hibernate.ddl-auto=none
 
+# Bouncy Castle initialization
+bouncycastle.provider.initialization.enabled=true
+
 # Database Lock Timeout Configuration
 spring.jpa.properties.jakarta.persistence.lock.timeout=10000
 

--- a/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/BouncyCastleProviderInitializer.java
+++ b/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/BouncyCastleProviderInitializer.java
@@ -1,0 +1,50 @@
+/*
+ * PowerAuth Enrollment Server
+ * Copyright (C) 2025 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.wultra.app.enrollmentserver;
+
+import lombok.extern.slf4j.Slf4j;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.stereotype.Component;
+
+import java.security.Security;
+
+/**
+ * Bouncy Castle provider initializer.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+@Component
+@Slf4j
+@ConditionalOnProperty(
+        name = "bouncycastle.provider.initialization.enabled",
+        havingValue = "true"
+)
+public class BouncyCastleProviderInitializer implements ApplicationListener<ApplicationReadyEvent> {
+
+    @Override
+    public void onApplicationEvent(ApplicationReadyEvent event) {
+        if (Security.getProvider("BC") == null) {
+            Security.addProvider(new BouncyCastleProvider());
+            logger.info("BouncyCastle provider initialized after application ready.");
+        }
+    }
+}

--- a/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/EnrollmentServerApplication.java
+++ b/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/EnrollmentServerApplication.java
@@ -32,7 +32,6 @@ import java.security.Security;
 public class EnrollmentServerApplication {
 
     public static void main(String[] args) {
-        Security.addProvider(new BouncyCastleProvider());
         SpringApplication.run(EnrollmentServerApplication.class, args);
     }
 

--- a/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/ServletInitializer.java
+++ b/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/ServletInitializer.java
@@ -29,9 +29,6 @@ public class ServletInitializer extends SpringBootServletInitializer {
     @Override
     protected SpringApplicationBuilder configure(SpringApplicationBuilder application) {
 
-        // Register BC provider and tell PowerAuth components to use it.
-        Security.addProvider(new BouncyCastleProvider());
-
         return application.sources(EnrollmentServerApplication.class);
     }
 

--- a/enrollment-server/src/main/resources/application.properties
+++ b/enrollment-server/src/main/resources/application.properties
@@ -41,6 +41,9 @@ spring.jpa.properties.hibernate.connection.useUnicode=true
 # Hibernate Configuration
 spring.jpa.hibernate.ddl-auto=none
 
+# Bouncy Castle initialization
+bouncycastle.provider.initialization.enabled=true
+
 # Database Lock Timeout Configuration
 spring.jpa.properties.jakarta.persistence.lock.timeout=10000
 


### PR DESCRIPTION
This PR makes BC initialization configurable for setup with multiple applications on same application server.