### PR TITLE
Resolves #1621: Update README for developers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 **/target/
 **/src/main/java/generated/
 **/.springBeans
+env.list
 
 ### NetBeans template
 **/nbproject/private/
@@ -26,3 +27,7 @@ rebel.xml
 ### Swagger
 .swagger-codegen
 .swagger-codegen-ignore
+
+### Vim
+*.swp
+*.swo

--- a/docs-private/Developer-How-To-Start.md
+++ b/docs-private/Developer-How-To-Start.md
@@ -16,10 +16,16 @@ the compatibility.
 
 ### Build
 
-Build with:
+From the repository root, build all modules with:
 
 ```shell
 mvn clean install
+```
+
+To build only the Enrollment Server module and its dependencies from the repository root, use:
+
+```shell
+mvn -pl enrollment-server -am clean install
 ```
 
 
@@ -32,20 +38,24 @@ mvn clean install
 
 Ensure you have a database installed and running, and that you have an admin account.
 
-##### Create a user and a schema
+##### Create a user and a database
 
 Start a `psql` session with your superuser:
 
 ```shell
-psql -U $(whoami) -d postgres
+psql -U postgres -d postgres
 ```
 
 Then run following commands in the `psql` shell:
 
 ```sql
-CREATE USER powerauth WITH PASSWORD 'powerauth';
+CREATE USER powerauth;
 CREATE DATABASE powerauth OWNER powerauth;
 ```
+
+By default, local development in this repository uses the `powerauth` user without a password.
+If your local PostgreSQL setup requires password authentication, set a password for the user
+and update the matching datasource and Liquibase settings in the commands below.
 
 ##### Load the data with Liquibase
 
@@ -103,6 +113,8 @@ The working directory is `enrollment-server`.
 java -jar target/enrollment-server-x.y.z.war --spring.profiles.active=dev
 ```
 
+The exact WAR filename can be found in the `target/` directory.
+
 #### Maven
 
 ```shell
@@ -129,12 +141,16 @@ If you run the server directly from CLI or Maven without extra server parameters
 curl -v http://localhost:8080/actuator/health
 ```
 
+Standalone CLI and Maven runs use port `8080` by default. Because Enrollment Server
+Onboarding also uses `8080` by default, you can run only one of them at a time unless
+you override `server.port` (and optionally `server.servlet.context-path`).
+
 You should get response: `200 {"status":"UP"}`
 
 You can check other APIs on:
 
-* http://localhost:8080/swagger-ui/index.html
 * http://localhost:8081/enrollment-server/swagger-ui/index.html
+* http://localhost:8080/swagger-ui/index.html (when running only Enrollment Server on the default standalone port)
 
 
 ### Schema Diagram
@@ -148,19 +164,19 @@ For database structure overview, see:
 ##### PostgreSQL
 
 ```shell
-liquibase --changeLogFile=./docs/db/changelog/changesets/enrollment-server/db.changelog-module.xml --output-file=./docs/sql/postgresql/generated-postgresql-script.sql updateSQL --url=offline:postgresql
+liquibase --changelog-file=./docs/db/changelog/changesets/enrollment-server/db.changelog-module.xml --output-file=./docs/sql/postgresql/generated-postgresql-script.sql updateSQL --url=offline:postgresql
 ```
 
 ##### Oracle
 
 ```shell
-liquibase --changeLogFile=./docs/db/changelog/changesets/enrollment-server/db.changelog-module.xml --output-file=./docs/sql/oracle/generated-oracle-script.sql updateSQL --url=offline:oracle
+liquibase --changelog-file=./docs/db/changelog/changesets/enrollment-server/db.changelog-module.xml --output-file=./docs/sql/oracle/generated-oracle-script.sql updateSQL --url=offline:oracle
 ```
 
 ##### MS SQL
 
 ```shell
-liquibase --changeLogFile=./docs/db/changelog/changesets/enrollment-server/db.changelog-module.xml --output-file=./docs/sql/mssql/generated-mssql-script.sql updateSQL --url=offline:mssql
+liquibase --changelog-file=./docs/db/changelog/changesets/enrollment-server/db.changelog-module.xml --output-file=./docs/sql/mssql/generated-mssql-script.sql updateSQL --url=offline:mssql
 ```
 
 
@@ -189,10 +205,16 @@ docker run -p 80:8080 -e ENROLLMENT_SERVER_DATASOURCE_URL='jdbc:postgresql://hos
 
 ### Build
 
-Build with:
+From the repository root, build all modules with:
 
 ```shell
 mvn clean install
+```
+
+To build only the Enrollment Server Onboarding module and its dependencies from the repository root, use:
+
+```shell
+mvn -pl enrollment-server-onboarding -am clean install
 ```
 
 
@@ -262,6 +284,8 @@ The working directory is `enrollment-server-onboarding`.
 java -jar target/enrollment-server-onboarding-x.y.z.war --spring.profiles.active=dev
 ```
 
+The exact WAR filename can be found in the `target/` directory.
+
 #### Maven
 
 ```shell
@@ -288,12 +312,16 @@ If you run the server directly from CLI or Maven without extra server parameters
 curl -v http://localhost:8080/actuator/health
 ```
 
+Standalone CLI and Maven runs use port `8080` by default. Because Enrollment Server
+also uses `8080` by default, you can run only one of them at a time unless you
+override `server.port` (and optionally `server.servlet.context-path`).
+
 You should get response: `200 {"status":"UP"}`
 
 You can check other APIs on:
 
-* http://localhost:8080/swagger-ui/index.html
 * http://localhost:8083/enrollment-server-onboarding/swagger-ui/index.html
+* http://localhost:8080/swagger-ui/index.html (when running only Enrollment Server Onboarding on the default standalone port)
 
 
 ### Schema Diagram
@@ -307,17 +335,17 @@ For database structure overview, see:
 ##### Oracle
 
 ```shell
-liquibase --changeLogFile=./docs/db/changelog/changesets/enrollment-server-onboarding/db.changelog-module.xml --output-file=./docs/sql/oracle/generated-oracle-script.sql updateSQL --url=offline:oracle
+liquibase --changelog-file=./docs/db/changelog/changesets/enrollment-server-onboarding/db.changelog-module.xml --output-file=./docs/sql/oracle/generated-oracle-script.sql updateSQL --url=offline:oracle
 ```
 
 ##### MS SQL
 
 ```shell
-liquibase --changeLogFile=./docs/db/changelog/changesets/enrollment-server-onboarding/db.changelog-module.xml --output-file=./docs/sql/mssql/generated-mssql-script.sql updateSQL --url=offline:mssql
+liquibase --changelog-file=./docs/db/changelog/changesets/enrollment-server-onboarding/db.changelog-module.xml --output-file=./docs/sql/mssql/generated-mssql-script.sql updateSQL --url=offline:mssql
 ```
 
 ##### PostgreSQL
 
 ```shell
-liquibase --changeLogFile=./docs/db/changelog/changesets/enrollment-server-onboarding/db.changelog-module.xml --output-file=./docs/sql/postgresql/generated-postgresql-script.sql updateSQL --url=offline:postgresql
+liquibase --changelog-file=./docs/db/changelog/changesets/enrollment-server-onboarding/db.changelog-module.xml --output-file=./docs/sql/postgresql/generated-postgresql-script.sql updateSQL --url=offline:postgresql
 ```

--- a/docs-private/Developer-How-To-Start.md
+++ b/docs-private/Developer-How-To-Start.md
@@ -92,7 +92,7 @@ spring.datasource.url=jdbc:postgresql://localhost:5432/powerauth
 spring.datasource.username=powerauth
 spring.datasource.password=
 powerauth.service.url=http://localhost:8080/powerauth-java-server/rest
-powerauth.push.service.url=http://localhost:8080/powerauth-push-server
+powerauth.push.service.url=http://localhost:8081/powerauth-push-server
 enrollment-server.auth-type=BASIC_HTTP
 enrollment-server.admin.enabled=true
 ```
@@ -149,8 +149,7 @@ You should get response: `200 {"status":"UP"}`
 
 You can check other APIs on:
 
-* http://localhost:8081/enrollment-server/swagger-ui/index.html
-* http://localhost:8080/swagger-ui/index.html (when running only Enrollment Server on the default standalone port)
+* http://localhost:8080/swagger-ui/index.html
 
 
 ### Schema Diagram
@@ -227,6 +226,7 @@ mvn -pl enrollment-server-onboarding -am clean install
 #### Set up
 
 If you have not created the database and user yet, use the same PostgreSQL setup as in the Enrollment Server section.
+See [Database](#database) section above for details.
 
 ##### Load the data with Liquibase
 
@@ -320,8 +320,7 @@ You should get response: `200 {"status":"UP"}`
 
 You can check other APIs on:
 
-* http://localhost:8083/enrollment-server-onboarding/swagger-ui/index.html
-* http://localhost:8080/swagger-ui/index.html (when running only Enrollment Server Onboarding on the default standalone port)
+* http://localhost:8080/swagger-ui/index.html
 
 
 ### Schema Diagram

--- a/docs-private/Developer-How-To-Start.md
+++ b/docs-private/Developer-How-To-Start.md
@@ -1,65 +1,88 @@
 # Developer - How to Start Guide
 
+## General prerequisites
+
+Following are _minimal_ versions of the tools and technologies used in the development
+of the PowerAuth Server. You can use higher versions, but make sure to check the compatibility.
+
+* _JDK_ version 21.x
+* _Maven_ version 3.9.x
+* _PostgreSQL_ version 18.x
+* _Liquibase_ version 4.33.x
+
 
 ## Enrollment Server
 
+### Build
 
-### Standalone Run
+Build with:
 
-- Use IntelliJ Idea run configuration at `../.run/EnrollmentServerApplication.run.xml`
-- Open [http://localhost:8081/enrollment-server/actuator/health](http://localhost:8081/enrollment-server/actuator/health) and you should get `{"status":"UP"}`
+```shell
+mvn clean install
+```
 
 
 ### Database
 
-Database changes are driven by Liquibase.
+* The default DB for development is _PostgreSQL_.
+* Database changes are driven by Liquibase.
 
-This is an example how to manually check the Liquibase status.
+#### Set up
+
+Ensure you have a database installed and running, and that you have an admin account.
+
+##### Create a user and a schema
+
+Start a `psql` session with your superuser:
+
+```shell
+psql -U $(whoami) -d postgres
+```
+
+Then run following commands in the `psql` shell:
+
+```sql
+CREATE USER powerauth WITH PASSWORD 'powerauth';
+CREATE DATABASE powerauth OWNER powerauth;
+```
+
+##### Load the data with Liquibase
+
+This is an example how to invoke Liquibase.
 Important and fixed parameter is `changelog-file`.
 Others (like URL, username, password) depend on your environment.
+
+To list all undeployed changesets run this `status` command. 
 
 ```shell
 liquibase --changelog-file=./docs/db/changelog/changesets/enrollment-server/db.changelog-module.xml --url=jdbc:postgresql://localhost:5432/powerauth --username=powerauth status
 ```
 
-To generate SQL script run this command.
-
-
-#### Oracle
+To apply the changesets run this `update` command.
 
 ```shell
-liquibase --changeLogFile=./docs/db/changelog/changesets/enrollment-server/db.changelog-module.xml --output-file=./docs/sql/oracle/generated-oracle-script.sql updateSQL --url=offline:oracle
+liquibase --changelog-file=./docs/db/changelog/changesets/enrollment-server/db.changelog-module.xml --url=jdbc:postgresql://localhost:5432/powerauth --username=powerauth update
 ```
 
 
-#### MS SQL
+#### Generate SQL script (optional)
 
-```shell
-liquibase --changeLogFile=./docs/db/changelog/changesets/enrollment-server/db.changelog-module.xml --output-file=./docs/sql/mssql/generated-mssql-script.sql updateSQL --url=offline:mssql
-```
-
-
-#### PostgreSQL
+##### PostgreSQL
 
 ```shell
 liquibase --changeLogFile=./docs/db/changelog/changesets/enrollment-server/db.changelog-module.xml --output-file=./docs/sql/postgresql/generated-postgresql-script.sql updateSQL --url=offline:postgresql
 ```
 
-
-### Docker
-
-
-### Build War
+##### Oracle
 
 ```shell
-mvn clean package
+liquibase --changeLogFile=./docs/db/changelog/changesets/enrollment-server/db.changelog-module.xml --output-file=./docs/sql/oracle/generated-oracle-script.sql updateSQL --url=offline:oracle
 ```
 
-
-### Build the docker image
+##### MS SQL
 
 ```shell
-docker build . -t enrollment-server:1.9.0
+liquibase --changeLogFile=./docs/db/changelog/changesets/enrollment-server/db.changelog-module.xml --output-file=./docs/sql/mssql/generated-mssql-script.sql updateSQL --url=offline:mssql
 ```
 
 
@@ -67,6 +90,52 @@ docker build . -t enrollment-server:1.9.0
 
 * Copy `deploy/env.list.tmp` to `./env.list` and edit the values to use it via `docker run --env-file env.list enrollment-server:1.9.0`
 * Or set environment variables via `docker run -e ENROLLMENT_SERVER_DATASOURCE_USERNAME='powerauth' enrollment-server:1.9.0`
+
+
+### Run
+
+The working directory is `enrollment-server`.
+
+#### CLI
+
+```shell
+java -jar target/enrollment-server-x.y.z.war
+```
+
+#### Maven
+
+```shell
+mvn spring-boot:run
+```
+
+#### IntelliJ Idea
+
+* Use IntelliJ Idea run configuration at `../.run/EnrollmentServerApplication.run.xml`
+* Open [http://localhost:8081/enrollment-server/actuator/health](http://localhost:8081/enrollment-server/actuator/health) and you should get `{"status":"UP"}`
+
+### Smoke test
+
+Run following `curl` command:
+
+```shell
+curl -v http://localhost:8080/actuator/health
+```
+
+You should get response: `200 {"status":"UP"}`
+
+You can check other APIs on:
+
+* http://localhost:8080/swagger-ui/index.html
+
+
+### Docker
+
+### Build the docker image
+
+```shell
+docker build . -t enrollment-server:1.9.0
+```
+
 
 
 ### Run the docker image

--- a/docs-private/Developer-How-To-Start.md
+++ b/docs-private/Developer-How-To-Start.md
@@ -43,7 +43,7 @@ Ensure you have a database installed and running, and that you have an admin acc
 Start a `psql` session with your superuser:
 
 ```shell
-psql -U postgres -d postgres
+psql -U $(whoami) -d postgres
 ```
 
 Then run following commands in the `psql` shell:

--- a/docs-private/Developer-How-To-Start.md
+++ b/docs-private/Developer-How-To-Start.md
@@ -3,7 +3,8 @@
 ## General prerequisites
 
 Following are _minimal_ versions of the tools and technologies used in the development
-of the PowerAuth Server. You can use higher versions, but make sure to check the compatibility.
+of the Enrollment Server project. You can use higher versions, but make sure to check
+the compatibility.
 
 * _JDK_ version 21.x
 * _Maven_ version 3.9.x
@@ -52,7 +53,7 @@ This is an example how to invoke Liquibase.
 Important and fixed parameter is `changelog-file`.
 Others (like URL, username, password) depend on your environment.
 
-To list all undeployed changesets run this `status` command. 
+To list all undeployed changesets run this `status` command.
 
 ```shell
 liquibase --changelog-file=./docs/db/changelog/changesets/enrollment-server/db.changelog-module.xml --url=jdbc:postgresql://localhost:5432/powerauth --username=powerauth status
@@ -64,6 +65,83 @@ To apply the changesets run this `update` command.
 liquibase --changelog-file=./docs/db/changelog/changesets/enrollment-server/db.changelog-module.xml --url=jdbc:postgresql://localhost:5432/powerauth --username=powerauth update
 ```
 
+
+### Configure
+
+For local development, the provided IntelliJ IDEA run configuration uses the `dev`
+Spring profile together with `enrollment-server/src/main/resources/application-dev.properties`.
+
+Outside this local `dev` setup, the default application configuration enables the `ext`
+profile, so you can override values using `application-ext.properties` or environment
+variables.
+
+Common properties to review for local development:
+
+```properties
+spring.datasource.url=jdbc:postgresql://localhost:5432/powerauth
+spring.datasource.username=powerauth
+spring.datasource.password=
+powerauth.service.url=http://localhost:8080/powerauth-java-server/rest
+powerauth.push.service.url=http://localhost:8080/powerauth-push-server
+enrollment-server.auth-type=BASIC_HTTP
+enrollment-server.admin.enabled=true
+```
+
+For additional details, see:
+
+* [Configuration Properties](../docs/Configuration-Properties.md)
+* [Deploying Enrollment Server](../docs/Deploying-Enrollment-Server.md)
+
+
+### Run
+
+The working directory is `enrollment-server`.
+
+#### CLI
+
+```shell
+java -jar target/enrollment-server-x.y.z.war --spring.profiles.active=dev
+```
+
+#### Maven
+
+```shell
+mvn spring-boot:run -Dspring-boot.run.profiles=dev
+```
+
+#### IntelliJ IDEA
+
+* Use IntelliJ IDEA run configuration at `../.run/EnrollmentServerApplication.run.xml`
+* The provided run configuration starts the server on `http://localhost:8081/enrollment-server`
+
+
+### Smoke test
+
+If you use the provided IntelliJ IDEA run configuration, run:
+
+```shell
+curl -v http://localhost:8081/enrollment-server/actuator/health
+```
+
+If you run the server directly from CLI or Maven without extra server parameters, run:
+
+```shell
+curl -v http://localhost:8080/actuator/health
+```
+
+You should get response: `200 {"status":"UP"}`
+
+You can check other APIs on:
+
+* http://localhost:8080/swagger-ui/index.html
+* http://localhost:8081/enrollment-server/swagger-ui/index.html
+
+
+### Schema Diagram
+
+For database structure overview, see:
+
+* [Database Structure](../docs/Database-Structure.md)
 
 #### Generate SQL script (optional)
 
@@ -92,30 +170,119 @@ liquibase --changeLogFile=./docs/db/changelog/changesets/enrollment-server/db.ch
 * Or set environment variables via `docker run -e ENROLLMENT_SERVER_DATASOURCE_USERNAME='powerauth' enrollment-server:1.9.0`
 
 
+### Docker
+
+#### Build the docker image
+
+```shell
+docker build . -t enrollment-server:1.9.0
+```
+
+#### Run the docker image
+
+```shell
+docker run -p 80:8080 -e ENROLLMENT_SERVER_DATASOURCE_URL='jdbc:postgresql://host.docker.internal:5432/powerauth' -e ENROLLMENT_SERVER_DATASOURCE_USERNAME='powerauth' -e ENROLLMENT_SERVER_DATASOURCE_PASSWORD='' enrollment-server:1.9.0
+```
+
+
+## Enrollment Server Onboarding
+
+### Build
+
+Build with:
+
+```shell
+mvn clean install
+```
+
+
+### Database
+
+* The default DB for development is _PostgreSQL_.
+* Database changes are driven by Liquibase.
+* If you already created the `powerauth` database and user for Enrollment Server, you can reuse them here.
+
+#### Set up
+
+If you have not created the database and user yet, use the same PostgreSQL setup as in the Enrollment Server section.
+
+##### Load the data with Liquibase
+
+This is an example how to invoke Liquibase.
+Important and fixed parameter is `changelog-file`.
+Others (like URL, username, password) depend on your environment.
+
+To list all undeployed changesets run this `status` command.
+
+```shell
+liquibase --changelog-file=./docs/db/changelog/changesets/enrollment-server-onboarding/db.changelog-module.xml --url=jdbc:postgresql://localhost:5432/powerauth --username=powerauth status
+```
+
+To apply the changesets run this `update` command.
+
+```shell
+liquibase --changelog-file=./docs/db/changelog/changesets/enrollment-server-onboarding/db.changelog-module.xml --url=jdbc:postgresql://localhost:5432/powerauth --username=powerauth update
+```
+
+
+### Configure
+
+For local development, the provided IntelliJ IDEA run configuration uses the `dev`
+Spring profile together with `enrollment-server-onboarding/src/main/resources/application-dev.properties`.
+
+Outside this local `dev` setup, the default application configuration enables the `ext`
+profile, so you can override values using `application-ext.properties` or environment
+variables.
+
+Common properties to review for local development:
+
+```properties
+spring.datasource.url=jdbc:postgresql://localhost:5432/powerauth
+spring.datasource.username=powerauth
+spring.datasource.password=
+powerauth.service.url=http://localhost:8080/powerauth-java-server/rest
+enrollment-server-onboarding.security.auth-type=BASIC_AUTH
+enrollment-server-onboarding.identity-verification.enabled=true
+enrollment-server-onboarding.document-verification.provider=mock
+```
+
+For additional details, see:
+
+* [Configuration Properties](../docs/onboarding/Configuration-Properties.md)
+* [Deploying Onboarding Server](../docs/onboarding/Deploying-Onboarding-Server.md)
+
+
 ### Run
 
-The working directory is `enrollment-server`.
+The working directory is `enrollment-server-onboarding`.
 
 #### CLI
 
 ```shell
-java -jar target/enrollment-server-x.y.z.war
+java -jar target/enrollment-server-onboarding-x.y.z.war --spring.profiles.active=dev
 ```
 
 #### Maven
 
 ```shell
-mvn spring-boot:run
+mvn spring-boot:run -Dspring-boot.run.profiles=dev
 ```
 
-#### IntelliJ Idea
+#### IntelliJ IDEA
 
-* Use IntelliJ Idea run configuration at `../.run/EnrollmentServerApplication.run.xml`
-* Open [http://localhost:8081/enrollment-server/actuator/health](http://localhost:8081/enrollment-server/actuator/health) and you should get `{"status":"UP"}`
+* Use IntelliJ IDEA run configuration at `../.run/EnrollmentServerOnboardingApplication.run.xml`
+* The provided run configuration starts the server on `http://localhost:8083/enrollment-server-onboarding`
+
 
 ### Smoke test
 
-Run following `curl` command:
+If you use the provided IntelliJ IDEA run configuration, run:
+
+```shell
+curl -v http://localhost:8083/enrollment-server-onboarding/actuator/health
+```
+
+If you run the server directly from CLI or Maven without extra server parameters, run:
 
 ```shell
 curl -v http://localhost:8080/actuator/health
@@ -126,64 +293,30 @@ You should get response: `200 {"status":"UP"}`
 You can check other APIs on:
 
 * http://localhost:8080/swagger-ui/index.html
+* http://localhost:8083/enrollment-server-onboarding/swagger-ui/index.html
 
 
-### Docker
+### Schema Diagram
 
-### Build the docker image
+For database structure overview, see:
 
-```shell
-docker build . -t enrollment-server:1.9.0
-```
+* [Database Structure](../docs/onboarding/Database-Structure.md)
 
+#### Generate SQL script (optional)
 
-
-### Run the docker image
-
-```shell
-docker run -p 80:8080 -e ENROLLMENT_SERVER_DATASOURCE_URL='jdbc:postgresql://host.docker.internal:5432/powerauth' -e ENROLLMENT_SERVER_DATASOURCE_USERNAME='powerauth' -e ENROLLMENT_SERVER_DATASOURCE_PASSWORD='' enrollment-server:1.9.0
-```
-
-
-## Enrollment Server Onboarding
-
-
-### Standalone Run
-
-- Use IntelliJ Idea run configuration at `../.run/EnrollmentServerOnboardingApplication.run.xml`
-- Open [http://localhost:8083/enrollment-server-onboarding/actuator/health](http://localhost:8083/enrollment-server-onboarding/actuator/health) and you should get `{"status":"UP"}`
-
-
-### Database
-
-Database changes are driven by Liquibase.
-
-This is an example how to manually check the Liquibase status.
-Important and fixed parameter is `changelog-file`.
-Others (like URL, username, password) depend on your environment.
-
-```shell
-liquibase --changelog-file=./docs/db/changelog/changesets/enrollment-server-onboarding/db.changelog-module.xml --url=jdbc:postgresql://localhost:5432/powerauth --username=powerauth status
-``` 
-
-To generate SQL script run this command.
-
-
-#### Oracle
+##### Oracle
 
 ```shell
 liquibase --changeLogFile=./docs/db/changelog/changesets/enrollment-server-onboarding/db.changelog-module.xml --output-file=./docs/sql/oracle/generated-oracle-script.sql updateSQL --url=offline:oracle
 ```
 
-
-#### MS SQL
+##### MS SQL
 
 ```shell
 liquibase --changeLogFile=./docs/db/changelog/changesets/enrollment-server-onboarding/db.changelog-module.xml --output-file=./docs/sql/mssql/generated-mssql-script.sql updateSQL --url=offline:mssql
 ```
 
-
-#### PostgreSQL
+##### PostgreSQL
 
 ```shell
 liquibase --changeLogFile=./docs/db/changelog/changesets/enrollment-server-onboarding/db.changelog-module.xml --output-file=./docs/sql/postgresql/generated-postgresql-script.sql updateSQL --url=offline:postgresql


### PR DESCRIPTION
## Summary
- align the developer getting started guide with the canonical PowerAuth guide structure
- keep Enrollment Server and Onboarding specific setup, configuration, and smoke-test details
- add missing Liquibase and local development guidance

## Testing
- not run (documentation-only changes)