### PR TITLE
Fix #1563: Use OTP if generated and activation type is CODE (backport)

### DIFF
--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/ActivationService.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/ActivationService.java
@@ -75,6 +75,7 @@ public class ActivationService {
             final InitActivationRequest initActivationRequest = new InitActivationRequest();
             initActivationRequest.setApplicationId(lookupResponse.getApplicationId());
             initActivationRequest.setUserId(request.userId());
+            initActivationRequest.setActivationOtp(request.otp());
             initActivationRequest.setCommitPhase(CommitPhase.ON_KEY_EXCHANGE);
             initActivationRequest.setFlags(activationFlagService.fetchInitialActivationFlags());
 
@@ -159,7 +160,7 @@ public class ActivationService {
     }
 
     @Builder
-    public record InitActivationContext(String userId, String applicationKey) {}
+    public record InitActivationContext(String userId, String applicationKey, String otp) {}
 
     @Builder
     public record InitTargetActivationContext(String userId, String applicationId, String parentActivationId) {}

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/OnboardingServiceImpl.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/OnboardingServiceImpl.java
@@ -71,10 +71,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.text.SimpleDateFormat;
 import java.time.Duration;
-import java.util.Calendar;
-import java.util.Collection;
-import java.util.Date;
-import java.util.Map;
+import java.util.*;
 
 /**
  * Service implementing specific behavior for the onboarding process. Shared behavior is inherited from {@link CommonOnboardingService}.
@@ -192,11 +189,12 @@ public class OnboardingServiceImpl extends CommonOnboardingService {
             throw new TooManyProcessesException("Maximum number of processes per day reached for user: " + userId);
         }
 
-        createAndSendOtp(process, userId);
+        final Optional<String> otp = createAndSendOtp(process, userId);
 
         final ActivationService.InitActivationContext initActivationContext = ActivationService.InitActivationContext.builder()
                 .applicationKey(encryptionContext.getApplicationKey())
                 .userId(userId)
+                .otp(otp.orElse(null))
                 .build();
 
         final var activationType = process.getProcessConfiguration().getConfiguration().activationType();
@@ -213,18 +211,20 @@ public class OnboardingServiceImpl extends CommonOnboardingService {
                 .build();
     }
 
-    private void createAndSendOtp(final OnboardingProcessEntity process, final String userId) throws OnboardingProcessException, OnboardingOtpDeliveryException {
+    private Optional<String> createAndSendOtp(final OnboardingProcessEntity process, final String userId) throws OnboardingProcessException, OnboardingOtpDeliveryException {
         if (isActivationOtpDisabled(process)) {
             logger.info("Activation OTP is disabled for process type: {}", process.getProcessConfiguration().getProcessType());
-            return;
+            return Optional.empty();
         }
 
         final String otpCode = otpService.createOtpCode(process, OtpType.ACTIVATION);
         if (userId == null) {
             logger.info("User ID is null, OTP is not sent");
+            return Optional.empty();
         } else {
             logger.debug("Sending OTP for user ID: {}", userId);
             sendOtp(process, otpCode);
+            return Optional.of(otpCode);
         }
     }
 

--- a/enrollment-server-onboarding/src/test/java/com/wultra/app/onboardingserver/impl/service/OnboardingServiceImplTest.java
+++ b/enrollment-server-onboarding/src/test/java/com/wultra/app/onboardingserver/impl/service/OnboardingServiceImplTest.java
@@ -116,6 +116,7 @@ class OnboardingServiceImplTest {
         final InitActivationRequest captorValue = requestCaptor.getValue();
         assertEquals("mock_app_id", captorValue.getApplicationId());
         assertEquals(List.of("VERIFICATION_PENDING"), captorValue.getFlags());
+        assertNotNull(captorValue.getActivationOtp());
 
         final Optional<OnboardingProcessEntity> process = onboardingProcessRepository.findById(result.processId());
         assertTrue(process.isPresent());


### PR DESCRIPTION
(cherry picked from commit 9a98add53cd6812254ffb1709f3b678c3df5a573)