### PR TITLE
Fix #1333: Add actionSettings to the button

### DIFF
--- a/enrollment-server/src/test/java/com/wultra/app/enrollmentserver/impl/service/converter/MobileTokenConverterTest.java
+++ b/enrollment-server/src/test/java/com/wultra/app/enrollmentserver/impl/service/converter/MobileTokenConverterTest.java
@@ -145,7 +145,8 @@ class MobileTokenConverterTest {
                           "type": "BUTTON",
                           "action": "PHONE",
                           "text": "Call center",
-                          "href": "+42012345678"
+                          "href": "+42012345678",
+                          "actionSettings": "REJECT"
                         },
                         {
                           "id": "custom_element_id",
@@ -208,6 +209,7 @@ class MobileTokenConverterTest {
         assertEquals(PreApprovalScreenV2.ActionType.PHONE, elements.get(1).action());
         assertEquals("Call center", elements.get(1).text());
         assertEquals("+42012345678", elements.get(1).href());
+        assertEquals("REJECT", elements.get(1).actionSettings());
 
         assertEquals(PreApprovalScreenV2.ElementType.LIST_ITEM, elements.get(2).type());
         assertEquals("icon-label", elements.get(2).icon());

--- a/mtoken-model/src/main/java/com/wultra/security/powerauth/lib/mtoken/model/entity/PreApprovalScreenV2.java
+++ b/mtoken-model/src/main/java/com/wultra/security/powerauth/lib/mtoken/model/entity/PreApprovalScreenV2.java
@@ -73,7 +73,7 @@ public class PreApprovalScreenV2 {
             String href,
             String icon,
             ActionType action,
-            @Schema(example = "REJECT")
+            @Schema(description = "Custom extended behavior or secondary action for the button.", example = "REJECT")
             String actionSettings
     ) {}
 

--- a/mtoken-model/src/main/java/com/wultra/security/powerauth/lib/mtoken/model/entity/PreApprovalScreenV2.java
+++ b/mtoken-model/src/main/java/com/wultra/security/powerauth/lib/mtoken/model/entity/PreApprovalScreenV2.java
@@ -72,7 +72,9 @@ public class PreApprovalScreenV2 {
             String text,
             String href,
             String icon,
-            ActionType action
+            ActionType action,
+            @Schema(example = "REJECT")
+            String actionSettings
     ) {}
 
     public enum ActionType {


### PR DESCRIPTION
Extends the preApprovalScreens type of button by adding actionSettings.

A follow-up to #1289