### PR TITLE
Fix #1335: Use polymorphism for elements of preApprovalScreens

### DIFF
--- a/enrollment-server/src/test/java/com/wultra/app/enrollmentserver/impl/service/converter/MobileTokenConverterTest.java
+++ b/enrollment-server/src/test/java/com/wultra/app/enrollmentserver/impl/service/converter/MobileTokenConverterTest.java
@@ -201,19 +201,23 @@ class MobileTokenConverterTest {
 
         final List<PreApprovalScreenV2.Element> elements = screen1.getElements();
         assertEquals(3, elements.size());
-        assertEquals(PreApprovalScreenV2.ElementType.ALERT, elements.get(0).type());
-        assertEquals(PreApprovalScreenV2.ElementStyle.INFO, elements.get(0).style());
-        assertEquals("Make sure the activation takes place on your device", elements.get(0).text());
 
-        assertEquals(PreApprovalScreenV2.ElementType.BUTTON, elements.get(1).type());
-        assertEquals(PreApprovalScreenV2.ActionType.PHONE, elements.get(1).action());
-        assertEquals("Call center", elements.get(1).text());
-        assertEquals("+42012345678", elements.get(1).href());
-        assertEquals("REJECT", elements.get(1).actionSettings());
+        assertInstanceOf(PreApprovalScreenV2.AlertElement.class, elements.get(0));
+        final PreApprovalScreenV2.AlertElement alertElement = (PreApprovalScreenV2.AlertElement) elements.get(0);
+        assertEquals(PreApprovalScreenV2.ElementStyle.INFO, alertElement.getStyle());
+        assertEquals("Make sure the activation takes place on your device", alertElement.getText());
 
-        assertEquals(PreApprovalScreenV2.ElementType.LIST_ITEM, elements.get(2).type());
-        assertEquals("icon-label", elements.get(2).icon());
-        assertEquals("You activate a new app and allow access to your accounts", elements.get(2).text());
+        assertInstanceOf(PreApprovalScreenV2.ButtonElement.class, elements.get(1));
+        final PreApprovalScreenV2.ButtonElement buttonElement = (PreApprovalScreenV2.ButtonElement) elements.get(1);
+        assertEquals(PreApprovalScreenV2.ActionType.PHONE, buttonElement.getAction());
+        assertEquals("Call center", buttonElement.getText());
+        assertEquals("+42012345678", buttonElement.getHref());
+        assertEquals("REJECT", buttonElement.getActionSettings());
+
+        assertInstanceOf(PreApprovalScreenV2.ListItemElement.class, elements.get(2));
+        final PreApprovalScreenV2.ListItemElement listItemElement = (PreApprovalScreenV2.ListItemElement) elements.get(2);
+        assertEquals("icon-label", listItemElement.getIcon());
+        assertEquals("You activate a new app and allow access to your accounts", listItemElement.getText());
 
         final PreApprovalScreenV2.Controls controls = screen1.getControls();
         assertTrue(controls.flip());

--- a/mtoken-model/src/main/java/com/wultra/security/powerauth/lib/mtoken/model/entity/PreApprovalScreenV2.java
+++ b/mtoken-model/src/main/java/com/wultra/security/powerauth/lib/mtoken/model/entity/PreApprovalScreenV2.java
@@ -17,9 +17,14 @@
  */
 package com.wultra.security.powerauth.lib.mtoken.model.entity;
 
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 
 import java.util.List;
 
@@ -65,28 +70,59 @@ public class PreApprovalScreenV2 {
 
     private Controls  controls;
 
-    public record Element(
-            String id,
-            ElementType type,
-            ElementStyle style,
-            String text,
-            String href,
-            String icon,
-            ActionType action,
-            @Schema(description = "Custom extended behavior or secondary action for the button.", example = "REJECT")
-            String actionSettings
-    ) {}
+    @Getter
+    @Setter
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+    @JsonSubTypes({
+            @JsonSubTypes.Type(value = ListItemElement.class, name = Element.LIST_ITEM),
+            @JsonSubTypes.Type(value = AlertElement.class, name = Element.ALERT),
+            @JsonSubTypes.Type(value = ButtonElement.class, name = Element.BUTTON)
+    })
+    public abstract static class Element {
+
+        public static final String LIST_ITEM = "LIST_ITEM";
+        public static final String ALERT = "ALERT";
+        public static final String BUTTON = "BUTTON";
+
+        @NotBlank
+        private String id;
+
+        @NotNull
+        private String text;
+    }
+
+    @Getter
+    @Setter
+    @Schema(description = "List item element")
+    public static class ListItemElement extends Element {
+        private String icon;
+        private ElementStyle style;
+    }
+
+    @Getter
+    @Setter
+    @Schema(description = "Alert element")
+    public static class AlertElement extends Element {
+        private ElementStyle style;
+    }
+
+    @Getter
+    @Setter
+    @Schema(description = "Button element")
+    public static class ButtonElement extends Element {
+
+        private ActionType action;
+
+        private String href;
+
+        @Schema(description = "Custom extended behavior or secondary action for the button.", example = "REJECT")
+        private String actionSettings;
+    }
 
     public enum ActionType {
         LINK,
         MAIL,
         PHONE
-    }
-
-    public enum ElementType {
-        LIST_ITEM,
-        ALERT,
-        BUTTON
     }
 
     public enum ElementStyle {

--- a/mtoken-model/src/main/java/com/wultra/security/powerauth/lib/mtoken/model/entity/PreApprovalScreenV2.java
+++ b/mtoken-model/src/main/java/com/wultra/security/powerauth/lib/mtoken/model/entity/PreApprovalScreenV2.java
@@ -87,7 +87,7 @@ public class PreApprovalScreenV2 {
         @NotBlank
         private String id;
 
-        @NotNull
+        @NotBlank
         private String text;
     }
 

--- a/mtoken-model/src/main/java/com/wultra/security/powerauth/lib/mtoken/model/entity/PreApprovalScreenV2.java
+++ b/mtoken-model/src/main/java/com/wultra/security/powerauth/lib/mtoken/model/entity/PreApprovalScreenV2.java
@@ -20,7 +20,6 @@ package com.wultra.security.powerauth.lib.mtoken.model.entity;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 import lombok.Getter;
@@ -84,10 +83,8 @@ public class PreApprovalScreenV2 {
         public static final String ALERT = "ALERT";
         public static final String BUTTON = "BUTTON";
 
-        @NotBlank
         private String id;
 
-        @NotBlank
         private String text;
     }
 


### PR DESCRIPTION
Refactor elements of preApprovalScreens to use polymorphism with `one of`.

A follow-up to #1289