### PR TITLE
Fix #1555: The ApproveClientResponseDto has mandatory resultReason (backport)

### DIFF
--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/provider/rest/ApproveClientResponseDto.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/provider/rest/ApproveClientResponseDto.java
@@ -32,7 +32,7 @@ import lombok.extern.jackson.Jacksonized;
 @Jacksonized
 record ApproveClientResponseDto(
         @NonNull EvaluationResult result,
-        @NonNull String resultReason
+        String resultReason
 ) {
     enum EvaluationResult {
         OK,


### PR DESCRIPTION
(cherry picked from commit e0c69e2f00a3c5c57a59a6d3da4ea9edf2203825)