### PR TITLE
Fix #1257: Migrate Legacy OSSRH to Central Portal (backport)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -390,8 +390,8 @@
                     <url>https://wultra.jfrog.io/artifactory/internal-maven-repository</url>
                 </repository>
                 <repository>
-                    <id>ossrh-snapshots</id>
-                    <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+                    <id>central-portal-snapshots</id>
+                    <url>https://central.sonatype.com/repository/maven-snapshots/</url>
                     <releases>
                         <enabled>false</enabled>
                     </releases>
@@ -412,12 +412,12 @@
             </properties>
             <distributionManagement>
                 <snapshotRepository>
-                    <id>ossrh-snapshots-distribution</id>
-                    <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
+                    <id>central-portal-snapshots-distribution</id>
+                    <url>https://central.sonatype.com/repository/maven-snapshots/</url>
                 </snapshotRepository>
                 <repository>
-                    <id>ossrh-staging-distribution</id>
-                    <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+                    <id>central-portal-staging-distribution</id>
+                    <url>https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/</url>
                 </repository>
             </distributionManagement>
         </profile>
@@ -425,18 +425,8 @@
 
     <repositories>
         <repository>
-            <id>ossrh-snapshots</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-        <repository>
-            <id>ossrh-snapshots-s01</id>
-            <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
+            <id>central-portal-snapshots</id>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
             <releases>
                 <enabled>false</enabled>
             </releases>


### PR DESCRIPTION
(cherry picked from commit https://github.com/wultra/enrollment-server/commit/58c4cabb88265719ba1e97e644e6f08720e35f2d)