### PR TITLE
Resolves #1640: Remove or mask password in application-dev.properties

### DIFF
--- a/enrollment-server-onboarding/src/main/resources/application-dev.properties
+++ b/enrollment-server-onboarding/src/main/resources/application-dev.properties
@@ -7,7 +7,8 @@ spring.liquibase.change-log=classpath:db/changelog/db.changelog-module.xml
 enrollment-server-onboarding.onboarding-process.default-type=onboarding
 
 spring.security.user.name=admin
-spring.security.user.password={bcrypt}$2a$10$Im45aSJeMpove4pF8/ypB.ufkITjfjpFvby9AMkvy.hrOVixkfkxq
+# Override locally if you need a different development password.
+spring.security.user.password=${ENROLLMENT_SERVER_ONBOARDING_DEV_SECURITY_USER_PASSWORD:{noop}changeit}
 
 logging.level.com.wultra=DEBUG
 logging.level.com.wultra.core.audit=INFO

--- a/enrollment-server/src/main/resources/application-dev.properties
+++ b/enrollment-server/src/main/resources/application-dev.properties
@@ -6,7 +6,8 @@ enrollment-server.admin.enabled=true
 enrollment-server.auth-type=BASIC_HTTP
 
 spring.security.user.name=admin
-spring.security.user.password={bcrypt}$2a$10$Im45aSJeMpove4pF8/ypB.ufkITjfjpFvby9AMkvy.hrOVixkfkxq
+# Override locally if you need a different development password.
+spring.security.user.password=${ENROLLMENT_SERVER_DEV_SECURITY_USER_PASSWORD:{noop}changeit}
 
 logging.level.com.wultra=DEBUG
 logging.level.com.wultra.core.audit=INFO


### PR DESCRIPTION
## Summary
- remove the hardcoded encoded development password from both application-dev.properties files
- replace it with overridable development defaults for Enrollment Server and Onboarding
- keep local basic auth usable without storing the previous hash in source control

## Testing
- mvn -q -pl enrollment-server,enrollment-server-onboarding -am -DskipTests -Dmaven.javadoc.skip=true package