### PR TITLE
Add CycloneDX Maven plugin version 2.9.1 for SBOM generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,7 @@
         <powerauth-push.version>2.0.0-SNAPSHOT</powerauth-push.version>
 
         <logstash.version>8.1</logstash.version>
+        <cyclonedx-maven-plugin.version>2.9.1</cyclonedx-maven-plugin.version>
     </properties>
 
     <dependencyManagement>
@@ -350,6 +351,11 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.cyclonedx</groupId>
+                <artifactId>cyclonedx-maven-plugin</artifactId>
+                <version>${cyclonedx-maven-plugin.version}</version>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Result sbom is part of each module artifact