### PR TITLE
Fix #1657: Set subject id to the audit log records

### DIFF
--- a/docs/Migration-Instructions.md
+++ b/docs/Migration-Instructions.md
@@ -2,6 +2,7 @@
 
 This page contains PowerAuth Enrollment Server migration instructions.
 
+- [PowerAuth Enrollment Server 2.1.0](./PowerAuth-Enrollment-Server-2.1.0.md)
 - [PowerAuth Enrollment Server 2.0.0](./PowerAuth-Enrollment-Server-2.0.0.md)
 - [PowerAuth Enrollment Server 1.10.0](./PowerAuth-Enrollment-Server-1.10.0.md)
 - [PowerAuth Enrollment Server 1.9.0](./PowerAuth-Enrollment-Server-1.9.0.md)

--- a/docs/PowerAuth-Enrollment-Server-2.1.0.md
+++ b/docs/PowerAuth-Enrollment-Server-2.1.0.md
@@ -1,0 +1,20 @@
+# Migration from 2.0.x to 2.1.x
+
+This guide contains instructions for migration from PowerAuth Enrollment Server version `2.0.x` to version `2.1.0`.
+
+## Database Changes
+
+For convenience, you can use liquibase for your database migration.
+
+For manual changes use SQL scripts:
+
+- [PostgreSQL script](./sql/postgresql/enrollment/migration_2.0.0_2.1.0.sql)
+- [Oracle script](./sql/oracle/enrollment/migration_2.0.0_2.1.0.sql)
+
+### Add Column subject_id to audit_log table
+
+Added a new indexed column `subject_id` holding an identifier linking the audit record to an entity it is related to (e.g. user ID for user-related audit records).
+
+<!-- begin box warning -->
+The auditing tables may be already updated in your database schema if the database schema is not separated for different PowerAuth applications. In case the column `audit_log.subject_id` and its index `audit_log_subject_id_idx` are already present, you can safely skip this migration step.
+<!-- end -->

--- a/docs/db/changelog/changesets/enrollment-server-onboarding/2.1.x/20260330-audit-subject-id.xml
+++ b/docs/db/changelog/changesets/enrollment-server-onboarding/2.1.x/20260330-audit-subject-id.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.33.xsd">
+
+    <changeSet id="1" logicalFilePath="enrollment-server-onboarding/2.1.x/20260330-audit-subject-id.xml" author="Pavel Sindelar">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="audit_log" columnName="subject_id"/>
+            </not>
+        </preConditions>
+        <comment>Add subject_id column to audit_log table</comment>
+        <addColumn tableName="audit_log">
+            <column name="subject_id" type="varchar(256)"/>
+        </addColumn>
+        <!-- no rollback on purpose, the audit tables may be shared across several components -->
+        <rollback />
+    </changeSet>
+
+    <changeSet id="2" logicalFilePath="enrollment-server-onboarding/2.1.x/20260330-audit-subject-id.xml" author="Pavel Sindelar">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <indexExists tableName="audit_log" indexName="audit_log_subject_id_idx"/>
+            </not>
+        </preConditions>
+        <comment>Create a new index on audit_log(subject_id)</comment>
+        <createIndex tableName="audit_log" indexName="audit_log_subject_id_idx">
+            <column name="subject_id"/>
+        </createIndex>
+        <!-- no rollback on purpose, the audit tables may be shared across several components -->
+        <rollback />
+    </changeSet>
+
+</databaseChangeLog>

--- a/docs/db/changelog/changesets/enrollment-server-onboarding/2.1.x/db.changelog-version.xml
+++ b/docs/db/changelog/changesets/enrollment-server-onboarding/2.1.x/db.changelog-version.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd">
+
+    <include file="20260330-audit-subject-id.xml" relativeToChangelogFile="true" />
+
+</databaseChangeLog>

--- a/docs/db/changelog/changesets/enrollment-server-onboarding/db.changelog-module.xml
+++ b/docs/db/changelog/changesets/enrollment-server-onboarding/db.changelog-module.xml
@@ -16,5 +16,6 @@
     <include file="1.5.x/db.changelog-version.xml" relativeToChangelogFile="true" />
     <include file="1.7.x/db.changelog-version.xml" relativeToChangelogFile="true" />
     <include file="2.0.x/db.changelog-version.xml" relativeToChangelogFile="true" />
+    <include file="2.1.x/db.changelog-version.xml" relativeToChangelogFile="true" />
 
 </databaseChangeLog>

--- a/docs/db/changelog/changesets/enrollment-server/2.1.x/20260330-audit-subject-id.xml
+++ b/docs/db/changelog/changesets/enrollment-server/2.1.x/20260330-audit-subject-id.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd">
+
+    <changeSet id="1" logicalFilePath="enrollment-server/2.1.x/20260330-audit-subject-id.xml" author="Pavel Sindelar">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="audit_log" columnName="subject_id"/>
+            </not>
+        </preConditions>
+        <comment>Add subject_id column to audit_log table</comment>
+        <addColumn tableName="audit_log">
+            <column name="subject_id" type="varchar(256)"/>
+        </addColumn>
+        <!-- no rollback on purpose, the audit tables may be shared across several components -->
+        <rollback />
+    </changeSet>
+
+    <changeSet id="2" logicalFilePath="enrollment-server/2.1.x/20260330-audit-subject-id.xml" author="Pavel Sindelar">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <indexExists tableName="audit_log" indexName="audit_log_subject_id_idx"/>
+            </not>
+        </preConditions>
+        <comment>Create a new index on audit_log(subject_id)</comment>
+        <createIndex tableName="audit_log" indexName="audit_log_subject_id_idx">
+            <column name="subject_id"/>
+        </createIndex>
+        <!-- no rollback on purpose, the audit tables may be shared across several components -->
+        <rollback />
+    </changeSet>
+
+</databaseChangeLog>

--- a/docs/db/changelog/changesets/enrollment-server/2.1.x/db.changelog-version.xml
+++ b/docs/db/changelog/changesets/enrollment-server/2.1.x/db.changelog-version.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd">
+
+    <include file="20260330-audit-subject-id.xml" relativeToChangelogFile="true" />
+
+</databaseChangeLog>

--- a/docs/db/changelog/changesets/enrollment-server/db.changelog-module.xml
+++ b/docs/db/changelog/changesets/enrollment-server/db.changelog-module.xml
@@ -11,5 +11,6 @@
     <include file="1.4.x/db.changelog-version.xml" relativeToChangelogFile="true" />
     <include file="1.5.x/db.changelog-version.xml" relativeToChangelogFile="true" />
     <include file="1.8.x/db.changelog-version.xml" relativeToChangelogFile="true" />
+    <include file="2.1.x/db.changelog-version.xml" relativeToChangelogFile="true" />
 
 </databaseChangeLog>

--- a/docs/onboarding/Migration-Instructions.md
+++ b/docs/onboarding/Migration-Instructions.md
@@ -2,6 +2,7 @@
 
 This page contains PowerAuth Enrollment Onboarding Server migration instructions.
 
+- [PowerAuth Enrollment Onboarding Server 2.1.0](./PowerAuth-Enrollment-Onboarding-Server-2.1.0.md)
 - [PowerAuth Enrollment Onboarding Server 2.0.0](./PowerAuth-Enrollment-Onboarding-Server-2.0.0.md)
 - [PowerAuth Enrollment Onboarding Server 1.9.0](./PowerAuth-Enrollment-Onboarding-Server-1.9.0.md)
 - [PowerAuth Enrollment Onboarding Server 1.8.0](./PowerAuth-Enrollment-Onboarding-Server-1.8.0.md)

--- a/docs/onboarding/PowerAuth-Enrollment-Onboarding-Server-2.1.0.md
+++ b/docs/onboarding/PowerAuth-Enrollment-Onboarding-Server-2.1.0.md
@@ -1,0 +1,20 @@
+# Migration from 2.0.x to 2.1.x
+
+This guide contains instructions for migration from PowerAuth Enrollment Onboarding Server version `2.0.x` to version `2.1.0`.
+
+## Database Changes
+
+For convenience, you can use liquibase for your database migration.
+
+For manual changes use SQL scripts:
+
+- [PostgreSQL script](./../sql/postgresql/onboarding/migration_2.0.0_2.1.0.sql)
+- [Oracle script](./../sql/oracle/onboarding/migration_2.0.0_2.1.0.sql)
+
+### Add Column subject_id to audit_log table
+
+Added a new indexed column `subject_id` holding an identifier linking the audit record to an entity it is related to (e.g. user ID for user-related audit records).
+
+<!-- begin box warning -->
+The auditing tables may be already updated in your database schema if the database schema is not separated for different PowerAuth applications. In case the column `audit_log.subject_id` and its index `audit_log_subject_id_idx` are already present, you can safely skip this migration step.
+<!-- end -->

--- a/docs/sql/oracle/enrollment/migration_2.0.0_2.1.0.sql
+++ b/docs/sql/oracle/enrollment/migration_2.0.0_2.1.0.sql
@@ -1,0 +1,7 @@
+-- Changeset enrollment-server/2.1.x/20260330-audit-subject-id.xml::1::Pavel Sindelar
+-- Add subject_id column to audit_log table
+ALTER TABLE audit_log ADD subject_id VARCHAR2(256);
+
+-- Changeset enrollment-server/2.1.x/20260330-audit-subject-id.xml::2::Pavel Sindelar
+-- Create a new index on audit_log(subject_id)
+CREATE INDEX audit_log_subject_id_idx ON audit_log(subject_id);

--- a/docs/sql/oracle/onboarding/create-schema.sql
+++ b/docs/sql/oracle/onboarding/create-schema.sql
@@ -364,3 +364,12 @@ CREATE INDEX es_processed_document_data_document_verification_id_idx ON es_proce
 -- Changeset enrollment-server-onboarding/2.0.x/20260313-consent-accepted.xml::1::Michal Rozehnal
 -- Creates a new column consent_accepted in es_onboarding_process
 ALTER TABLE es_onboarding_process ADD consent_accepted BOOLEAN;
+
+-- Changeset enrollment-server-onboarding/2.0.x/20251215-add-tag-2.0.0.xml::1::Lubos Racansky
+-- Changeset enrollment-server-onboarding/2.1.x/20260330-audit-subject-id.xml::1::Pavel Sindelar
+-- Add subject_id column to audit_log table
+ALTER TABLE audit_log ADD subject_id VARCHAR2(256);
+
+-- Changeset enrollment-server-onboarding/2.1.x/20260330-audit-subject-id.xml::2::Pavel Sindelar
+-- Create a new index on audit_log(subject_id)
+CREATE INDEX audit_log_subject_id_idx ON audit_log(subject_id);

--- a/docs/sql/oracle/onboarding/migration_2.0.0_2.1.0.sql
+++ b/docs/sql/oracle/onboarding/migration_2.0.0_2.1.0.sql
@@ -1,0 +1,8 @@
+-- Changeset enrollment-server-onboarding/2.0.x/20251215-add-tag-2.0.0.xml::1::Lubos Racansky
+-- Changeset enrollment-server-onboarding/2.1.x/20260330-audit-subject-id.xml::1::Pavel Sindelar
+-- Add subject_id column to audit_log table
+ALTER TABLE audit_log ADD subject_id VARCHAR2(256);
+
+-- Changeset enrollment-server-onboarding/2.1.x/20260330-audit-subject-id.xml::2::Pavel Sindelar
+-- Create a new index on audit_log(subject_id)
+CREATE INDEX audit_log_subject_id_idx ON audit_log(subject_id);

--- a/docs/sql/postgresql/enrollment/migration_2.0.0_2.1.0.sql
+++ b/docs/sql/postgresql/enrollment/migration_2.0.0_2.1.0.sql
@@ -1,0 +1,7 @@
+-- Changeset enrollment-server/2.1.x/20260330-audit-subject-id.xml::1::Pavel Sindelar
+-- Add subject_id column to audit_log table
+ALTER TABLE audit_log ADD subject_id VARCHAR(256);
+
+-- Changeset enrollment-server/2.1.x/20260330-audit-subject-id.xml::2::Pavel Sindelar
+-- Create a new index on audit_log(subject_id)
+CREATE INDEX audit_log_subject_id_idx ON audit_log(subject_id);

--- a/docs/sql/postgresql/onboarding/create-schema.sql
+++ b/docs/sql/postgresql/onboarding/create-schema.sql
@@ -341,3 +341,12 @@ CREATE INDEX es_processed_document_data_document_verification_id_idx ON es_proce
 -- Changeset enrollment-server-onboarding/2.0.x/20260313-consent-accepted.xml::1::Michal Rozehnal
 -- Creates a new column consent_accepted in es_onboarding_process
 ALTER TABLE es_onboarding_process ADD consent_accepted BOOLEAN;
+
+-- Changeset enrollment-server-onboarding/2.0.x/20251215-add-tag-2.0.0.xml::1::Lubos Racansky
+-- Changeset enrollment-server-onboarding/2.1.x/20260330-audit-subject-id.xml::1::Pavel Sindelar
+-- Add subject_id column to audit_log table
+ALTER TABLE audit_log ADD subject_id VARCHAR(256);
+
+-- Changeset enrollment-server-onboarding/2.1.x/20260330-audit-subject-id.xml::2::Pavel Sindelar
+-- Create a new index on audit_log(subject_id)
+CREATE INDEX audit_log_subject_id_idx ON audit_log(subject_id);

--- a/docs/sql/postgresql/onboarding/migration_2.0.0_2.1.0.sql
+++ b/docs/sql/postgresql/onboarding/migration_2.0.0_2.1.0.sql
@@ -1,0 +1,8 @@
+-- Changeset enrollment-server-onboarding/2.0.x/20251215-add-tag-2.0.0.xml::1::Lubos Racansky
+-- Changeset enrollment-server-onboarding/2.1.x/20260330-audit-subject-id.xml::1::Pavel Sindelar
+-- Add subject_id column to audit_log table
+ALTER TABLE audit_log ADD subject_id VARCHAR(256);
+
+-- Changeset enrollment-server-onboarding/2.1.x/20260330-audit-subject-id.xml::2::Pavel Sindelar
+-- Create a new index on audit_log(subject_id)
+CREATE INDEX audit_log_subject_id_idx ON audit_log(subject_id);

--- a/enrollment-server-onboarding-common/src/test/java/com/wultra/app/onboardingserver/common/service/AuditServiceTest.java
+++ b/enrollment-server-onboarding-common/src/test/java/com/wultra/app/onboardingserver/common/service/AuditServiceTest.java
@@ -19,6 +19,10 @@ package com.wultra.app.onboardingserver.common.service;
 
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.wultra.app.enrollmentserver.model.integration.OwnerId;
+import com.wultra.app.onboardingserver.common.database.entity.DocumentVerificationEntity;
+import com.wultra.app.onboardingserver.common.database.entity.IdentityVerificationEntity;
+import com.wultra.app.onboardingserver.common.database.entity.OnboardingOtpEntity;
+import com.wultra.app.onboardingserver.common.database.entity.OnboardingProcessEntity;
 import com.wultra.core.audit.base.Audit;
 import com.wultra.core.audit.base.model.AuditDetail;
 import org.junit.jupiter.api.Test;
@@ -32,6 +36,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 
@@ -43,14 +48,35 @@ import static org.mockito.Mockito.verify;
 @ExtendWith(MockitoExtension.class)
 class AuditServiceTest {
 
-    private static final String DOCUMENT_VERIFICATION_PROVIDER_CODE = "documentVerificationProvider";
+    private static final String TYPE_PROCESS = "process";
+    private static final String TYPE_OTP = "otp";
+    private static final String TYPE_IDENTITY_VERIFICATION = "identityVerification";
+    private static final String TYPE_ACTIVATION = "activation";
+    private static final String TYPE_DOCUMENT_VERIFICATION = "documentVerification";
+    private static final String TYPE_PRESENCE_CHECK_PROVIDER = "presenceCheckProvider";
+    private static final String TYPE_DOCUMENT_VERIFICATION_PROVIDER = "documentVerificationProvider";
+    private static final String TYPE_ONBOARDING_PROVIDER = "onboardingProvider";
 
+    private static final String IDENTITY_VERIFICATION_ID_PARAM = "identityVerificationId";
+    private static final String PROCESS_ID_PARAM = "processId";
     private static final String ACTIVATION_ID_PARAM = "activationId";
+    private static final String TARGET_ACTIVATION_ID_PARAM = "targetActivationId";
     private static final String USER_ID_PARAM = "userId";
+    private static final String OTP_ID_PARAM = "otpId";
+    private static final String DOCUMENT_ID_PARAM = "documentId";
+    private static final String DOCUMENT_VERIFICATION_ID_PARAM = "documentVerificationId";
     private static final String DOCUMENT_RESPONSE_JSON_PARAM = "documentResponseJson";
 
-    private static final String ACTIVATION_ID = "test-activation-id";
+    private static final String PROCESS_ID = "test-process-id";
     private static final String USER_ID = "test-user-id";
+    private static final String ACTIVATION_ID = "test-activation-id";
+    private static final String TARGET_ACTIVATION_ID = "test-target-activation-id";
+    private static final String IDENTITY_VERIFICATION_ID = "test-identity-verification-id";
+    private static final String OTP_ID = "test-otp-id";
+    private static final String DOCUMENT_ID = "test-document-id";
+    private static final String DOCUMENT_VERIFICATION_ID = "test-document-verification-id";
+
+    private static final String MESSAGE = "Test message";
 
     @Mock
     private Audit audit;
@@ -62,30 +88,323 @@ class AuditServiceTest {
     private ArgumentCaptor<AuditDetail> auditDetailCaptor;
 
     @Test
-    void testAuditDocumentVerificationProvider() {
-        // given
-        final var ownerId = new OwnerId();
+    void testAuditProcess() {
+        final OnboardingProcessEntity process = createProcess();
+
+        tested.audit(process, MESSAGE);
+
+        verify(audit).info(eq(MESSAGE), auditDetailCaptor.capture(), any(Object[].class));
+        final AuditDetail auditDetail = auditDetailCaptor.getValue();
+        assertEquals(TYPE_PROCESS, auditDetail.getType());
+        assertEquals(Map.of(
+                PROCESS_ID_PARAM, PROCESS_ID,
+                ACTIVATION_ID_PARAM, ACTIVATION_ID,
+                TARGET_ACTIVATION_ID_PARAM, TARGET_ACTIVATION_ID,
+                USER_ID_PARAM, USER_ID
+        ), auditDetail.getParam());
+    }
+
+    @Test
+    void testAuditProcessWithoutOptionalFields() {
+        final OnboardingProcessEntity process = new OnboardingProcessEntity();
+        process.setId(PROCESS_ID);
+        process.setUserId(USER_ID);
+
+        tested.audit(process, MESSAGE);
+
+        verify(audit).info(eq(MESSAGE), auditDetailCaptor.capture(), any(Object[].class));
+        final AuditDetail auditDetail = auditDetailCaptor.getValue();
+        assertEquals(TYPE_PROCESS, auditDetail.getType());
+        assertEquals(Map.of(
+                PROCESS_ID_PARAM, PROCESS_ID,
+                USER_ID_PARAM, USER_ID
+        ), auditDetail.getParam());
+    }
+
+    @Test
+    void testAuditProcessWithIdentityVerification() {
+        final OnboardingProcessEntity process = createProcess();
+        final IdentityVerificationEntity identityVerification = createIdentityVerification();
+
+        tested.audit(process, identityVerification, MESSAGE);
+
+        verify(audit).info(eq(MESSAGE), auditDetailCaptor.capture(), any(Object[].class));
+        final AuditDetail auditDetail = auditDetailCaptor.getValue();
+        assertEquals(TYPE_PROCESS, auditDetail.getType());
+        assertEquals(Map.of(
+                PROCESS_ID_PARAM, PROCESS_ID,
+                IDENTITY_VERIFICATION_ID_PARAM, IDENTITY_VERIFICATION_ID,
+                ACTIVATION_ID_PARAM, ACTIVATION_ID,
+                TARGET_ACTIVATION_ID_PARAM, TARGET_ACTIVATION_ID,
+                USER_ID_PARAM, USER_ID
+        ), auditDetail.getParam());
+    }
+
+    @Test
+    void testAuditOtpWithIdentityVerification() {
+        final OnboardingProcessEntity process = createProcess();
+        final OnboardingOtpEntity otp = createOtp(process);
+        final IdentityVerificationEntity identityVerification = createIdentityVerification();
+
+        tested.audit(otp, identityVerification, MESSAGE);
+
+        verify(audit).info(eq(MESSAGE), auditDetailCaptor.capture(), any(Object[].class));
+        final AuditDetail auditDetail = auditDetailCaptor.getValue();
+        assertEquals(TYPE_OTP, auditDetail.getType());
+        assertEquals(Map.of(
+                IDENTITY_VERIFICATION_ID_PARAM, IDENTITY_VERIFICATION_ID,
+                PROCESS_ID_PARAM, PROCESS_ID,
+                ACTIVATION_ID_PARAM, ACTIVATION_ID,
+                USER_ID_PARAM, USER_ID,
+                OTP_ID_PARAM, OTP_ID
+        ), auditDetail.getParam());
+    }
+
+    @Test
+    void testAuditOtp() {
+        final OnboardingProcessEntity process = createProcess();
+        final OnboardingOtpEntity otp = createOtp(process);
+
+        tested.audit(otp, MESSAGE);
+
+        verify(audit).info(eq(MESSAGE), auditDetailCaptor.capture(), any(Object[].class));
+        final AuditDetail auditDetail = auditDetailCaptor.getValue();
+        assertEquals(TYPE_OTP, auditDetail.getType());
+        assertEquals(Map.of(
+                ACTIVATION_ID_PARAM, ACTIVATION_ID,
+                PROCESS_ID_PARAM, PROCESS_ID,
+                USER_ID_PARAM, USER_ID,
+                OTP_ID_PARAM, OTP_ID
+        ), auditDetail.getParam());
+    }
+
+    @Test
+    void testAuditDebugOtp() {
+        final OnboardingProcessEntity process = createProcess();
+        final OnboardingOtpEntity otp = createOtp(process);
+
+        tested.auditDebug(otp, MESSAGE);
+
+        verify(audit).debug(eq(MESSAGE), auditDetailCaptor.capture(), any(Object[].class));
+        final AuditDetail auditDetail = auditDetailCaptor.getValue();
+        assertEquals(TYPE_OTP, auditDetail.getType());
+        assertEquals(Map.of(
+                ACTIVATION_ID_PARAM, ACTIVATION_ID,
+                PROCESS_ID_PARAM, PROCESS_ID,
+                USER_ID_PARAM, USER_ID,
+                OTP_ID_PARAM, OTP_ID
+        ), auditDetail.getParam());
+    }
+
+    @Test
+    void testAuditDocumentVerification() {
+        final IdentityVerificationEntity identityVerification = createIdentityVerification();
+        final DocumentVerificationEntity documentVerification = createDocumentVerification(identityVerification);
+
+        tested.audit(documentVerification, MESSAGE);
+
+        verify(audit).info(eq(MESSAGE), auditDetailCaptor.capture(), any(Object[].class));
+        final AuditDetail auditDetail = auditDetailCaptor.getValue();
+        assertEquals(TYPE_DOCUMENT_VERIFICATION, auditDetail.getType());
+        assertEquals(Map.of(
+                IDENTITY_VERIFICATION_ID_PARAM, IDENTITY_VERIFICATION_ID,
+                PROCESS_ID_PARAM, PROCESS_ID,
+                ACTIVATION_ID_PARAM, ACTIVATION_ID,
+                USER_ID_PARAM, USER_ID,
+                DOCUMENT_ID_PARAM, DOCUMENT_ID,
+                DOCUMENT_VERIFICATION_ID_PARAM, DOCUMENT_VERIFICATION_ID
+        ), auditDetail.getParam());
+    }
+
+    @Test
+    void testAuditDebugDocumentVerification() {
+        final IdentityVerificationEntity identityVerification = createIdentityVerification();
+        final DocumentVerificationEntity documentVerification = createDocumentVerification(identityVerification);
+
+        tested.auditDebug(documentVerification, MESSAGE);
+
+        verify(audit).debug(eq(MESSAGE), auditDetailCaptor.capture(), any(Object[].class));
+        final AuditDetail auditDetail = auditDetailCaptor.getValue();
+        assertEquals(TYPE_DOCUMENT_VERIFICATION, auditDetail.getType());
+        assertEquals(Map.of(
+                IDENTITY_VERIFICATION_ID_PARAM, IDENTITY_VERIFICATION_ID,
+                PROCESS_ID_PARAM, PROCESS_ID,
+                ACTIVATION_ID_PARAM, ACTIVATION_ID,
+                USER_ID_PARAM, USER_ID,
+                DOCUMENT_ID_PARAM, DOCUMENT_ID,
+                DOCUMENT_VERIFICATION_ID_PARAM, DOCUMENT_VERIFICATION_ID
+        ), auditDetail.getParam());
+    }
+
+    @Test
+    void testAuditIdentityVerification() {
+        final IdentityVerificationEntity identityVerification = createIdentityVerification();
+
+        tested.audit(identityVerification, MESSAGE);
+
+        verify(audit).info(eq(MESSAGE), auditDetailCaptor.capture(), any(Object[].class));
+        final AuditDetail auditDetail = auditDetailCaptor.getValue();
+        assertEquals(TYPE_IDENTITY_VERIFICATION, auditDetail.getType());
+        assertEquals(Map.of(
+                IDENTITY_VERIFICATION_ID_PARAM, IDENTITY_VERIFICATION_ID,
+                PROCESS_ID_PARAM, PROCESS_ID,
+                ACTIVATION_ID_PARAM, ACTIVATION_ID,
+                USER_ID_PARAM, USER_ID
+        ), auditDetail.getParam());
+    }
+
+    @Test
+    void testAuditDocumentVerificationProviderWithIdentityVerification() {
+        final IdentityVerificationEntity identityVerification = createIdentityVerification();
+
+        tested.auditDocumentVerificationProvider(identityVerification, MESSAGE);
+
+        verify(audit).info(eq(MESSAGE), auditDetailCaptor.capture(), any(Object[].class));
+        final AuditDetail auditDetail = auditDetailCaptor.getValue();
+        assertEquals(TYPE_DOCUMENT_VERIFICATION_PROVIDER, auditDetail.getType());
+        assertEquals(Map.of(
+                IDENTITY_VERIFICATION_ID_PARAM, IDENTITY_VERIFICATION_ID,
+                PROCESS_ID_PARAM, PROCESS_ID,
+                ACTIVATION_ID_PARAM, ACTIVATION_ID,
+                USER_ID_PARAM, USER_ID
+        ), auditDetail.getParam());
+    }
+
+    @Test
+    void testAuditPresenceCheckProvider() {
+        final IdentityVerificationEntity identityVerification = createIdentityVerification();
+
+        tested.auditPresenceCheckProvider(identityVerification, MESSAGE);
+
+        verify(audit).info(eq(MESSAGE), auditDetailCaptor.capture(), any(Object[].class));
+        final AuditDetail auditDetail = auditDetailCaptor.getValue();
+        assertEquals(TYPE_PRESENCE_CHECK_PROVIDER, auditDetail.getType());
+        assertEquals(Map.of(
+                IDENTITY_VERIFICATION_ID_PARAM, IDENTITY_VERIFICATION_ID,
+                PROCESS_ID_PARAM, PROCESS_ID,
+                ACTIVATION_ID_PARAM, ACTIVATION_ID,
+                USER_ID_PARAM, USER_ID
+        ), auditDetail.getParam());
+    }
+
+    @Test
+    void testAuditActivation() {
+        final OnboardingProcessEntity process = createProcess();
+
+        tested.auditActivation(process, MESSAGE);
+
+        verify(audit).info(eq(MESSAGE), auditDetailCaptor.capture(), any(Object[].class));
+        final AuditDetail auditDetail = auditDetailCaptor.getValue();
+        assertEquals(TYPE_ACTIVATION, auditDetail.getType());
+        assertEquals(Map.of(
+                PROCESS_ID_PARAM, PROCESS_ID,
+                ACTIVATION_ID_PARAM, ACTIVATION_ID,
+                TARGET_ACTIVATION_ID_PARAM, TARGET_ACTIVATION_ID,
+                USER_ID_PARAM, USER_ID
+        ), auditDetail.getParam());
+    }
+
+    @Test
+    void testAuditOnboardingProviderWithProcess() {
+        final OnboardingProcessEntity process = createProcess();
+
+        tested.auditOnboardingProvider(process, MESSAGE);
+
+        verify(audit).info(eq(MESSAGE), auditDetailCaptor.capture(), any(Object[].class));
+        final AuditDetail auditDetail = auditDetailCaptor.getValue();
+        assertEquals(TYPE_ONBOARDING_PROVIDER, auditDetail.getType());
+        assertEquals(Map.of(
+                PROCESS_ID_PARAM, PROCESS_ID,
+                ACTIVATION_ID_PARAM, ACTIVATION_ID,
+                TARGET_ACTIVATION_ID_PARAM, TARGET_ACTIVATION_ID,
+                USER_ID_PARAM, USER_ID
+        ), auditDetail.getParam());
+    }
+
+    @Test
+    void testAuditOnboardingProviderDebug() {
+        final OnboardingProcessEntity process = createProcess();
+
+        tested.auditOnboardingProviderDebug(process, MESSAGE);
+
+        verify(audit).debug(eq(MESSAGE), auditDetailCaptor.capture(), any(Object[].class));
+        final AuditDetail auditDetail = auditDetailCaptor.getValue();
+        assertEquals(TYPE_ONBOARDING_PROVIDER, auditDetail.getType());
+        assertEquals(Map.of(
+                PROCESS_ID_PARAM, PROCESS_ID,
+                ACTIVATION_ID_PARAM, ACTIVATION_ID,
+                TARGET_ACTIVATION_ID_PARAM, TARGET_ACTIVATION_ID,
+                USER_ID_PARAM, USER_ID
+        ), auditDetail.getParam());
+    }
+
+    @Test
+    void testAuditOnboardingProviderWithIdentityVerification() {
+        final IdentityVerificationEntity identityVerification = createIdentityVerification();
+
+        tested.auditOnboardingProvider(identityVerification, MESSAGE);
+
+        verify(audit).info(eq(MESSAGE), auditDetailCaptor.capture(), any(Object[].class));
+        final AuditDetail auditDetail = auditDetailCaptor.getValue();
+        assertEquals(TYPE_ONBOARDING_PROVIDER, auditDetail.getType());
+        assertEquals(Map.of(
+                IDENTITY_VERIFICATION_ID_PARAM, IDENTITY_VERIFICATION_ID,
+                PROCESS_ID_PARAM, PROCESS_ID,
+                ACTIVATION_ID_PARAM, ACTIVATION_ID,
+                USER_ID_PARAM, USER_ID
+        ), auditDetail.getParam());
+    }
+
+    @Test
+    void testAuditDocumentVerificationProviderWithOwnerId() {
+        final OwnerId ownerId = new OwnerId();
         ownerId.setActivationId(ACTIVATION_ID);
         ownerId.setUserId(USER_ID);
 
         final var documentResponseJson = JsonNodeFactory.instance.objectNode();
 
-        final var message = "Test message for user: {}";
+        tested.auditDocumentVerificationProvider(ownerId, documentResponseJson, MESSAGE);
 
-        // when
-        tested.auditDocumentVerificationProvider(ownerId, documentResponseJson, message, USER_ID);
-
-        // then
-        final Map<String, Object> expectedParams = Map.of(
+        verify(audit).info(eq(MESSAGE), auditDetailCaptor.capture(), any(Object[].class));
+        final AuditDetail auditDetail = auditDetailCaptor.getValue();
+        assertEquals(TYPE_DOCUMENT_VERIFICATION_PROVIDER, auditDetail.getType());
+        assertEquals(Map.of(
                 ACTIVATION_ID_PARAM, ACTIVATION_ID,
                 USER_ID_PARAM, USER_ID,
                 DOCUMENT_RESPONSE_JSON_PARAM, documentResponseJson
-        );
+        ), auditDetail.getParam());
+    }
 
-        verify(audit).info(eq(message), auditDetailCaptor.capture(), eq(USER_ID));
+    private static OnboardingProcessEntity createProcess() {
+        final OnboardingProcessEntity process = new OnboardingProcessEntity();
+        process.setId(PROCESS_ID);
+        process.setUserId(USER_ID);
+        process.setActivationId(ACTIVATION_ID);
+        process.setTargetActivationId(TARGET_ACTIVATION_ID);
+        return process;
+    }
 
-        final var auditDetail = auditDetailCaptor.getValue();
-        assertEquals(DOCUMENT_VERIFICATION_PROVIDER_CODE, auditDetail.getType());
-        assertEquals(expectedParams, auditDetail.getParam());
+    private static IdentityVerificationEntity createIdentityVerification() {
+        final IdentityVerificationEntity identityVerification = new IdentityVerificationEntity();
+        identityVerification.setId(IDENTITY_VERIFICATION_ID);
+        identityVerification.setProcessId(PROCESS_ID);
+        identityVerification.setActivationId(ACTIVATION_ID);
+        identityVerification.setUserId(USER_ID);
+        return identityVerification;
+    }
+
+    private static OnboardingOtpEntity createOtp(final OnboardingProcessEntity process) {
+        final OnboardingOtpEntity otp = new OnboardingOtpEntity();
+        otp.setId(OTP_ID);
+        otp.setProcess(process);
+        return otp;
+    }
+
+    private static DocumentVerificationEntity createDocumentVerification(final IdentityVerificationEntity identityVerification) {
+        final DocumentVerificationEntity documentVerification = new DocumentVerificationEntity();
+        documentVerification.setId(DOCUMENT_ID);
+        documentVerification.setVerificationId(DOCUMENT_VERIFICATION_ID);
+        documentVerification.setIdentityVerification(identityVerification);
+        return documentVerification;
     }
 }

--- a/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/impl/service/ActivationCodeService.java
+++ b/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/impl/service/ActivationCodeService.java
@@ -132,6 +132,7 @@ public class ActivationCodeService {
         final String userId = response.getUserId();
         final AuditDetail auditDetail = AuditDetail.builder()
                 .type("activation")
+                .subjectId(userId)
                 .param("activationId", response.getActivationId())
                 .param("userId", userId)
                 .build();

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
         <moneta.version>1.4.5</moneta.version>
         <central.publishing.plugin.version>0.10.0</central.publishing.plugin.version>
 
-        <wultra-core.version>2.0.0</wultra-core.version>
+        <wultra-core.version>2.1.0</wultra-core.version>
         <powerauth-crypto.version>2.0.1</powerauth-crypto.version>
         <powerauth-restful-integration.version>2.0.0</powerauth-restful-integration.version>
         <powerauth-push.version>2.0.1</powerauth-push.version>


### PR DESCRIPTION
Setting of `subjectId` to `userId` in audit log records (Enrollment Server only).

Setting of `subjectId` in Enrollment Server Onboarding will be addressed in a dedicated PR.