### PR TITLE
Add ui element to template API

### DIFF
--- a/enrollment-server-api-model/src/main/java/com/wultra/app/enrollmentserver/api/model/enrollment/response/TemplateListResponse.java
+++ b/enrollment-server-api-model/src/main/java/com/wultra/app/enrollmentserver/api/model/enrollment/response/TemplateListResponse.java
@@ -37,6 +37,6 @@ public class TemplateListResponse extends ArrayList<TemplateListResponse.Templat
     private static final long serialVersionUID = -5446919236567435144L;
 
     @Builder
-    public record TemplateDetail(String name, String title, String message, List<Object> attributes, String language, Map<String, String> resultTexts) {
+    public record TemplateDetail(String name, String title, String message, String ui, List<Object> attributes, String language, Map<String, String> resultTexts) {
     }
 }

--- a/enrollment-server-api-model/src/main/resources/com/wultra/app/enrollmentserver/controller/api/admin/AdminControllerTest.sql
+++ b/enrollment-server-api-model/src/main/resources/com/wultra/app/enrollmentserver/controller/api/admin/AdminControllerTest.sql
@@ -18,7 +18,10 @@ values
       "value": "iban"
     }
   }
-]', null,
+]',
+'{
+  "flipButtons": true
+}',
  '{
   "success": "Payment of ${amount} ${currency} was confirmed",
   "reject": "Payment was rejected",

--- a/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/controller/api/admin/AdminController.java
+++ b/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/controller/api/admin/AdminController.java
@@ -71,6 +71,7 @@ public class AdminController {
                 .name(source.getPlaceholder())
                 .title(source.getTitle())
                 .message(source.getMessage())
+                .ui(source.getUi())
                 .language(source.getLanguage())
                 .attributes(convert(source.getAttributes()))
                 .resultTexts(convertResultTexts(source.getResultTexts()))

--- a/enrollment-server/src/test/java/com/wultra/app/enrollmentserver/controller/api/admin/AdminControllerTest.java
+++ b/enrollment-server/src/test/java/com/wultra/app/enrollmentserver/controller/api/admin/AdminControllerTest.java
@@ -55,6 +55,7 @@ class AdminControllerTest {
                 .andExpect(jsonPath("$.status", is("OK")))
                 .andExpect(jsonPath("$.responseObject.*", hasSize(1)))
                 .andExpect(jsonPath("$.responseObject[0].title", is("Payment Approval")))
+                .andExpect(jsonPath("$.responseObject[0].ui", containsString("\"flipButtons\": true")))
                 .andExpect(jsonPath("$.responseObject[0].resultTexts.success", is("Payment of ${amount} ${currency} was confirmed")));
     }
 }


### PR DESCRIPTION
## Summary
- add `ui` to `TemplateListResponse.TemplateDetail`
- map the template entity `ui` value in admin template responses
- cover the new field in `AdminControllerTest`

## Testing
- mvn -q -pl enrollment-server -am -Dtest=AdminControllerTest -Dsurefire.failIfNoSpecifiedTests=false test