### PR TITLE
Fix #1650: Add country to the submit document endpoint

### DIFF
--- a/docs/db/changelog/changesets/enrollment-server-onboarding/2.0.x/20260402-document-country.xml
+++ b/docs/db/changelog/changesets/enrollment-server-onboarding/2.0.x/20260402-document-country.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.33.xsd">
+
+    <changeSet id="1" logicalFilePath="enrollment-server-onboarding/2.0.x/20260402-document-country.xml" author="Lubos Racansky">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="es_document_verification" columnName="country" />
+            </not>
+        </preConditions>
+        <comment>Creates a new column country in es_document_verification</comment>
+        <addColumn tableName="es_document_verification">
+            <column name="country" type="varchar(3)" />
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/docs/db/changelog/changesets/enrollment-server-onboarding/2.0.x/db.changelog-version.xml
+++ b/docs/db/changelog/changesets/enrollment-server-onboarding/2.0.x/db.changelog-version.xml
@@ -10,6 +10,7 @@
     <include file="20260205-audit.xml" relativeToChangelogFile="true" />
     <include file="20260309-processed-document-data-verification-id.xml" relativeToChangelogFile="true" />
     <include file="20260313-consent-accepted.xml" relativeToChangelogFile="true" />
+    <include file="20260402-document-country.xml" relativeToChangelogFile="true" />
     <include file="20251215-add-tag-2.0.0.xml" relativeToChangelogFile="true" />
 
 </databaseChangeLog>

--- a/docs/onboarding/PowerAuth-Enrollment-Onboarding-Server-2.0.0.md
+++ b/docs/onboarding/PowerAuth-Enrollment-Onboarding-Server-2.0.0.md
@@ -59,6 +59,11 @@ The following changes were made to the onboarding start endpoint:
 Endpoint `POST api/identity/document/upload` was removed because it was never used in production.
 
 
+## Document Submit
+
+The endpoint `/api/identity/document/submit` has been deprecated in favor of `/api/v2/identity/document/submit`.
+
+
 ## External Onboarding Services Changes
 
 

--- a/docs/onboarding/PowerAuth-Enrollment-Onboarding-Server-2.0.0.md
+++ b/docs/onboarding/PowerAuth-Enrollment-Onboarding-Server-2.0.0.md
@@ -38,6 +38,11 @@ linked to `es_document_data` records via `upload_id` column.
 A new table `es_selfie` has been added to temporarily store selfie images of identity verification.
 
 
+### Document Verification
+
+A new column `country` has been added to the table `es_document_verification`.
+
+
 ## REST API Changes
 
 

--- a/docs/onboarding/PowerAuth-Enrollment-Onboarding-Server-2.0.0.md
+++ b/docs/onboarding/PowerAuth-Enrollment-Onboarding-Server-2.0.0.md
@@ -59,7 +59,7 @@ The following changes were made to the onboarding start endpoint:
 Endpoint `POST api/identity/document/upload` was removed because it was never used in production.
 
 
-## Document Submit
+### Document Submit
 
 The endpoint `/api/identity/document/submit` has been deprecated in favor of `/api/v2/identity/document/submit`.
 

--- a/docs/sql/oracle/onboarding/create-schema.sql
+++ b/docs/sql/oracle/onboarding/create-schema.sql
@@ -373,3 +373,7 @@ ALTER TABLE audit_log ADD subject_id VARCHAR2(256);
 -- Changeset enrollment-server-onboarding/2.1.x/20260330-audit-subject-id.xml::2::Pavel Sindelar
 -- Create a new index on audit_log(subject_id)
 CREATE INDEX audit_log_subject_id_idx ON audit_log(subject_id);
+
+-- Changeset enrollment-server-onboarding/2.0.x/20260402-document-country.xml::1::Lubos Racansky
+-- Creates a new column country in es_document_verification
+ALTER TABLE es_document_verification ADD country VARCHAR2(3);

--- a/docs/sql/oracle/onboarding/migration_1.10.0_2.0.0.sql
+++ b/docs/sql/oracle/onboarding/migration_1.10.0_2.0.0.sql
@@ -114,4 +114,8 @@ CREATE INDEX es_processed_document_data_document_verification_id_idx ON es_proce
 -- Creates a new column consent_accepted in es_onboarding_process
 ALTER TABLE es_onboarding_process ADD consent_accepted BOOLEAN;
 
+-- Changeset enrollment-server-onboarding/2.0.x/20260402-document-country.xml::1::Lubos Racansky
+-- Creates a new column country in es_document_verification
+ALTER TABLE es_document_verification ADD country VARCHAR2(3);
+
 -- Changeset enrollment-server-onboarding/2.0.x/20251215-add-tag-2.0.0.xml::1::Lubos Racansky

--- a/docs/sql/postgresql/onboarding/create-schema.sql
+++ b/docs/sql/postgresql/onboarding/create-schema.sql
@@ -350,3 +350,8 @@ ALTER TABLE audit_log ADD subject_id VARCHAR(256);
 -- Changeset enrollment-server-onboarding/2.1.x/20260330-audit-subject-id.xml::2::Pavel Sindelar
 -- Create a new index on audit_log(subject_id)
 CREATE INDEX audit_log_subject_id_idx ON audit_log(subject_id);
+
+
+-- Changeset enrollment-server-onboarding/2.0.x/20260402-document-country.xml::1::Lubos Racansky
+-- Creates a new column country in es_document_verification
+ALTER TABLE es_document_verification ADD country VARCHAR(3);

--- a/docs/sql/postgresql/onboarding/migration_1.10.0_2.0.0.sql
+++ b/docs/sql/postgresql/onboarding/migration_1.10.0_2.0.0.sql
@@ -114,4 +114,8 @@ CREATE INDEX es_processed_document_data_document_verification_id_idx ON es_proce
 -- Creates a new column consent_accepted in es_onboarding_process
 ALTER TABLE es_onboarding_process ADD consent_accepted BOOLEAN;
 
+-- Changeset enrollment-server-onboarding/2.0.x/20260402-document-country.xml::1::Lubos Racansky
+-- Creates a new column country in es_document_verification
+ALTER TABLE es_document_verification ADD country VARCHAR(3);
+
 -- Changeset enrollment-server-onboarding/2.0.x/20251215-add-tag-2.0.0.xml::1::Lubos Racansky

--- a/enrollment-server-onboarding-api-model/src/main/java/com/wultra/app/enrollmentserver/api/model/onboarding/request/DocumentSubmitV2Request.java
+++ b/enrollment-server-onboarding-api-model/src/main/java/com/wultra/app/enrollmentserver/api/model/onboarding/request/DocumentSubmitV2Request.java
@@ -68,6 +68,9 @@ public record DocumentSubmitV2Request(
             @NotEmpty
             CardSide side,
 
+            @Schema(description = "Document country as an ISO 3166-1 alpha-3 code", example = "CZE", maxLength = 3, minLength = 3)
+            String country,
+
             @Schema(description = "Document image", example = "iVBORw0KGgoAAAANSUhEUgAA...", format = "byte")
             @NotEmpty
             String data
@@ -76,11 +79,12 @@ public record DocumentSubmitV2Request(
         @Override
         @NonNull
         public String toString() {
-            return "Document[originalDocumentId=%s, filename=%s, type=%s, side=%s, data=%s]".formatted(
+            return "Document[originalDocumentId=%s, filename=%s, type=%s, side=%s, country=%s, data=%s]".formatted(
                     originalDocumentId,
                     filename,
                     type,
                     side,
+                    country,
                     data != null ? "length:" + data.length() : "null"
             );
         }

--- a/enrollment-server-onboarding-api-model/src/main/java/com/wultra/app/enrollmentserver/api/model/onboarding/response/data/DocumentMetadataResponseDto.java
+++ b/enrollment-server-onboarding-api-model/src/main/java/com/wultra/app/enrollmentserver/api/model/onboarding/response/data/DocumentMetadataResponseDto.java
@@ -64,6 +64,9 @@ public class DocumentMetadataResponseDto {
      */
     private List<String> errors;
 
+    /**
+     * Document country as an ISO 3166-1 alpha-3 code.
+     */
     @Schema(description = "Document country as an ISO 3166-1 alpha-3 code", example = "CZE", maxLength = 3, minLength = 3)
     @Size(min = 3, max = 3)
     private String country;

--- a/enrollment-server-onboarding-api-model/src/main/java/com/wultra/app/enrollmentserver/api/model/onboarding/response/data/DocumentMetadataResponseDto.java
+++ b/enrollment-server-onboarding-api-model/src/main/java/com/wultra/app/enrollmentserver/api/model/onboarding/response/data/DocumentMetadataResponseDto.java
@@ -21,6 +21,7 @@ import com.wultra.app.enrollmentserver.model.enumeration.CardSide;
 import com.wultra.app.enrollmentserver.model.enumeration.DocumentStatus;
 import com.wultra.app.enrollmentserver.model.enumeration.DocumentType;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Size;
 import lombok.Data;
 
 import java.util.List;
@@ -64,6 +65,7 @@ public class DocumentMetadataResponseDto {
     private List<String> errors;
 
     @Schema(description = "Document country as an ISO 3166-1 alpha-3 code", example = "CZE", maxLength = 3, minLength = 3)
+    @Size(min = 3, max = 3)
     private String country;
 
 }

--- a/enrollment-server-onboarding-api-model/src/main/java/com/wultra/app/enrollmentserver/api/model/onboarding/response/data/DocumentMetadataResponseDto.java
+++ b/enrollment-server-onboarding-api-model/src/main/java/com/wultra/app/enrollmentserver/api/model/onboarding/response/data/DocumentMetadataResponseDto.java
@@ -20,6 +20,7 @@ package com.wultra.app.enrollmentserver.api.model.onboarding.response.data;
 import com.wultra.app.enrollmentserver.model.enumeration.CardSide;
 import com.wultra.app.enrollmentserver.model.enumeration.DocumentStatus;
 import com.wultra.app.enrollmentserver.model.enumeration.DocumentType;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
 import java.util.List;
@@ -61,5 +62,8 @@ public class DocumentMetadataResponseDto {
      * Errors discovered during processing of the document
      */
     private List<String> errors;
+
+    @Schema(description = "Document country as an ISO 3166-1 alpha-3 code", example = "CZE", maxLength = 3, minLength = 3)
+    private String country;
 
 }

--- a/enrollment-server-onboarding-api-model/src/test/java/com/wultra/app/enrollmentserver/api/model/onboarding/request/DocumentSubmitV2RequestTest.java
+++ b/enrollment-server-onboarding-api-model/src/test/java/com/wultra/app/enrollmentserver/api/model/onboarding/request/DocumentSubmitV2RequestTest.java
@@ -56,7 +56,7 @@ class DocumentSubmitV2RequestTest {
 
         // then
         assertEquals(
-                "DocumentSubmitV2Request[processId=process-1, documents=[Document[originalDocumentId=doc-1, filename=file1.jpg, type=ID_CARD, side=FRONT, data=null]], resubmit=true]",
+                "DocumentSubmitV2Request[processId=process-1, documents=[Document[originalDocumentId=doc-1, filename=file1.jpg, type=ID_CARD, side=FRONT, country=null, data=null]], resubmit=true]",
                 requestAsString
         );
     }
@@ -72,6 +72,7 @@ class DocumentSubmitV2RequestTest {
                                 DocumentSubmitV2Request.Document.builder()
                                         .originalDocumentId("doc-1")
                                         .filename("file1.jpg")
+                                        .country("CZE")
                                         .type(DocumentType.ID_CARD)
                                         .side(CardSide.FRONT)
                                         .data("base64-data")
@@ -85,7 +86,7 @@ class DocumentSubmitV2RequestTest {
 
         // then
         assertEquals(
-                "DocumentSubmitV2Request[processId=process-1, documents=[Document[originalDocumentId=doc-1, filename=file1.jpg, type=ID_CARD, side=FRONT, data=length:11]], resubmit=true]",
+                "DocumentSubmitV2Request[processId=process-1, documents=[Document[originalDocumentId=doc-1, filename=file1.jpg, type=ID_CARD, side=FRONT, country=CZE, data=length:11]], resubmit=true]",
                 requestAsString
         );
     }

--- a/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/database/entity/DocumentVerificationEntity.java
+++ b/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/database/entity/DocumentVerificationEntity.java
@@ -89,7 +89,7 @@ public class DocumentVerificationEntity implements Serializable {
     private String otherSideId;
 
     /**
-     * Country stored as an ISO 3166-1 alpha-3 code, e.g. CZE.
+     * Country stored as an ISO 3166-1 alpha-3 code, e.g. {@code CZE}.
      */
     @Column(name = "country", length = 3)
     private String country;

--- a/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/database/entity/DocumentVerificationEntity.java
+++ b/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/database/entity/DocumentVerificationEntity.java
@@ -89,7 +89,7 @@ public class DocumentVerificationEntity implements Serializable {
     private String otherSideId;
 
     /**
-     * Document the country as an ISO 3166-1 alpha-3 code, e.g. CZE.
+     * Country stored as an ISO 3166-1 alpha-3 code, e.g. CZE.
      */
     @Column(name = "country", length = 3)
     private String country;

--- a/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/database/entity/DocumentVerificationEntity.java
+++ b/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/database/entity/DocumentVerificationEntity.java
@@ -89,6 +89,12 @@ public class DocumentVerificationEntity implements Serializable {
     private String otherSideId;
 
     /**
+     * Document the country as an ISO 3166-1 alpha-3 code, e.g. CZE.
+     */
+    @Column(name = "country", length = 3)
+    private String country;
+
+    /**
      * Name identifying {@code DocumentVerificationProvider}.
      */
     @Column(name = "provider_name")

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/IdentityVerificationService.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/IdentityVerificationService.java
@@ -527,7 +527,7 @@ public class IdentityVerificationService {
      * @return Document metadata for response
      */
     private DocumentMetadataResponseDto toDocumentMetadata(DocumentVerificationEntity entity) {
-        final DocumentMetadataResponseDto docMetadata = new DocumentMetadataResponseDto();
+        final var docMetadata = new DocumentMetadataResponseDto();
         docMetadata.setId(entity.getId());
         // Hide specific error reason if any.
         if (StringUtils.isNotBlank(entity.getErrorDetail()) || StringUtils.isNotBlank(entity.getRejectReason())) {

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/IdentityVerificationService.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/IdentityVerificationService.java
@@ -527,7 +527,7 @@ public class IdentityVerificationService {
      * @return Document metadata for response
      */
     private DocumentMetadataResponseDto toDocumentMetadata(DocumentVerificationEntity entity) {
-        DocumentMetadataResponseDto docMetadata = new DocumentMetadataResponseDto();
+        final DocumentMetadataResponseDto docMetadata = new DocumentMetadataResponseDto();
         docMetadata.setId(entity.getId());
         // Hide specific error reason if any.
         if (StringUtils.isNotBlank(entity.getErrorDetail()) || StringUtils.isNotBlank(entity.getRejectReason())) {
@@ -537,6 +537,7 @@ public class IdentityVerificationService {
         docMetadata.setSide(entity.getSide());
         docMetadata.setStatus(entity.getStatus());
         docMetadata.setType(entity.getType());
+        docMetadata.setCountry(entity.getCountry());
         return docMetadata;
     }
 

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/IdentityVerificationService.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/IdentityVerificationService.java
@@ -527,7 +527,7 @@ public class IdentityVerificationService {
      * @return Document metadata for response
      */
     private DocumentMetadataResponseDto toDocumentMetadata(DocumentVerificationEntity entity) {
-        final var docMetadata = new DocumentMetadataResponseDto();
+        final DocumentMetadataResponseDto docMetadata = new DocumentMetadataResponseDto();
         docMetadata.setId(entity.getId());
         // Hide specific error reason if any.
         if (StringUtils.isNotBlank(entity.getErrorDetail()) || StringUtils.isNotBlank(entity.getRejectReason())) {

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/document/DocumentProcessingService.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/document/DocumentProcessingService.java
@@ -306,6 +306,7 @@ public class DocumentProcessingService {
         entity.setOriginalDocumentId(document.originalDocumentId());
         entity.setSide(document.side());
         entity.setType(document.type());
+        entity.setCountry(document.country());
         entity.setStatus(DocumentStatus.UPLOAD_IN_PROGRESS);
         entity.setTimestampCreated(ownerId.getTimestamp());
         entity.setUsedForVerification(true);


### PR DESCRIPTION
- [x] Add `country` field to `DocumentSubmitV2Request` with bean validation (`@Size(min=3, max=3)`)
- [x] Add `country` field to `DocumentVerificationEntity` with JavaDoc
- [x] Add `country` field to `DocumentMetadataResponseDto` with JavaDoc
- [x] Persist `country` in service layer
- [x] Add DB migration changeset for `country` column
- [x] Update migration docs