### PR TITLE
Fix #1678: Process data are not cleaned after defined period

### DIFF
--- a/docs/db/changelog/changesets/enrollment-server-onboarding/2.1.x/20260408-identity-data-cleaned-timestamp.xml
+++ b/docs/db/changelog/changesets/enrollment-server-onboarding/2.1.x/20260408-identity-data-cleaned-timestamp.xml
@@ -6,14 +6,14 @@
     <changeSet id="1" author="Michal Rozehnal">
         <preConditions onFail="MARK_RAN">
             <not>
-                <columnExists tableName="es_onboarding_process" columnName="timestamp_identity_data_cleaned"/>
+                <columnExists tableName="es_onboarding_process" columnName="timestamp_personal_data_cleaned"/>
             </not>
         </preConditions>
         <comment>
-            Create a new column timestamp_identity_data_cleaned in es_onboarding_process table to store the timestamp when the identity data was cleaned
+            Create a new column timestamp_personal_data_cleaned in es_onboarding_process table to store the timestamp when the identity data was cleaned
         </comment>
         <addColumn tableName="es_onboarding_process">
-            <column name="timestamp_identity_data_cleaned" type="timestamp" />
+            <column name="timestamp_personal_data_cleaned" type="timestamp" />
         </addColumn>
     </changeSet>
 

--- a/docs/db/changelog/changesets/enrollment-server-onboarding/2.1.x/20260408-identity-data-cleaned-timestamp.xml
+++ b/docs/db/changelog/changesets/enrollment-server-onboarding/2.1.x/20260408-identity-data-cleaned-timestamp.xml
@@ -18,7 +18,7 @@
     </changeSet>
 
     <changeSet id="2" author="Michal Rozehnal">
-        <preConditions>
+        <preConditions onFail="MARK_RAN">
             <not>
                 <indexExists indexName="es_onboarding_process_timestamp_identity_data_cleaned_idx"/>
             </not>
@@ -32,7 +32,7 @@
     </changeSet>
 
     <changeSet id="3" author="Michal Rozehnal">
-        <preConditions>
+        <preConditions onFail="MARK_RAN">
             <not>
                 <indexExists indexName="es_onboarding_process_timestamp_finished_idx" />
             </not>
@@ -46,7 +46,7 @@
     </changeSet>
 
     <changeSet id="4" author="Michal Rozehnal">
-        <preConditions>
+        <preConditions onFail="MARK_RAN">
             <not>
                 <indexExists indexName="es_onboarding_process_timestamp_failed_idx" />
             </not>
@@ -60,7 +60,7 @@
     </changeSet>
 
     <changeSet id="5" author="Michal Rozehnal">
-        <preConditions>
+        <preConditions onFail="MARK_RAN">
             <not>
                 <indexExists indexName="es_identity_verification_process_id_idx" />
             </not>

--- a/docs/db/changelog/changesets/enrollment-server-onboarding/2.1.x/20260408-identity-data-cleaned-timestamp.xml
+++ b/docs/db/changelog/changesets/enrollment-server-onboarding/2.1.x/20260408-identity-data-cleaned-timestamp.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.33.xsd">
+
+    <changeSet id="1" author="Michal Rozehnal">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="es_onboarding_process" columnName="timestamp_identity_data_cleaned"/>
+            </not>
+        </preConditions>
+        <comment>
+            Create a new column timestamp_identity_data_cleaned in es_onboarding_process table to store the timestamp when the identity data was cleaned
+        </comment>
+        <addColumn tableName="es_onboarding_process">
+            <column name="timestamp_identity_data_cleaned" type="timestamp" />
+        </addColumn>
+    </changeSet>
+
+    <changeSet id="2" author="Michal Rozehnal">
+        <preConditions>
+            <not>
+                <indexExists indexName="es_onboarding_process_timestamp_identity_data_cleaned_idx"/>
+            </not>
+        </preConditions>
+        <comment>
+            Create a new index es_onboarding_process_timestamp_identity_data_cleaned_idx
+        </comment>
+        <createIndex tableName="es_onboarding_process" indexName="es_onboarding_process_timestamp_identity_data_cleaned_idx">
+            <column name="timestamp_identity_data_cleaned" />
+        </createIndex>
+    </changeSet>
+
+    <changeSet id="3" author="Michal Rozehnal">
+        <preConditions>
+            <not>
+                <indexExists indexName="es_onboarding_process_timestamp_finished_idx" />
+            </not>
+        </preConditions>
+        <comment>
+            Create a new index es_onboarding_process_timestamp_finished_idx
+        </comment>
+        <createIndex tableName="es_onboarding_process" indexName="es_onboarding_process_timestamp_finished_idx">
+            <column name="timestamp_finished"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet id="4" author="Michal Rozehnal">
+        <preConditions>
+            <not>
+                <indexExists indexName="es_onboarding_process_timestamp_failed_idx" />
+            </not>
+        </preConditions>
+        <comment>
+            Create a new index es_onboarding_process_timestamp_failed_idx
+        </comment>
+        <createIndex tableName="es_onboarding_process" indexName="es_onboarding_process_timestamp_failed_idx">
+            <column name="timestamp_failed"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet id="5" author="Michal Rozehnal">
+        <preConditions>
+            <not>
+                <indexExists indexName="es_identity_verification_process_id_idx" />
+            </not>
+        </preConditions>
+        <comment>
+            Create a new index es_identity_verification_process_id_idx
+        </comment>
+        <createIndex tableName="es_identity_verification" indexName="es_identity_verification_process_id_idx">
+            <column name="process_id"/>
+        </createIndex>
+    </changeSet>
+
+</databaseChangeLog>

--- a/docs/db/changelog/changesets/enrollment-server-onboarding/2.1.x/20260408-identity-data-cleaned-timestamp.xml
+++ b/docs/db/changelog/changesets/enrollment-server-onboarding/2.1.x/20260408-identity-data-cleaned-timestamp.xml
@@ -73,4 +73,34 @@
         </createIndex>
     </changeSet>
 
+    <changeSet id="6" author="Michal Rozehnal">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="es_document_data" columnName="document_verification_id"/>
+            </not>
+        </preConditions>
+        <comment>
+            Create a new column document_verification_id in es_document_data table
+        </comment>
+        <addColumn tableName="es_document_data">
+            <column name="document_verification_id" type="varchar(36)">
+                <constraints foreignKeyName="es_document_verification_id_fk" referencedTableName="es_document_verification" referencedColumnNames="id" />
+            </column>
+        </addColumn>
+    </changeSet>
+
+    <changeSet id="7" author="Michal Rozehnal">
+        <preConditions>
+            <not>
+                <indexExists indexName="es_document_data_document_verification_id_idx" />
+            </not>
+        </preConditions>
+        <comment>
+            Create a new index es_document_data_document_verification_id_idx
+        </comment>
+        <createIndex tableName="es_document_data" indexName="es_document_data_document_verification_id_idx">
+            <column name="document_verification_id" />
+        </createIndex>
+    </changeSet>
+
 </databaseChangeLog>

--- a/docs/db/changelog/changesets/enrollment-server-onboarding/2.1.x/20260408-personal-data-cleaned-timestamp.xml
+++ b/docs/db/changelog/changesets/enrollment-server-onboarding/2.1.x/20260408-personal-data-cleaned-timestamp.xml
@@ -20,46 +20,18 @@
     <changeSet id="2" author="Michal Rozehnal">
         <preConditions onFail="MARK_RAN">
             <not>
-                <indexExists indexName="es_onboarding_process_timestamp_identity_data_cleaned_idx"/>
+                <indexExists indexName="es_onboarding_process_timestamp_personal_data_cleaned_idx"/>
             </not>
         </preConditions>
         <comment>
-            Create a new index es_onboarding_process_timestamp_identity_data_cleaned_idx
+            Create a new index es_onboarding_process_timestamp_personal_data_cleaned_idx
         </comment>
-        <createIndex tableName="es_onboarding_process" indexName="es_onboarding_process_timestamp_identity_data_cleaned_idx">
-            <column name="timestamp_identity_data_cleaned" />
+        <createIndex tableName="es_onboarding_process" indexName="es_onboarding_process_timestamp_personal_data_cleaned_idx">
+            <column name="timestamp_personal_data_cleaned" />
         </createIndex>
     </changeSet>
 
     <changeSet id="3" author="Michal Rozehnal">
-        <preConditions onFail="MARK_RAN">
-            <not>
-                <indexExists indexName="es_onboarding_process_timestamp_finished_idx" />
-            </not>
-        </preConditions>
-        <comment>
-            Create a new index es_onboarding_process_timestamp_finished_idx
-        </comment>
-        <createIndex tableName="es_onboarding_process" indexName="es_onboarding_process_timestamp_finished_idx">
-            <column name="timestamp_finished"/>
-        </createIndex>
-    </changeSet>
-
-    <changeSet id="4" author="Michal Rozehnal">
-        <preConditions onFail="MARK_RAN">
-            <not>
-                <indexExists indexName="es_onboarding_process_timestamp_failed_idx" />
-            </not>
-        </preConditions>
-        <comment>
-            Create a new index es_onboarding_process_timestamp_failed_idx
-        </comment>
-        <createIndex tableName="es_onboarding_process" indexName="es_onboarding_process_timestamp_failed_idx">
-            <column name="timestamp_failed"/>
-        </createIndex>
-    </changeSet>
-
-    <changeSet id="5" author="Michal Rozehnal">
         <preConditions onFail="MARK_RAN">
             <not>
                 <indexExists indexName="es_identity_verification_process_id_idx" />
@@ -73,7 +45,7 @@
         </createIndex>
     </changeSet>
 
-    <changeSet id="6" author="Michal Rozehnal">
+    <changeSet id="4" author="Michal Rozehnal">
         <preConditions onFail="MARK_RAN">
             <not>
                 <columnExists tableName="es_document_data" columnName="document_verification_id"/>
@@ -89,7 +61,7 @@
         </addColumn>
     </changeSet>
 
-    <changeSet id="7" author="Michal Rozehnal">
+    <changeSet id="5" author="Michal Rozehnal">
         <preConditions>
             <not>
                 <indexExists indexName="es_document_data_document_verification_id_idx" />

--- a/docs/db/changelog/changesets/enrollment-server-onboarding/2.1.x/20260408-personal-data-cleaned-timestamp.xml
+++ b/docs/db/changelog/changesets/enrollment-server-onboarding/2.1.x/20260408-personal-data-cleaned-timestamp.xml
@@ -62,7 +62,7 @@
     </changeSet>
 
     <changeSet id="5" author="Michal Rozehnal">
-        <preConditions>
+        <preConditions onFail="MARK_RAN">
             <not>
                 <indexExists indexName="es_document_data_document_verification_id_idx" />
             </not>

--- a/docs/db/changelog/changesets/enrollment-server-onboarding/2.1.x/db.changelog-version.xml
+++ b/docs/db/changelog/changesets/enrollment-server-onboarding/2.1.x/db.changelog-version.xml
@@ -4,6 +4,6 @@
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd">
 
     <include file="20260330-audit-subject-id.xml" relativeToChangelogFile="true" />
-    <include file="20260408-identity-data-cleaned-timestamp.xml" relativeToChangelogFile="true" />
+    <include file="20260408-personal-data-cleaned-timestamp.xml" relativeToChangelogFile="true" />
 
 </databaseChangeLog>

--- a/docs/db/changelog/changesets/enrollment-server-onboarding/2.1.x/db.changelog-version.xml
+++ b/docs/db/changelog/changesets/enrollment-server-onboarding/2.1.x/db.changelog-version.xml
@@ -4,5 +4,6 @@
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd">
 
     <include file="20260330-audit-subject-id.xml" relativeToChangelogFile="true" />
+    <include file="20260408-identity-data-cleaned-timestamp.xml" relativeToChangelogFile="true" />
 
 </databaseChangeLog>

--- a/docs/onboarding/Configuration-Properties.md
+++ b/docs/onboarding/Configuration-Properties.md
@@ -29,18 +29,18 @@ The configuration properties below are global to all the onboarding processes.
 Specific process options are defined in the database.
 See [Configuration of Onboarding Process](./Configuration-Onboarding-Process.md) for the details of JSON configuration.
 
-| Property                                                                            | Default   | Note                                                                                                   |
-|-------------------------------------------------------------------------------------|-----------|--------------------------------------------------------------------------------------------------------|
-| `enrollment-server-onboarding.onboarding-process.otp.length`                        | `8`       | Length of generated digital OTP codes.                                                                 |
-| `enrollment-server-onboarding.onboarding-process.otp.expiration`                    | `5m`      | Expiration time for OTP codes.                                                                         |
-| `enrollment-server-onboarding.onboarding-process.otp.max-failed-attempts`           | `5`       | Maximum number of failed attempts for OTP verification.                                                |
-| `enrollment-server-onboarding.onboarding-process.otp.resend-period`                 | `30s`     | A time period after which next OTP can be sent.                                                        |
-| `enrollment-server-onboarding.onboarding-process.expiration`                        | `3h`      | Onboarding process expiration time.                                                                    |
-| `enrollment-server-onboarding.onboarding-process.activation.expiration`             | `5m`      | Expiration of activations used within an onboarding process.                                           |
-| `enrollment-server-onboarding.onboarding-process.verification.expiration`           | `1h`      | Expiration of identity verification within an onboarding process.                                      |
-| `enrollment-server-onboarding.onboarding-process.max-processes-per-day`             | `5`       | Maximum number of onboarding processes during last 24 hours per user.                                  |
-| `enrollment-server-onboarding.onboarding-process.max-error-score`                   | `15`      | Maximum error score for an onboarding process.                                                         |
-| `enrollment-server-onboarding.onboarding-process.default-type`                      | `_empty_` | Default process type used for starting onboarding if not specified by the mobile application.          |
+| Property                                                                   | Default   | Note                                                                                            |
+|----------------------------------------------------------------------------|-----------|-------------------------------------------------------------------------------------------------|
+| `enrollment-server-onboarding.onboarding-process.otp.length`               | `8`       | Length of generated digital OTP codes.                                                          |
+| `enrollment-server-onboarding.onboarding-process.otp.expiration`           | `5m`      | Expiration time for OTP codes.                                                                  |
+| `enrollment-server-onboarding.onboarding-process.otp.max-failed-attempts`  | `5`       | Maximum number of failed attempts for OTP verification.                                         |
+| `enrollment-server-onboarding.onboarding-process.otp.resend-period`        | `30s`     | A time period after which next OTP can be sent.                                                 |
+| `enrollment-server-onboarding.onboarding-process.expiration`               | `3h`      | Onboarding process expiration time.                                                             |
+| `enrollment-server-onboarding.onboarding-process.activation.expiration`    | `5m`      | Expiration of activations used within an onboarding process.                                    |
+| `enrollment-server-onboarding.onboarding-process.verification.expiration`  | `1h`      | Expiration of identity verification within an onboarding process.                               |
+| `enrollment-server-onboarding.onboarding-process.max-processes-per-day`    | `5`       | Maximum number of onboarding processes during last 24 hours per user.                           |
+| `enrollment-server-onboarding.onboarding-process.max-error-score`          | `15`      | Maximum error score for an onboarding process.                                                  |
+| `enrollment-server-onboarding.onboarding-process.default-type`             | `_empty_` | Default process type used for starting onboarding if not specified by the mobile application.   |
 
 ## Identity Verification Configuration
 

--- a/docs/onboarding/Configuration-Properties.md
+++ b/docs/onboarding/Configuration-Properties.md
@@ -29,18 +29,19 @@ The configuration properties below are global to all the onboarding processes.
 Specific process options are defined in the database.
 See [Configuration of Onboarding Process](./Configuration-Onboarding-Process.md) for the details of JSON configuration.
 
-| Property                                                                   | Default   | Note                                                                                            |
-|----------------------------------------------------------------------------|-----------|-------------------------------------------------------------------------------------------------|
-| `enrollment-server-onboarding.onboarding-process.otp.length`               | `8`       | Length of generated digital OTP codes.                                                          |
-| `enrollment-server-onboarding.onboarding-process.otp.expiration`           | `5m`      | Expiration time for OTP codes.                                                                  |
-| `enrollment-server-onboarding.onboarding-process.otp.max-failed-attempts`  | `5`       | Maximum number of failed attempts for OTP verification.                                         |
-| `enrollment-server-onboarding.onboarding-process.otp.resend-period`        | `30s`     | A time period after which next OTP can be sent.                                                 |
-| `enrollment-server-onboarding.onboarding-process.expiration`               | `3h`      | Onboarding process expiration time.                                                             |
-| `enrollment-server-onboarding.onboarding-process.activation.expiration`    | `5m`      | Expiration of activations used within an onboarding process.                                    |
-| `enrollment-server-onboarding.onboarding-process.verification.expiration`  | `1h`      | Expiration of identity verification within an onboarding process.                               |
-| `enrollment-server-onboarding.onboarding-process.max-processes-per-day`    | `5`       | Maximum number of onboarding processes during last 24 hours per user.                           |
-| `enrollment-server-onboarding.onboarding-process.max-error-score`          | `15`      | Maximum error score for an onboarding process.                                                  |
-| `enrollment-server-onboarding.onboarding-process.default-type`             | `_empty_` | Default process type used for starting onboarding if not specified by the mobile application.   |
+| Property                                                                  | Default   | Note                                                                                          |
+|---------------------------------------------------------------------------|-----------|-----------------------------------------------------------------------------------------------|
+| `enrollment-server-onboarding.onboarding-process.otp.length`              | `8`       | Length of generated digital OTP codes.                                                        |
+| `enrollment-server-onboarding.onboarding-process.otp.expiration`          | `5m`      | Expiration time for OTP codes.                                                                |
+| `enrollment-server-onboarding.onboarding-process.otp.max-failed-attempts` | `5`       | Maximum number of failed attempts for OTP verification.                                       |
+| `enrollment-server-onboarding.onboarding-process.otp.resend-period`       | `30s`     | A time period after which next OTP can be sent.                                               |
+| `enrollment-server-onboarding.onboarding-process.expiration`              | `3h`      | Onboarding process expiration time.                                                           |
+| `enrollment-server-onboarding.onboarding-process.activation.expiration`   | `5m`      | Expiration of activations used within an onboarding process.                                  |
+| `enrollment-server-onboarding.onboarding-process.verification.expiration` | `1h`      | Expiration of identity verification within an onboarding process.                             |
+| `enrollment-server-onboarding.onboarding-process.max-processes-per-day`   | `5`       | Maximum number of onboarding processes during last 24 hours per user.                         |
+| `enrollment-server-onboarding.onboarding-process.max-error-score`         | `15`      | Maximum error score for an onboarding process.                                                |
+| `enrollment-server-onboarding.onboarding-process.default-type`            | `_empty_` | Default process type used for starting onboarding if not specified by the mobile application. |
+| `enrollment-server-onboarding.onboarding-process.cleanup-limit`           | `10000`   | Maximum number of records processed in a single cleaning task run.                            |
 
 ## Identity Verification Configuration
 

--- a/docs/onboarding/Configuration-Properties.md
+++ b/docs/onboarding/Configuration-Properties.md
@@ -41,15 +41,15 @@ See [Configuration of Onboarding Process](./Configuration-Onboarding-Process.md)
 | `enrollment-server-onboarding.onboarding-process.max-processes-per-day`             | `5`       | Maximum number of onboarding processes during last 24 hours per user.                                  |
 | `enrollment-server-onboarding.onboarding-process.max-error-score`                   | `15`      | Maximum error score for an onboarding process.                                                         |
 | `enrollment-server-onboarding.onboarding-process.default-type`                      | `_empty_` | Default process type used for starting onboarding if not specified by the mobile application.          |
-| `enrollment-server-onboarding.onboarding-process.completedProcessDataRetentionTime` | `1h`      | Time period for which the identity data of completed onboarding processes is retained in the database. |
 
 ## Identity Verification Configuration
 
-| Property                                                                                 | Default | Note                                                              |
-|------------------------------------------------------------------------------------------|---------|-------------------------------------------------------------------|
-| `enrollment-server-onboarding.identity-verification.enabled`                             | `false` | Whether identity verification is enabled.                         |
-| `enrollment-server-onboarding.identity-verification.max-failed-attempts`                 | `5`     | Maximum failed attempts for identity verification.                |
-| `enrollment-server-onboarding.identity-verification.max-failed-attempts-document-upload` | `5`     | Maximum failed attempts for document upload.                      |
+| Property                                                                                 | Default | Note                                                                                                   |
+|------------------------------------------------------------------------------------------|---------|--------------------------------------------------------------------------------------------------------|
+| `enrollment-server-onboarding.identity-verification.enabled`                             | `false` | Whether identity verification is enabled.                                                              |
+| `enrollment-server-onboarding.identity-verification.max-failed-attempts`                 | `5`     | Maximum failed attempts for identity verification.                                                     |
+| `enrollment-server-onboarding.identity-verification.max-failed-attempts-document-upload` | `5`     | Maximum failed attempts for document upload.                                                           |
+| `enrollment-server-onboarding.identity-verification.data-retention`                      | `1h`    | Time period for which the identity data of completed onboarding processes is retained in the database. |
 
 ## Digital Onboarding Adapter Configuration
 

--- a/docs/onboarding/Configuration-Properties.md
+++ b/docs/onboarding/Configuration-Properties.md
@@ -29,18 +29,19 @@ The configuration properties below are global to all the onboarding processes.
 Specific process options are defined in the database.
 See [Configuration of Onboarding Process](./Configuration-Onboarding-Process.md) for the details of JSON configuration.
 
-| Property                                                                  | Default   | Note                                                                                          |
-|---------------------------------------------------------------------------|-----------|-----------------------------------------------------------------------------------------------|
-| `enrollment-server-onboarding.onboarding-process.otp.length`              | `8`       | Length of generated digital OTP codes.                                                        |
-| `enrollment-server-onboarding.onboarding-process.otp.expiration`          | `5m`      | Expiration time for OTP codes.                                                                |
-| `enrollment-server-onboarding.onboarding-process.otp.max-failed-attempts` | `5`       | Maximum number of failed attempts for OTP verification.                                       |
-| `enrollment-server-onboarding.onboarding-process.otp.resend-period`       | `30s`     | A time period after which next OTP can be sent.                                               |
-| `enrollment-server-onboarding.onboarding-process.expiration`              | `3h`      | Onboarding process expiration time.                                                           |
-| `enrollment-server-onboarding.onboarding-process.activation.expiration`   | `5m`      | Expiration of activations used within an onboarding process.                                  |
-| `enrollment-server-onboarding.onboarding-process.verification.expiration` | `1h`      | Expiration of identity verification within an onboarding process.                             |
-| `enrollment-server-onboarding.onboarding-process.max-processes-per-day`   | `5`       | Maximum number of onboarding processes during last 24 hours per user.                         |
-| `enrollment-server-onboarding.onboarding-process.max-error-score`         | `15`      | Maximum error score for an onboarding process.                                                |
-| `enrollment-server-onboarding.onboarding-process.default-type`            | `_empty_` | Default process type used for starting onboarding if not specified by the mobile application. |
+| Property                                                                            | Default   | Note                                                                                                   |
+|-------------------------------------------------------------------------------------|-----------|--------------------------------------------------------------------------------------------------------|
+| `enrollment-server-onboarding.onboarding-process.otp.length`                        | `8`       | Length of generated digital OTP codes.                                                                 |
+| `enrollment-server-onboarding.onboarding-process.otp.expiration`                    | `5m`      | Expiration time for OTP codes.                                                                         |
+| `enrollment-server-onboarding.onboarding-process.otp.max-failed-attempts`           | `5`       | Maximum number of failed attempts for OTP verification.                                                |
+| `enrollment-server-onboarding.onboarding-process.otp.resend-period`                 | `30s`     | A time period after which next OTP can be sent.                                                        |
+| `enrollment-server-onboarding.onboarding-process.expiration`                        | `3h`      | Onboarding process expiration time.                                                                    |
+| `enrollment-server-onboarding.onboarding-process.activation.expiration`             | `5m`      | Expiration of activations used within an onboarding process.                                           |
+| `enrollment-server-onboarding.onboarding-process.verification.expiration`           | `1h`      | Expiration of identity verification within an onboarding process.                                      |
+| `enrollment-server-onboarding.onboarding-process.max-processes-per-day`             | `5`       | Maximum number of onboarding processes during last 24 hours per user.                                  |
+| `enrollment-server-onboarding.onboarding-process.max-error-score`                   | `15`      | Maximum error score for an onboarding process.                                                         |
+| `enrollment-server-onboarding.onboarding-process.default-type`                      | `_empty_` | Default process type used for starting onboarding if not specified by the mobile application.          |
+| `enrollment-server-onboarding.onboarding-process.completedProcessDataRetentionTime` | `1h`      | Time period for which the identity data of completed onboarding processes is retained in the database. |
 
 ## Identity Verification Configuration
 

--- a/docs/onboarding/PowerAuth-Enrollment-Onboarding-Server-2.1.0.md
+++ b/docs/onboarding/PowerAuth-Enrollment-Onboarding-Server-2.1.0.md
@@ -32,33 +32,34 @@ The `document_verification_id` column is used to link a record to the `es_docume
 
 ### Onboarding process personal data retention
 
-The personal data retention period is configured using the property `enrollment-server-onboarding.identity-verification.data-retention`, and the retention period
-is measured from the process completion time—either the `timestamp_finished` or `timestamp_failed` column in the `es_onboarding_process` table.
-
-After this period, records linked to the process are deleted from the following tables:
+The cleanup logic was changed and the retention period is configured by `enrollment-server-onboarding.identity-verification.data-retention` and is counted from 
+the process completion time (either `timestamp_finished` or `timestamp_failed` column in `es_onboarding_process` table). After this period, records linked to the process 
+are deleted from the following tables:
 - `es_document_data`
 - `es_processed_document_data`
 - `es_selfie`
 
-This is a change from the previous version, where the retention period for records was calculated from their `timestamp_created`.
-After the upgrade, there may be situations where legacy records in `es_document_data` have a `NULL` value in the `document_verification_id` column—they have not yet been deleted 
-by the old cleaning service. Such records will not be deleted by the automatic cleanup task and must be removed manually. Every new record will have document_verification_id set, 
-and the cleanup will work as described.
-
-For manual cleanup, check whether any such records exist by executing the following SQL query:
+The new cleanup logic uses a new column, `es_onboarding_process.timestamp_personal_data_cleaned`, to track whether personal data has been deleted for a process. 
+Because the default value is `NULL`, all processes would be picked up by the first run of cleanup task. 
+To reduce the load on the task, it is recommended to set this value for processes that have already been cleaned by the old cleanup logic.
+Use the following SQL query to do so:
 
 ```sql
-SELECT count(*)
-FROM es_document_data
-WHERE document_verification_id IS NULL;
+UPDATE es_onboarding_process
+SET timestamp_personal_data_cleaned = now()
+WHERE timestamp_created < now() - interval :cleaned_processes_timestamp;
 ```
 
-If any records exist, they can be deleted using the following SQL query:
+The `:cleaned_processes_timestamp` is calculated as `2 * enrollment-server-onboarding.onboarding-process.expiration + 10 minutes`
 
-```sql
-DELETE FROM es_document_data
-WHERE document_verification_id IS NULL;
-```
+For example, if the configuration property `enrollment-server-onboarding.onboarding-process.expiration` is set to `8 hours`, the value of `:cleaned_processes_timestamp` would be `16 hours 10 minutes`.
+
+EXPLANATION OF THE CALCULATION:
+
+Each process expires after `enrollment-server-onboarding.onboarding-process.expiration` from its creation, and no personal data records can be created after that point. Personal data is then deleted 
+after the same `enrollment-server-onboarding.onboarding-process.expiration`, calculated from the time the data was created—not from the process creation time.
+In the worst case, a personal data record can be created very close to the process expiration time, which is why the configuration property is multiplied by 2. 
+The cleanup task for personal data runs every 10 minutes, which accounts for the additional 10 minutes added to the total time.
 
 
 ## Cleaning task

--- a/docs/onboarding/PowerAuth-Enrollment-Onboarding-Server-2.1.0.md
+++ b/docs/onboarding/PowerAuth-Enrollment-Onboarding-Server-2.1.0.md
@@ -22,7 +22,7 @@ The auditing tables may be already updated in your database schema if the databa
 
 ### Onboarding process identity data retention
 
-The identity data retention period is configured in the new `property enrollment-server-onboarding.onboarding-process.completedProcessDataRetentionTime`.
+The identity data retention period is configured using the new property `enrollment-server-onboarding.onboarding-process.completedProcessDataRetentionTime`.
 The retention period is measured from the process completion time—either the `timestamp_finished` or `timestamp_failed` column in the `es_onboarding_process` table.
 After this period, records linked to the process are deleted from the following tables:
 - `es_document_data`

--- a/docs/onboarding/PowerAuth-Enrollment-Onboarding-Server-2.1.0.md
+++ b/docs/onboarding/PowerAuth-Enrollment-Onboarding-Server-2.1.0.md
@@ -32,9 +32,30 @@ The `document_verification_id` column is used to link record with the `es_docume
 
 ### Onboarding process identity data retention
 
-The identity data retention period is configured using the new property `enrollment-server-onboarding.onboarding-process.completedProcessDataRetentionTime`.
-The retention period is measured from the process completion time—either the `timestamp_finished` or `timestamp_failed` column in the `es_onboarding_process` table.
+The identity data retention period is configured using the property `enrollment-server-onboarding.identity-verification.data-retention`, and the retention period 
+is measured from the process completion time—either the `timestamp_finished` or `timestamp_failed column` in the `es_onboarding_process` table.
+
 After this period, records linked to the process are deleted from the following tables:
 - `es_document_data`
 - `es_processed_document_data`
 - `es_selfie`
+
+This is a change from the previous version, where the retention period for records was calculated from their `timestamp_created`.
+After the upgrade, there may be situations where legacy records in `es_document_data` have a `NULL` value in the `document_verification_id` column—they have not yet been deleted 
+by the old cleaning service. Such records will not be deleted by the automatic cleanup task and must be removed manually. Every new record will have document_verification_id set, 
+and the cleanup will work as described.
+
+For manual cleanup, check whether any such records exist by executing the following SQL query:
+
+```sql
+SELECT count(*)
+FROM es_document_data
+WHERE document_verification_id IS NULL;
+```
+
+If any records exist, they can be deleted using the following SQL query:
+
+```sql
+DELETE FROM es_document_data
+WHERE document_verification_id IS NULL;
+```

--- a/docs/onboarding/PowerAuth-Enrollment-Onboarding-Server-2.1.0.md
+++ b/docs/onboarding/PowerAuth-Enrollment-Onboarding-Server-2.1.0.md
@@ -47,17 +47,31 @@ Because the default value is `NULL`, all processes would be picked up by the fir
 To reduce the load on the task, it is recommended to set this value for processes that have already been cleaned by the old cleanup logic.
 Use the following SQL query to do so:
 
+PostgreSQL:
+
 ```sql
 ALTER TABLE es_document_data ADD document_verification_id VARCHAR(36);
 
 UPDATE es_onboarding_process
 SET timestamp_personal_data_cleaned = now()
-WHERE timestamp_created < now() - interval :cleaned_processes_timestamp;
+WHERE timestamp_created < now() - :cleaned_processes_timestamp;
+```
+
+Oracle:
+
+```sql
+ALTER TABLE es_document_data ADD document_verification_id VARCHAR2(36);
+
+UPDATE es_onboarding_process
+SET timestamp_personal_data_cleaned = SYSTIMESTAMP
+WHERE timestamp_created < SYSTIMESTAMP - :cleaned_processes_timestamp;
 ```
 
 The `:cleaned_processes_timestamp` is calculated as `2 * enrollment-server-onboarding.onboarding-process.expiration + 10 minutes`
 
-For example, if the configuration property `enrollment-server-onboarding.onboarding-process.expiration` is set to `8 hours`, the value of `:cleaned_processes_timestamp` would be `16 hours 10 minutes`.
+For example, if the configuration property `enrollment-server-onboarding.onboarding-process.expiration` is set to `8 hours`, the value of `:cleaned_processes_timestamp` would be `16 hours 10 minutes`:
+- PostgreSQL: `INTERVAL '16 hours 10 minutes'`
+- Oracle: `TO_DSINTERVAL('0 16:10:00')`
 
 EXPLANATION OF THE CALCULATION:
 

--- a/docs/onboarding/PowerAuth-Enrollment-Onboarding-Server-2.1.0.md
+++ b/docs/onboarding/PowerAuth-Enrollment-Onboarding-Server-2.1.0.md
@@ -27,13 +27,13 @@ The `timestamp_personal_data_cleaned` column track when the personal data associ
 
 ### Add column document_verification_id to es_document_data table
 
-The `document_verification_id` column is used to link record with the `es_document_verification`. There is a one-to-one relationship and there is foreign key constraint.
+The `document_verification_id` column is used to link a record to the `es_document_verification` table. There is a one-to-one relationship and there is a foreign key constraint.
 
 
 ### Onboarding process identity data retention
 
-The identity data retention period is configured using the property `enrollment-server-onboarding.identity-verification.data-retention`, and the retention period 
-is measured from the process completion time—either the `timestamp_finished` or `timestamp_failed column` in the `es_onboarding_process` table.
+The identity data retention period is configured using the property `enrollment-server-onboarding.identity-verification.data-retention`, and the retention period
+is measured from the process completion time—either the `timestamp_finished` or `timestamp_failed` column in the `es_onboarding_process` table.
 
 After this period, records linked to the process are deleted from the following tables:
 - `es_document_data`

--- a/docs/onboarding/PowerAuth-Enrollment-Onboarding-Server-2.1.0.md
+++ b/docs/onboarding/PowerAuth-Enrollment-Onboarding-Server-2.1.0.md
@@ -18,3 +18,13 @@ Added a new indexed column `subject_id` holding an identifier linking the audit 
 <!-- begin box warning -->
 The auditing tables may be already updated in your database schema if the database schema is not separated for different PowerAuth applications. In case the column `audit_log.subject_id` and its index `audit_log_subject_id_idx` are already present, you can safely skip this migration step.
 <!-- end -->
+
+
+### Onboarding process identity data retention
+
+The identity data retention period is configured in the new `property enrollment-server-onboarding.onboarding-process.completedProcessDataRetentionTime`.
+The retention period is measured from the process completion time—either the `timestamp_finished` or `timestamp_failed` column in the `es_onboarding_process` table.
+After this period, records linked to the process are deleted from the following tables:
+- `es_document_data`
+- `es_processed_document_data`
+- `es_selfie`

--- a/docs/onboarding/PowerAuth-Enrollment-Onboarding-Server-2.1.0.md
+++ b/docs/onboarding/PowerAuth-Enrollment-Onboarding-Server-2.1.0.md
@@ -20,6 +20,16 @@ The auditing tables may be already updated in your database schema if the databa
 <!-- end -->
 
 
+### Add column timestamp_personal_data_cleaned to es_onboarding_process table
+
+The `timestamp_personal_data_cleaned` column track when the personal data associated with an onboarding process has been cleaned up.
+
+
+### Add column document_verification_id to es_document_data table
+
+The `document_verification_id` column is used to link record with the `es_document_verification`. There is a one-to-one relationship and there is foreign key constraint.
+
+
 ### Onboarding process identity data retention
 
 The identity data retention period is configured using the new property `enrollment-server-onboarding.onboarding-process.completedProcessDataRetentionTime`.

--- a/docs/onboarding/PowerAuth-Enrollment-Onboarding-Server-2.1.0.md
+++ b/docs/onboarding/PowerAuth-Enrollment-Onboarding-Server-2.1.0.md
@@ -30,9 +30,9 @@ The `timestamp_personal_data_cleaned` column track when the personal data associ
 The `document_verification_id` column is used to link a record to the `es_document_verification` table. There is a one-to-one relationship and there is a foreign key constraint.
 
 
-### Onboarding process identity data retention
+### Onboarding process personal data retention
 
-The identity data retention period is configured using the property `enrollment-server-onboarding.identity-verification.data-retention`, and the retention period
+The personal data retention period is configured using the property `enrollment-server-onboarding.identity-verification.data-retention`, and the retention period
 is measured from the process completion time—either the `timestamp_finished` or `timestamp_failed` column in the `es_onboarding_process` table.
 
 After this period, records linked to the process are deleted from the following tables:
@@ -59,3 +59,9 @@ If any records exist, they can be deleted using the following SQL query:
 DELETE FROM es_document_data
 WHERE document_verification_id IS NULL;
 ```
+
+
+## Cleaning task
+
+Added a new configuration property `enrollment-server-onboarding.onboarding-process.cleanup-limit` to limit the number of records 
+processed in a single run of the task cleaning personal data of completed onboarding processed.

--- a/docs/onboarding/PowerAuth-Enrollment-Onboarding-Server-2.1.0.md
+++ b/docs/onboarding/PowerAuth-Enrollment-Onboarding-Server-2.1.0.md
@@ -39,12 +39,17 @@ are deleted from the following tables:
 - `es_processed_document_data`
 - `es_selfie`
 
+
+#### Reduce the load of the first run of the new cleanup logic
+
 The new cleanup logic uses a new column, `es_onboarding_process.timestamp_personal_data_cleaned`, to track whether personal data has been deleted for a process. 
 Because the default value is `NULL`, all processes would be picked up by the first run of cleanup task. 
 To reduce the load on the task, it is recommended to set this value for processes that have already been cleaned by the old cleanup logic.
 Use the following SQL query to do so:
 
 ```sql
+ALTER TABLE es_document_data ADD document_verification_id VARCHAR(36);
+
 UPDATE es_onboarding_process
 SET timestamp_personal_data_cleaned = now()
 WHERE timestamp_created < now() - interval :cleaned_processes_timestamp;
@@ -60,6 +65,28 @@ Each process expires after `enrollment-server-onboarding.onboarding-process.expi
 after the same `enrollment-server-onboarding.onboarding-process.expiration`, calculated from the time the data was created—not from the process creation time.
 In the worst case, a personal data record can be created very close to the process expiration time, which is why the configuration property is multiplied by 2. 
 The cleanup task for personal data runs every 10 minutes, which accounts for the additional 10 minutes added to the total time.
+
+
+#### Cleanup of legacy records without document_verification_id
+
+After the upgrade, there may be situations where legacy records in `es_document_data` have a `NULL` value in the `document_verification_id` column—they have not yet been deleted
+by the old cleaning service. Such records will not be deleted by the automatic cleanup task and must be removed manually. This is because of a change from the previous version, 
+where the retention period for records was calculated from their `timestamp_created`. Every new record will have `document_verification_id` set, and the cleanup will work as described.
+
+For manual cleanup, check whether any such records exist by executing the following SQL query:
+
+```sql
+SELECT count(*)
+FROM es_document_data
+WHERE document_verification_id IS NULL;
+```
+
+If any records exist, they can be deleted using the following SQL query:
+
+```sql
+DELETE FROM es_document_data
+WHERE document_verification_id IS NULL;
+```
 
 
 ## Cleaning task

--- a/docs/sql/oracle/onboarding/create-schema.sql
+++ b/docs/sql/oracle/onboarding/create-schema.sql
@@ -377,3 +377,25 @@ CREATE INDEX audit_log_subject_id_idx ON audit_log(subject_id);
 -- Changeset enrollment-server-onboarding/2.0.x/20260402-document-country.xml::1::Lubos Racansky
 -- Creates a new column country in es_document_verification
 ALTER TABLE es_document_verification ADD country VARCHAR2(3);
+
+-- Changeset docs/db/changelog/changesets/enrollment-server-onboarding/2.1.x/20260408-personal-data-cleaned-timestamp.xml::1::Michal Rozehnal
+-- Create a new column timestamp_personal_data_cleaned in es_onboarding_process table to store the timestamp when the identity data was cleaned
+ALTER TABLE es_onboarding_process ADD timestamp_personal_data_cleaned TIMESTAMP;
+
+-- Changeset docs/db/changelog/changesets/enrollment-server-onboarding/2.1.x/20260408-personal-data-cleaned-timestamp.xml::2::Michal Rozehnal
+-- Create a new index es_onboarding_process_timestamp_personal_data_cleaned_idx
+CREATE INDEX es_onboarding_process_timestamp_personal_data_cleaned_idx ON es_onboarding_process(timestamp_personal_data_cleaned);
+
+-- Changeset docs/db/changelog/changesets/enrollment-server-onboarding/2.1.x/20260408-personal-data-cleaned-timestamp.xml::3::Michal Rozehnal
+-- Create a new index es_identity_verification_process_id_idx
+CREATE INDEX es_identity_verification_process_id_idx ON es_identity_verification(process_id);
+
+-- Changeset docs/db/changelog/changesets/enrollment-server-onboarding/2.1.x/20260408-personal-data-cleaned-timestamp.xml::4::Michal Rozehnal
+-- Create a new column document_verification_id in es_document_data table
+ALTER TABLE es_document_data ADD document_verification_id VARCHAR2(36);
+
+ALTER TABLE es_document_data ADD CONSTRAINT es_document_verification_id_fk FOREIGN KEY (document_verification_id) REFERENCES es_document_verification (id);
+
+-- Changeset docs/db/changelog/changesets/enrollment-server-onboarding/2.1.x/20260408-personal-data-cleaned-timestamp.xml::5::Michal Rozehnal
+-- Create a new index es_document_data_document_verification_id_idx
+CREATE INDEX es_document_data_document_verification_id_idx ON es_document_data(document_verification_id);

--- a/docs/sql/oracle/onboarding/migration_2.0.0_2.1.0.sql
+++ b/docs/sql/oracle/onboarding/migration_2.0.0_2.1.0.sql
@@ -6,3 +6,25 @@ ALTER TABLE audit_log ADD subject_id VARCHAR2(256);
 -- Changeset enrollment-server-onboarding/2.1.x/20260330-audit-subject-id.xml::2::Pavel Sindelar
 -- Create a new index on audit_log(subject_id)
 CREATE INDEX audit_log_subject_id_idx ON audit_log(subject_id);
+
+-- Changeset docs/db/changelog/changesets/enrollment-server-onboarding/2.1.x/20260408-personal-data-cleaned-timestamp.xml::1::Michal Rozehnal
+-- Create a new column timestamp_personal_data_cleaned in es_onboarding_process table to store the timestamp when the identity data was cleaned
+ALTER TABLE es_onboarding_process ADD timestamp_personal_data_cleaned TIMESTAMP;
+
+-- Changeset docs/db/changelog/changesets/enrollment-server-onboarding/2.1.x/20260408-personal-data-cleaned-timestamp.xml::2::Michal Rozehnal
+-- Create a new index es_onboarding_process_timestamp_personal_data_cleaned_idx
+CREATE INDEX es_onboarding_process_timestamp_personal_data_cleaned_idx ON es_onboarding_process(timestamp_personal_data_cleaned);
+
+-- Changeset docs/db/changelog/changesets/enrollment-server-onboarding/2.1.x/20260408-personal-data-cleaned-timestamp.xml::3::Michal Rozehnal
+-- Create a new index es_identity_verification_process_id_idx
+CREATE INDEX es_identity_verification_process_id_idx ON es_identity_verification(process_id);
+
+-- Changeset docs/db/changelog/changesets/enrollment-server-onboarding/2.1.x/20260408-personal-data-cleaned-timestamp.xml::4::Michal Rozehnal
+-- Create a new column document_verification_id in es_document_data table
+ALTER TABLE es_document_data ADD document_verification_id VARCHAR2(36);
+
+ALTER TABLE es_document_data ADD CONSTRAINT es_document_verification_id_fk FOREIGN KEY (document_verification_id) REFERENCES es_document_verification (id);
+
+-- Changeset docs/db/changelog/changesets/enrollment-server-onboarding/2.1.x/20260408-personal-data-cleaned-timestamp.xml::5::Michal Rozehnal
+-- Create a new index es_document_data_document_verification_id_idx
+CREATE INDEX es_document_data_document_verification_id_idx ON es_document_data(document_verification_id);

--- a/docs/sql/postgresql/onboarding/create-schema.sql
+++ b/docs/sql/postgresql/onboarding/create-schema.sql
@@ -355,3 +355,25 @@ CREATE INDEX audit_log_subject_id_idx ON audit_log(subject_id);
 -- Changeset enrollment-server-onboarding/2.0.x/20260402-document-country.xml::1::Lubos Racansky
 -- Creates a new column country in es_document_verification
 ALTER TABLE es_document_verification ADD country VARCHAR(3);
+
+-- Changeset docs/db/changelog/changesets/enrollment-server-onboarding/2.1.x/20260408-personal-data-cleaned-timestamp.xml::1::Michal Rozehnal
+-- Create a new column timestamp_personal_data_cleaned in es_onboarding_process table to store the timestamp when the identity data was cleaned
+ALTER TABLE es_onboarding_process ADD timestamp_personal_data_cleaned TIMESTAMP WITHOUT TIME ZONE;
+
+-- Changeset docs/db/changelog/changesets/enrollment-server-onboarding/2.1.x/20260408-personal-data-cleaned-timestamp.xml::2::Michal Rozehnal
+-- Create a new index es_onboarding_process_timestamp_personal_data_cleaned_idx
+CREATE INDEX es_onboarding_process_timestamp_personal_data_cleaned_idx ON es_onboarding_process(timestamp_personal_data_cleaned);
+
+-- Changeset docs/db/changelog/changesets/enrollment-server-onboarding/2.1.x/20260408-personal-data-cleaned-timestamp.xml::3::Michal Rozehnal
+-- Create a new index es_identity_verification_process_id_idx
+CREATE INDEX es_identity_verification_process_id_idx ON es_identity_verification(process_id);
+
+-- Changeset docs/db/changelog/changesets/enrollment-server-onboarding/2.1.x/20260408-personal-data-cleaned-timestamp.xml::4::Michal Rozehnal
+-- Create a new column document_verification_id in es_document_data table
+ALTER TABLE es_document_data ADD document_verification_id VARCHAR(36);
+
+ALTER TABLE es_document_data ADD CONSTRAINT es_document_verification_id_fk FOREIGN KEY (document_verification_id) REFERENCES es_document_verification (id);
+
+-- Changeset docs/db/changelog/changesets/enrollment-server-onboarding/2.1.x/20260408-personal-data-cleaned-timestamp.xml::5::Michal Rozehnal
+-- Create a new index es_document_data_document_verification_id_idx
+CREATE INDEX es_document_data_document_verification_id_idx ON es_document_data(document_verification_id);

--- a/docs/sql/postgresql/onboarding/migration_2.0.0_2.1.0.sql
+++ b/docs/sql/postgresql/onboarding/migration_2.0.0_2.1.0.sql
@@ -6,3 +6,25 @@ ALTER TABLE audit_log ADD subject_id VARCHAR(256);
 -- Changeset enrollment-server-onboarding/2.1.x/20260330-audit-subject-id.xml::2::Pavel Sindelar
 -- Create a new index on audit_log(subject_id)
 CREATE INDEX audit_log_subject_id_idx ON audit_log(subject_id);
+
+-- Changeset docs/db/changelog/changesets/enrollment-server-onboarding/2.1.x/20260408-personal-data-cleaned-timestamp.xml::1::Michal Rozehnal
+-- Create a new column timestamp_personal_data_cleaned in es_onboarding_process table to store the timestamp when the identity data was cleaned
+ALTER TABLE es_onboarding_process ADD timestamp_personal_data_cleaned TIMESTAMP WITHOUT TIME ZONE;
+
+-- Changeset docs/db/changelog/changesets/enrollment-server-onboarding/2.1.x/20260408-personal-data-cleaned-timestamp.xml::2::Michal Rozehnal
+-- Create a new index es_onboarding_process_timestamp_personal_data_cleaned_idx
+CREATE INDEX es_onboarding_process_timestamp_personal_data_cleaned_idx ON es_onboarding_process(timestamp_personal_data_cleaned);
+
+-- Changeset docs/db/changelog/changesets/enrollment-server-onboarding/2.1.x/20260408-personal-data-cleaned-timestamp.xml::3::Michal Rozehnal
+-- Create a new index es_identity_verification_process_id_idx
+CREATE INDEX es_identity_verification_process_id_idx ON es_identity_verification(process_id);
+
+-- Changeset docs/db/changelog/changesets/enrollment-server-onboarding/2.1.x/20260408-personal-data-cleaned-timestamp.xml::4::Michal Rozehnal
+-- Create a new column document_verification_id in es_document_data table
+ALTER TABLE es_document_data ADD document_verification_id VARCHAR(36);
+
+ALTER TABLE es_document_data ADD CONSTRAINT es_document_verification_id_fk FOREIGN KEY (document_verification_id) REFERENCES es_document_verification (id);
+
+-- Changeset docs/db/changelog/changesets/enrollment-server-onboarding/2.1.x/20260408-personal-data-cleaned-timestamp.xml::5::Michal Rozehnal
+-- Create a new index es_document_data_document_verification_id_idx
+CREATE INDEX es_document_data_document_verification_id_idx ON es_document_data(document_verification_id);

--- a/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/database/DocumentDataRepository.java
+++ b/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/database/DocumentDataRepository.java
@@ -24,7 +24,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.Set;
+import java.util.List;
 
 /**
  * Repository for document data records.
@@ -36,6 +36,6 @@ public interface DocumentDataRepository extends CrudRepository<DocumentDataEntit
 
     @Modifying
     @Query("DELETE FROM DocumentDataEntity d WHERE d.documentVerificationId IN :documentVerificationIds")
-    void deleteAllByDocumentVerificationIds(final Set<String> documentVerificationIds);
+    void deleteAllByDocumentVerificationIds(final List<String> documentVerificationIds);
 
 }

--- a/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/database/DocumentDataRepository.java
+++ b/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/database/DocumentDataRepository.java
@@ -24,7 +24,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.Date;
+import java.util.Set;
 
 /**
  * Repository for document data records.
@@ -35,7 +35,7 @@ import java.util.Date;
 public interface DocumentDataRepository extends CrudRepository<DocumentDataEntity, String> {
 
     @Modifying
-    @Query("DELETE FROM DocumentDataEntity d WHERE d.timestampCreated < :dateCleanup")
-    int cleanupDocumentData(Date dateCleanup);
+    @Query("DELETE FROM DocumentDataEntity d WHERE d.documentVerificationId IN :documentVerificationIds")
+    void deleteAllByDocumentVerificationIds(final Set<String> documentVerificationIds);
 
 }

--- a/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/database/OnboardingProcessRepository.java
+++ b/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/database/OnboardingProcessRepository.java
@@ -20,7 +20,7 @@ package com.wultra.app.onboardingserver.common.database;
 
 import com.wultra.app.enrollmentserver.model.enumeration.ErrorOrigin;
 import com.wultra.app.enrollmentserver.model.enumeration.OnboardingStatus;
-import com.wultra.app.onboardingserver.common.database.entity.OnboardingProcessIdentityDataIdsView;
+import com.wultra.app.onboardingserver.common.database.entity.OnboardingProcessPersonalDataIdsProjection;
 import com.wultra.app.onboardingserver.common.database.entity.OnboardingProcessEntity;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.Lock;
@@ -213,9 +213,9 @@ public interface OnboardingProcessRepository extends CrudRepository<OnboardingPr
         JOIN DocumentVerificationEntity dv ON dv.identityVerification.id = iv.id
         WHERE p.status IN :statuses
           AND (p.timestampFinished < :processCompletedBefore OR p.timestampFailed < :processCompletedBefore)
-          AND p.timestampIdentityDataCleaned IS NULL
+          AND p.timestampPersonalDataCleaned IS NULL
         """)
-    List<OnboardingProcessIdentityDataIdsView> findIdentityDataForCleanup(final Set<OnboardingStatus> statuses, final Date processCompletedBefore);
+    List<OnboardingProcessPersonalDataIdsProjection> findIdentityDataForCleanup(final Set<OnboardingStatus> statuses, final Date processCompletedBefore);
 
     /**
      * Sets identity data cleaned timestamp.
@@ -226,8 +226,8 @@ public interface OnboardingProcessRepository extends CrudRepository<OnboardingPr
     @Modifying
     @Query("""
             UPDATE OnboardingProcessEntity p SET
-                    p.timestampIdentityDataCleaned = :timestamp
+                    p.timestampPersonalDataCleaned = :timestamp
             WHERE p.id IN :ids
         """)
-    void updateIdentityDataCleanup(final Set<String> ids, final Date timestamp);
+    void updateIdentityDataCleanup(final List<String> ids, final Date timestamp);
 }

--- a/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/database/OnboardingProcessRepository.java
+++ b/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/database/OnboardingProcessRepository.java
@@ -212,7 +212,7 @@ public interface OnboardingProcessRepository extends CrudRepository<OnboardingPr
                dv.id AS documentVerificationId
         FROM OnboardingProcessEntity p
         JOIN IdentityVerificationEntity iv ON iv.processId = p.id
-        LEFT JOIN DocumentVerificationEntity dv ON dv.identityVerification.id = iv.id
+        JOIN DocumentVerificationEntity dv ON dv.identityVerification.id = iv.id
         WHERE p.status IN :statuses
           AND (p.timestampFinished < :processCompletedBefore OR p.timestampFailed < :processCompletedBefore)
           AND p.timestampPersonalDataCleaned IS NULL

--- a/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/database/OnboardingProcessRepository.java
+++ b/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/database/OnboardingProcessRepository.java
@@ -23,6 +23,7 @@ import com.wultra.app.enrollmentserver.model.enumeration.OnboardingStatus;
 import com.wultra.app.onboardingserver.common.database.entity.OnboardingProcessPersonalDataIdsProjection;
 import com.wultra.app.onboardingserver.common.database.entity.OnboardingProcessEntity;
 import jakarta.persistence.LockModeType;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -202,6 +203,7 @@ public interface OnboardingProcessRepository extends CrudRepository<OnboardingPr
      *
      * @param statuses statuses of completed processes
      * @param processCompletedBefore time before which the process must have been completed to be included in the result
+     * @param pageable pagination for limiting size of result
      * @return list of identity data IDs for completed processes to be cleaned up
      */
     @Query("""
@@ -215,7 +217,7 @@ public interface OnboardingProcessRepository extends CrudRepository<OnboardingPr
           AND (p.timestampFinished < :processCompletedBefore OR p.timestampFailed < :processCompletedBefore)
           AND p.timestampPersonalDataCleaned IS NULL
         """)
-    List<OnboardingProcessPersonalDataIdsProjection> findIdentityDataForCleanup(final Set<OnboardingStatus> statuses, final Date processCompletedBefore);
+    List<OnboardingProcessPersonalDataIdsProjection> findIdentityDataForCleanup(final Set<OnboardingStatus> statuses, final Date processCompletedBefore, final Pageable pageable);
 
     /**
      * Sets identity data cleaned timestamp.

--- a/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/database/OnboardingProcessRepository.java
+++ b/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/database/OnboardingProcessRepository.java
@@ -207,8 +207,7 @@ public interface OnboardingProcessRepository extends CrudRepository<OnboardingPr
     @Query("""
         SELECT p.id AS processId,
                iv.id AS identityVerificationId,
-               dv.id AS documentVerificationId,
-               dv.uploadId AS uploadId
+               dv.id AS documentVerificationId
         FROM OnboardingProcessEntity p
         JOIN IdentityVerificationEntity iv ON iv.processId = p.id
         JOIN DocumentVerificationEntity dv ON dv.identityVerification.id = iv.id

--- a/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/database/OnboardingProcessRepository.java
+++ b/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/database/OnboardingProcessRepository.java
@@ -20,6 +20,7 @@ package com.wultra.app.onboardingserver.common.database;
 
 import com.wultra.app.enrollmentserver.model.enumeration.ErrorOrigin;
 import com.wultra.app.enrollmentserver.model.enumeration.OnboardingStatus;
+import com.wultra.app.onboardingserver.common.database.entity.OnboardingProcessIdentityDataIdsView;
 import com.wultra.app.onboardingserver.common.database.entity.OnboardingProcessEntity;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.Lock;
@@ -195,5 +196,24 @@ public interface OnboardingProcessRepository extends CrudRepository<OnboardingPr
             "p.errorOrigin = :errorOrigin " +
             "WHERE p.id IN :ids")
     void terminate(Collection<String> ids, Date timestampExpired, String errorDetail, ErrorOrigin errorOrigin);
+
+    /**
+     * Finds all identity data IDs for completed processes to be cleaned up.
+     *
+     * @param statuses statuses of completed processes
+     * @param processCompletedBefore time before which the process must have been completed to be included in the result
+     * @return list of identity data IDs for completed processes to be cleaned up
+     */
+    @Query("""
+        SELECT iv.id AS identityVerificationId,
+               dv.id AS documentVerificationId,
+               dv.uploadId AS uploadId
+        FROM OnboardingProcessEntity p
+        JOIN IdentityVerificationEntity iv ON iv.processId = p.id
+        JOIN DocumentVerificationEntity dv ON dv.identityVerification.id = iv.id
+        WHERE p.status IN :statuses
+          AND (p.timestampFinished < :processCompletedBefore OR p.timestampFailed < :processCompletedBefore)
+        """)
+    List<OnboardingProcessIdentityDataIdsView> findIdentityDataForCleanup(final Set<OnboardingStatus> statuses, final Date processCompletedBefore);
 
 }

--- a/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/database/OnboardingProcessRepository.java
+++ b/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/database/OnboardingProcessRepository.java
@@ -205,7 +205,8 @@ public interface OnboardingProcessRepository extends CrudRepository<OnboardingPr
      * @return list of identity data IDs for completed processes to be cleaned up
      */
     @Query("""
-        SELECT iv.id AS identityVerificationId,
+        SELECT p.id AS processId,
+               iv.id AS identityVerificationId,
                dv.id AS documentVerificationId,
                dv.uploadId AS uploadId
         FROM OnboardingProcessEntity p
@@ -213,7 +214,21 @@ public interface OnboardingProcessRepository extends CrudRepository<OnboardingPr
         JOIN DocumentVerificationEntity dv ON dv.identityVerification.id = iv.id
         WHERE p.status IN :statuses
           AND (p.timestampFinished < :processCompletedBefore OR p.timestampFailed < :processCompletedBefore)
+          AND p.timestampIdentityDataCleaned IS NULL
         """)
     List<OnboardingProcessIdentityDataIdsView> findIdentityDataForCleanup(final Set<OnboardingStatus> statuses, final Date processCompletedBefore);
 
+    /**
+     * Sets identity data cleaned timestamp.
+     *
+     * @param ids process IDs where the timestamp will be set
+     * @param timestamp timestamp to be set
+     */
+    @Modifying
+    @Query("""
+            UPDATE OnboardingProcessEntity p SET
+                    p.timestampIdentityDataCleaned = :timestamp
+            WHERE p.id IN :ids
+        """)
+    void updateIdentityDataCleanup(final Set<String> ids, final Date timestamp);
 }

--- a/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/database/OnboardingProcessRepository.java
+++ b/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/database/OnboardingProcessRepository.java
@@ -210,7 +210,7 @@ public interface OnboardingProcessRepository extends CrudRepository<OnboardingPr
                dv.id AS documentVerificationId
         FROM OnboardingProcessEntity p
         JOIN IdentityVerificationEntity iv ON iv.processId = p.id
-        JOIN DocumentVerificationEntity dv ON dv.identityVerification.id = iv.id
+        LEFT JOIN DocumentVerificationEntity dv ON dv.identityVerification.id = iv.id
         WHERE p.status IN :statuses
           AND (p.timestampFinished < :processCompletedBefore OR p.timestampFailed < :processCompletedBefore)
           AND p.timestampPersonalDataCleaned IS NULL

--- a/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/database/ProcessedDocumentDataRepository.java
+++ b/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/database/ProcessedDocumentDataRepository.java
@@ -48,4 +48,13 @@ public interface ProcessedDocumentDataRepository extends CrudRepository<Processe
 
     @Query("SELECT p FROM ProcessedDocumentDataEntity p WHERE p.documentVerificationId IN :documentVerificationIds")
     List<ProcessedDocumentDataEntity> findAllByDocumentVerificationIds(final Set<String> documentVerificationIds);
+
+    /**
+     * Deletes all records by document verification IDs.
+     *
+     * @param documentVerificationIds document verification IDs to be deleted
+     */
+    @Modifying
+    @Query("DELETE FROM ProcessedDocumentDataEntity p WHERE p.documentVerificationId IN :documentVerificationIds")
+    void deleteAllByDocumentVerificationIds(final Set<String> documentVerificationIds);
 }

--- a/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/database/ProcessedDocumentDataRepository.java
+++ b/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/database/ProcessedDocumentDataRepository.java
@@ -56,5 +56,5 @@ public interface ProcessedDocumentDataRepository extends CrudRepository<Processe
      */
     @Modifying
     @Query("DELETE FROM ProcessedDocumentDataEntity p WHERE p.documentVerificationId IN :documentVerificationIds")
-    void deleteAllByDocumentVerificationIds(final Set<String> documentVerificationIds);
+    void deleteAllByDocumentVerificationIds(final List<String> documentVerificationIds);
 }

--- a/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/database/SelfieRepository.java
+++ b/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/database/SelfieRepository.java
@@ -26,8 +26,8 @@ import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.Date;
+import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 /**
  * Repository for {@link SelfieEntity}.
@@ -54,5 +54,5 @@ public interface SelfieRepository extends CrudRepository<SelfieEntity, Long> {
      */
     @Modifying
     @Query("DELETE FROM SelfieEntity s WHERE s.identityVerification.id IN :identityVerificationIds")
-    void deleteAllByIdentityVerificationIds(final Set<String> identityVerificationIds);
+    void deleteAllByIdentityVerificationIds(final List<String> identityVerificationIds);
 }

--- a/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/database/SelfieRepository.java
+++ b/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/database/SelfieRepository.java
@@ -27,6 +27,7 @@ import org.springframework.stereotype.Repository;
 
 import java.util.Date;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Repository for {@link SelfieEntity}.
@@ -45,4 +46,13 @@ public interface SelfieRepository extends CrudRepository<SelfieEntity, Long> {
     @Modifying
     @Query("DELETE FROM SelfieEntity s WHERE s.identityVerification.id = :identityVerificationId")
     void deleteAllByIdentityVerificationId(final String identityVerificationId);
+
+    /**
+     * Deletes all records by identity verification IDs.
+     *
+     * @param identityVerificationIds identity verification IDs to be deleted
+     */
+    @Modifying
+    @Query("DELETE FROM SelfieEntity s WHERE s.identityVerification.id IN :identityVerificationIds")
+    void deleteAllByIdentityVerificationIds(final Set<String> identityVerificationIds);
 }

--- a/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/database/entity/DocumentDataEntity.java
+++ b/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/database/entity/DocumentDataEntity.java
@@ -22,6 +22,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -65,6 +66,15 @@ public class DocumentDataEntity implements Serializable {
      */
     @Column(name = "timestamp_created", nullable = false)
     private Date timestampCreated;
+
+    /**
+     * ID of linked {@link DocumentVerificationEntity}.
+     *
+     * @implNote Nullable for backward compatibility. New records should be non-null.
+     */
+    @Column(name = "document_verification_id")
+    @NotNull
+    private String documentVerificationId;
 
     @Override
     public boolean equals(Object o) {

--- a/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/database/entity/OnboardingProcessEntity.java
+++ b/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/database/entity/OnboardingProcessEntity.java
@@ -148,6 +148,12 @@ public class OnboardingProcessEntity implements Serializable {
     @NotNull
     private OnboardingProcessConfigurationEntity processConfiguration;
 
+    /**
+     * Timestamp when the identity data (e.g. selfie, uploaded documents) was cleaned up.
+     */
+    @Column(name = "timestamp_identity_data_cleaned")
+    private Date timestampIdentityDataCleaned;
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/database/entity/OnboardingProcessEntity.java
+++ b/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/database/entity/OnboardingProcessEntity.java
@@ -151,8 +151,8 @@ public class OnboardingProcessEntity implements Serializable {
     /**
      * Timestamp when the identity data (e.g. selfie, uploaded documents) was cleaned up.
      */
-    @Column(name = "timestamp_identity_data_cleaned")
-    private Date timestampIdentityDataCleaned;
+    @Column(name = "timestamp_personal_data_cleaned")
+    private Date timestampPersonalDataCleaned;
 
     @Override
     public boolean equals(Object o) {

--- a/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/database/entity/OnboardingProcessIdentityDataIdsView.java
+++ b/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/database/entity/OnboardingProcessIdentityDataIdsView.java
@@ -1,0 +1,49 @@
+/*
+ * PowerAuth Enrollment Server
+ * Copyright (C) 2026 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.wultra.app.onboardingserver.common.database.entity;
+
+
+/**
+ * View for {@link OnboardingProcessEntity} identity data IDs.
+ *
+ * @author Michal Rozehnal, michal.rozehnal@wultra.com
+ */
+public interface OnboardingProcessIdentityDataIdsView {
+
+    /**
+     * Gets linked {@link IdentityVerificationEntity#id}.
+     *
+     * @return identity verification ID
+     */
+    String getIdentityVerificationId();
+
+    /**
+     * Gets linked {@link DocumentVerificationEntity#id}.
+     *
+     * @return document verification ID
+     */
+    String getDocumentVerificationId();
+
+    /**
+     * Gets linked {@link DocumentVerificationEntity#uploadId}
+     *
+     * @return document verification upload ID
+     */
+    String getUploadId();
+}

--- a/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/database/entity/OnboardingProcessIdentityDataIdsView.java
+++ b/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/database/entity/OnboardingProcessIdentityDataIdsView.java
@@ -27,6 +27,13 @@ package com.wultra.app.onboardingserver.common.database.entity;
 public interface OnboardingProcessIdentityDataIdsView {
 
     /**
+     * Gets {@link OnboardingProcessEntity#id}.
+     *
+     * @return onboarding process ID
+     */
+    String getProcessId();
+
+    /**
      * Gets linked {@link IdentityVerificationEntity#id}.
      *
      * @return identity verification ID

--- a/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/database/entity/OnboardingProcessIdentityDataIdsView.java
+++ b/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/database/entity/OnboardingProcessIdentityDataIdsView.java
@@ -46,11 +46,4 @@ public interface OnboardingProcessIdentityDataIdsView {
      * @return document verification ID
      */
     String getDocumentVerificationId();
-
-    /**
-     * Gets linked {@link DocumentVerificationEntity#uploadId}
-     *
-     * @return document verification upload ID
-     */
-    String getUploadId();
 }

--- a/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/database/entity/OnboardingProcessPersonalDataIdsProjection.java
+++ b/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/database/entity/OnboardingProcessPersonalDataIdsProjection.java
@@ -20,11 +20,11 @@ package com.wultra.app.onboardingserver.common.database.entity;
 
 
 /**
- * View for {@link OnboardingProcessEntity} identity data IDs.
+ * Projection for {@link OnboardingProcessEntity} personal data IDs.
  *
  * @author Michal Rozehnal, michal.rozehnal@wultra.com
  */
-public interface OnboardingProcessIdentityDataIdsView {
+public interface OnboardingProcessPersonalDataIdsProjection {
 
     /**
      * Gets {@link OnboardingProcessEntity#id}.

--- a/enrollment-server-onboarding-domain-model/src/main/java/com/wultra/app/enrollmentserver/model/enumeration/OnboardingStatus.java
+++ b/enrollment-server-onboarding-domain-model/src/main/java/com/wultra/app/enrollmentserver/model/enumeration/OnboardingStatus.java
@@ -52,4 +52,9 @@ public enum OnboardingStatus {
      */
     public static final Set<OnboardingStatus> NOT_YET_COMPLETED = Set.of(ACTIVATION_IN_PROGRESS, VERIFICATION_IN_PROGRESS);
 
+    /**
+     * Set of statuses representing completed onboarding process.
+     */
+    public static final Set<OnboardingStatus> COMPLETED = Set.of(ACTIVATION_IN_PROGRESS, VERIFICATION_IN_PROGRESS);
+
 }

--- a/enrollment-server-onboarding-domain-model/src/main/java/com/wultra/app/enrollmentserver/model/enumeration/OnboardingStatus.java
+++ b/enrollment-server-onboarding-domain-model/src/main/java/com/wultra/app/enrollmentserver/model/enumeration/OnboardingStatus.java
@@ -55,6 +55,6 @@ public enum OnboardingStatus {
     /**
      * Set of statuses representing completed onboarding process.
      */
-    public static final Set<OnboardingStatus> COMPLETED = Set.of(ACTIVATION_IN_PROGRESS, VERIFICATION_IN_PROGRESS);
+    public static final Set<OnboardingStatus> COMPLETED = Set.of(FINISHED, FAILED);
 
 }

--- a/enrollment-server-onboarding-provider-microblink/src/main/java/com/wultra/app/onboardingserver/provider/microblink/MicroblinkDocumentVerificationProvider.java
+++ b/enrollment-server-onboarding-provider-microblink/src/main/java/com/wultra/app/onboardingserver/provider/microblink/MicroblinkDocumentVerificationProvider.java
@@ -157,7 +157,7 @@ public class MicroblinkDocumentVerificationProvider implements DocumentVerificat
             logger.info("action: submitDocuments, state: succeeded, provider: microblink, rejectReason: {}", result.getRejectReason());
             return result;
         } catch (final DocumentVerificationException | RemoteCommunicationException | RuntimeException e) {
-            final var errorMessage = e.getMessage();
+            final var errorMessage = "Microblink provider exception: %s %s".formatted(e.getClass().getSimpleName(), e.getMessage());
             final var documentResults = documentsVerificationData.stream()
                 .map(document -> {
                     final var submitResult = new DocumentSubmitResult();

--- a/enrollment-server-onboarding-provider-microblink/src/main/java/com/wultra/app/onboardingserver/provider/microblink/MicroblinkDocumentVerificationProvider.java
+++ b/enrollment-server-onboarding-provider-microblink/src/main/java/com/wultra/app/onboardingserver/provider/microblink/MicroblinkDocumentVerificationProvider.java
@@ -130,32 +130,47 @@ public class MicroblinkDocumentVerificationProvider implements DocumentVerificat
                 .map(MicroblinkDocumentVerificationProvider::buildDocumentVerificationData)
                 .toList();
 
-        saveDocumentsData(documentsVerificationData);
+        final var microblinkResponseByDocumentType = new EnumMap<DocumentType, DocumentVerificationResponseBundle>(DocumentType.class);
+        final var auditData = new EnumMap<DocumentType, ObjectNode>(DocumentType.class);
+        String facePhotoId = null;
 
-        final var documentsByTypeAndSide = groupDocumentsByTypeAndSide(documentsVerificationData);
-        final var microblinkResponseByDocumentType = fetchMicroblinkResults(documentsByTypeAndSide);
+        try {
+            saveDocumentsData(documentsVerificationData);
 
-        final var documentResults = processMicroblinkResults(documentsVerificationData, microblinkResponseByDocumentType);
+            final var documentsByTypeAndSide = groupDocumentsByTypeAndSide(documentsVerificationData);
 
-        final var documentVerificationsByDocumentType = getDocumentVerificationsByDocumentType(ownerId, documentsByTypeAndSide.keySet());
-        final var facePhotoId = saveProcessedImages(microblinkResponseByDocumentType, documentVerificationsByDocumentType);
+            microblinkResponseByDocumentType.putAll(fetchMicroblinkResults(documentsByTypeAndSide));
+            auditData.putAll(collectDataForAudit(microblinkResponseByDocumentType));
 
-        final var result = new DocumentsSubmitResult();
-        result.setResults(documentResults);
-        result.setExtractedPhotoId(facePhotoId);
-        result.setAuditData(collectDataForAudit(microblinkResponseByDocumentType));
+            final var documentResults = processMicroblinkResults(documentsVerificationData, microblinkResponseByDocumentType);
 
-        final var rejectedDocuments = documentResults.stream()
-                .filter(r -> r.getRejectReason() != null)
-                .map(DocumentSubmitResult::getDocumentId)
-                .toList();
+            final var documentVerificationsByDocumentType = getDocumentVerificationsByDocumentType(ownerId, documentsByTypeAndSide.keySet());
+            facePhotoId = saveProcessedImages(microblinkResponseByDocumentType, documentVerificationsByDocumentType);
 
-        if (!rejectedDocuments.isEmpty()) {
-            result.setRejectReason("Rejected documents: " + rejectedDocuments);
+            final var result = createSubmitResult(documentResults, facePhotoId, auditData, null);
+
+            logger.info("action: submitDocuments, state: succeeded, provider: microblink, rejectReason: {}", result.getRejectReason());
+            return result;
+        } catch (final DocumentVerificationException | RemoteCommunicationException | RuntimeException e) {
+            logger.info("action: submitDocuments, state: failed, provider: microblink, error: {}", e.getMessage(), e);
+
+            final var errorMessage = e.getMessage();
+            final var documentResults = documentsVerificationData.stream()
+                .map(document -> {
+                    final var submitResult = new DocumentSubmitResult();
+                    submitResult.setDocumentId(document.documentId());
+
+                    // If any DocumentDataEntity is saved, then uploadId must always be returned so it can be bound to the DocumentVerificationEntity.
+                    // A foreign key cannot be used for DocumentVerificationEntity.uploadId because, depending on the provider, data may be uploaded to the cloud and there may be no corresponding DocumentDataEntity record.
+                    submitResult.setUploadId(document.uploadId());
+
+                    submitResult.setErrorDetail(errorMessage);
+                    return submitResult;
+                })
+            .toList();
+
+            return createSubmitResult(documentResults, facePhotoId, auditData, errorMessage);
         }
-
-        logger.info("action: submitDocuments, state: succeeded, provider: microblink, rejectReason: {}", result.getRejectReason());
-        return result;
     }
 
     @Override
@@ -801,6 +816,31 @@ public class MicroblinkDocumentVerificationProvider implements DocumentVerificat
                         Map.Entry::getKey,
                         entry -> entry.getValue().getResponseWithoutPersonalData()
                 ));
+    }
+
+    private static DocumentsSubmitResult createSubmitResult(
+            final List<DocumentSubmitResult> documentResults,
+            final String facePhotoId,
+            final Map<DocumentType, ObjectNode> auditData,
+            final String errorDetail
+    ) {
+        final var result = new DocumentsSubmitResult();
+        result.setResults(documentResults);
+        result.setExtractedPhotoId(facePhotoId);
+        result.setAuditData(auditData);
+
+        final var rejectedDocuments = documentResults.stream()
+                .filter(r -> r.getRejectReason() != null)
+                .map(DocumentSubmitResult::getDocumentId)
+                .toList();
+
+        if (!rejectedDocuments.isEmpty()) {
+            result.setRejectReason("Rejected documents: " + rejectedDocuments);
+        }
+
+        result.setErrorDetail(errorDetail);
+
+        return result;
     }
 
     @Builder(toBuilder = true)

--- a/enrollment-server-onboarding-provider-microblink/src/main/java/com/wultra/app/onboardingserver/provider/microblink/MicroblinkDocumentVerificationProvider.java
+++ b/enrollment-server-onboarding-provider-microblink/src/main/java/com/wultra/app/onboardingserver/provider/microblink/MicroblinkDocumentVerificationProvider.java
@@ -118,16 +118,21 @@ public class MicroblinkDocumentVerificationProvider implements DocumentVerificat
         throw new UnsupportedOperationException("Method checkDocumentUpload is not supported by Microblink provider.");
     }
 
+    /**
+     * @implNote If any DocumentDataEntity is saved, then uploadId must always be returned so it can be bound to the DocumentVerificationEntity.
+     * A foreign key cannot be used for DocumentVerificationEntity.uploadId because, depending on the provider, data may be uploaded to the cloud
+     * and there may be no corresponding DocumentDataEntity record.
+     */
     @Override
     public DocumentsSubmitResult submitDocuments(OwnerId ownerId, List<SubmittedDocument> submittedDocuments) throws DocumentVerificationException, RemoteCommunicationException {
-        final var documentIds = submittedDocuments.stream()
+        final var documentVerificationIds = submittedDocuments.stream()
                 .map(SubmittedDocument::getDocumentId)
                 .toList();
 
-        logger.info("action: submitDocuments, state: initiated, provider: microblink, ownerId: {}, documentIds: {}", ownerId, documentIds);
+        logger.info("action: submitDocuments, state: initiated, provider: microblink, ownerId: {}, documentVerificationIds: {}", ownerId, documentVerificationIds);
 
         final var documentsVerificationData = submittedDocuments.stream()
-                .map(MicroblinkDocumentVerificationProvider::buildDocumentVerificationData)
+                .map(MicroblinkDocumentVerificationProvider::createDocumentVerificationData)
                 .toList();
 
         final var microblinkResponseByDocumentType = new EnumMap<DocumentType, DocumentVerificationResponseBundle>(DocumentType.class);
@@ -152,23 +157,18 @@ public class MicroblinkDocumentVerificationProvider implements DocumentVerificat
             logger.info("action: submitDocuments, state: succeeded, provider: microblink, rejectReason: {}", result.getRejectReason());
             return result;
         } catch (final DocumentVerificationException | RemoteCommunicationException | RuntimeException e) {
-            logger.info("action: submitDocuments, state: failed, provider: microblink, error: {}", e.getMessage(), e);
-
             final var errorMessage = e.getMessage();
             final var documentResults = documentsVerificationData.stream()
                 .map(document -> {
                     final var submitResult = new DocumentSubmitResult();
-                    submitResult.setDocumentId(document.documentId());
-
-                    // If any DocumentDataEntity is saved, then uploadId must always be returned so it can be bound to the DocumentVerificationEntity.
-                    // A foreign key cannot be used for DocumentVerificationEntity.uploadId because, depending on the provider, data may be uploaded to the cloud and there may be no corresponding DocumentDataEntity record.
+                    submitResult.setDocumentId(document.documentVerificationId());
                     submitResult.setUploadId(document.uploadId());
-
                     submitResult.setErrorDetail(errorMessage);
                     return submitResult;
                 })
             .toList();
 
+            logger.info("action: submitDocuments, state: failed, provider: microblink, error: {}", e.getMessage(), e);
             return createSubmitResult(documentResults, facePhotoId, auditData, errorMessage);
         }
     }
@@ -260,9 +260,9 @@ public class MicroblinkDocumentVerificationProvider implements DocumentVerificat
         }
     }
 
-    private static DocumentVerificationData buildDocumentVerificationData(final SubmittedDocument submittedDocument) {
+    private static DocumentVerificationData createDocumentVerificationData(final SubmittedDocument submittedDocument) {
         return DocumentVerificationData.builder()
-                .documentId(submittedDocument.getDocumentId())
+                .documentVerificationId(submittedDocument.getDocumentId())
                 .uploadId(UUID.randomUUID().toString())
                 .type(submittedDocument.getType())
                 .side(submittedDocument.getSide())
@@ -294,7 +294,7 @@ public class MicroblinkDocumentVerificationProvider implements DocumentVerificat
                         "Multiple documents of type %s and side %s found. Document ids: %s".formatted(
                                 documentType,
                                 documentSide,
-                                List.of(documentOfSameSide.documentId(), documentVerificationData.documentId())
+                                List.of(documentOfSameSide.documentVerificationId(), documentVerificationData.documentVerificationId())
                         )
                 );
             }
@@ -406,7 +406,7 @@ public class MicroblinkDocumentVerificationProvider implements DocumentVerificat
             final var extractedDataValue = microblinkExtractedDataParser.parseExtractedData(extractedData, responseBody.extraction());
 
             final var result = new DocumentSubmitResult();
-            result.setDocumentId(documentVerificationData.documentId());
+            result.setDocumentId(documentVerificationData.documentVerificationId());
             result.setUploadId(documentVerificationData.uploadId());
             result.setExtractedData(extractedDataValue);
             result.setValidationResult(microblinkResponse.getResponseWithoutImages());
@@ -807,6 +807,7 @@ public class MicroblinkDocumentVerificationProvider implements DocumentVerificat
         documentData.setId(document.uploadId());
         documentData.setData(document.image().getData());
         documentData.setTimestampCreated(new Date());
+        documentData.setDocumentVerificationId(document.documentVerificationId);
         return documentData;
     }
 
@@ -845,7 +846,7 @@ public class MicroblinkDocumentVerificationProvider implements DocumentVerificat
 
     @Builder(toBuilder = true)
     record DocumentVerificationData(
-            String documentId,
+            String documentVerificationId,
             String uploadId,
             DocumentType type,
             CardSide side,

--- a/enrollment-server-onboarding-provider-microblink/src/test/java/com/wultra/app/onboardingserver/provider/microblink/MicroblinkDocumentVerificationProviderIntTest.java
+++ b/enrollment-server-onboarding-provider-microblink/src/test/java/com/wultra/app/onboardingserver/provider/microblink/MicroblinkDocumentVerificationProviderIntTest.java
@@ -580,6 +580,7 @@ class MicroblinkDocumentVerificationProviderIntTest {
         final var frontDocumentData = documentDataByUploadId.get(frontDocumentUploadId);
         assertArrayEquals(idCardFrontImage.getData(), frontDocumentData.getData());
         assertEquals(new Date().getTime(), frontDocumentData.getTimestampCreated().getTime(), TIMESTAMP_ASSERT_DELTA_MS);
+        assertEquals(ID_CARD_FRONT_DOCUMENT_ID, frontDocumentData.getDocumentVerificationId());
 
         final var backDocumentUploadId = result.getResults().stream()
                 .filter(d -> d.getDocumentId().equals(ID_CARD_BACK_DOCUMENT_ID))
@@ -590,6 +591,7 @@ class MicroblinkDocumentVerificationProviderIntTest {
         final var backDocumentData = documentDataByUploadId.get(backDocumentUploadId);
         assertArrayEquals(idCardBackImage.getData(), backDocumentData.getData());
         assertEquals(new Date().getTime(), backDocumentData.getTimestampCreated().getTime(), TIMESTAMP_ASSERT_DELTA_MS);
+        assertEquals(ID_CARD_BACK_DOCUMENT_ID, backDocumentData.getDocumentVerificationId());
     }
 
     private void assertProcessedDocumentData() {

--- a/enrollment-server-onboarding-provider-microblink/src/test/java/com/wultra/app/onboardingserver/provider/microblink/MicroblinkDocumentVerificationProviderIntTest.java
+++ b/enrollment-server-onboarding-provider-microblink/src/test/java/com/wultra/app/onboardingserver/provider/microblink/MicroblinkDocumentVerificationProviderIntTest.java
@@ -215,7 +215,7 @@ class MicroblinkDocumentVerificationProviderIntTest {
         ownerId.setUserId("37f9c00e-67ad-47e3-9c02-9a87e61cfa12");
 
         idCardFrontDocument = MicroblinkDocumentVerificationProvider.DocumentVerificationData.builder()
-                .documentId(ID_CARD_FRONT_DOCUMENT_ID)
+                .documentVerificationId(ID_CARD_FRONT_DOCUMENT_ID)
                 .uploadId(ID_CARD_FRONT_UPLOAD_ID)
                 .type(DocumentType.ID_CARD)
                 .side(CardSide.FRONT)
@@ -223,7 +223,7 @@ class MicroblinkDocumentVerificationProviderIntTest {
                 .build();
 
         idCardBackDocument = MicroblinkDocumentVerificationProvider.DocumentVerificationData.builder()
-                .documentId(ID_CARD_BACK_DOCUMENT_ID)
+                .documentVerificationId(ID_CARD_BACK_DOCUMENT_ID)
                 .uploadId(ID_CARD_BACK_UPLOAD_ID)
                 .type(DocumentType.ID_CARD)
                 .side(CardSide.BACK)
@@ -231,7 +231,7 @@ class MicroblinkDocumentVerificationProviderIntTest {
                 .build();
 
         passportDocument = MicroblinkDocumentVerificationProvider.DocumentVerificationData.builder()
-                .documentId(PASSPORT_DOCUMENT_ID)
+                .documentVerificationId(PASSPORT_DOCUMENT_ID)
                 .uploadId(PASSPORT_UPLOAD_ID)
                 .type(DocumentType.PASSPORT)
                 .side(CardSide.FRONT)
@@ -470,7 +470,7 @@ class MicroblinkDocumentVerificationProviderIntTest {
         return documents.stream()
                 .map(d -> {
                     final var doc = new SubmittedDocument();
-                    doc.setDocumentId(d.documentId());
+                    doc.setDocumentId(d.documentVerificationId());
                     doc.setType(d.type());
                     doc.setSide(d.side());
                     doc.setPhoto(d.image());

--- a/enrollment-server-onboarding-provider-microblink/src/test/java/com/wultra/app/onboardingserver/provider/microblink/MicroblinkDocumentVerificationProviderIntTest.java
+++ b/enrollment-server-onboarding-provider-microblink/src/test/java/com/wultra/app/onboardingserver/provider/microblink/MicroblinkDocumentVerificationProviderIntTest.java
@@ -360,7 +360,7 @@ class MicroblinkDocumentVerificationProviderIntTest {
         final var result = microblinkDocumentVerificationProvider.submitDocuments(ownerId, submittedDocuments);
 
         // then
-        assertEquals("Failed REST API call to Microblink, statusCode=503 SERVICE_UNAVAILABLE, responseBody='Service Not Available'", result.getErrorDetail());
+        assertEquals("Microblink provider exception: RemoteCommunicationException Failed REST API call to Microblink, statusCode=503 SERVICE_UNAVAILABLE, responseBody='Service Not Available'", result.getErrorDetail());
         assertEquals(2, result.getResults().size());
         result.getResults()
                 .forEach(documentResult -> assertDoesNotThrow(() -> UUID.fromString(documentResult.getUploadId())));
@@ -624,6 +624,7 @@ class MicroblinkDocumentVerificationProviderIntTest {
         documentData.setId(ID_CARD_FRONT_UPLOAD_ID);
         documentData.setData(new byte[] { 1, 2 });
         documentData.setTimestampCreated(new Date());
+        documentData.setDocumentVerificationId(ID_CARD_FRONT_DOCUMENT_ID);
         documentDataRepository.save(documentData);
 
         final var documentVerification = prepareIdCardFrontDocumentVerificationInDatabase();
@@ -645,6 +646,7 @@ class MicroblinkDocumentVerificationProviderIntTest {
         documentData.setId(ID_CARD_BACK_UPLOAD_ID);
         documentData.setData(new byte[] { 3, 4 });
         documentData.setTimestampCreated(new Date());
+        documentData.setDocumentVerificationId(ID_CARD_BACK_DOCUMENT_ID);
         documentDataRepository.save(documentData);
 
         final var documentVerification = prepareIdCardBackDocumentVerificationInDatabase();
@@ -666,6 +668,7 @@ class MicroblinkDocumentVerificationProviderIntTest {
         documentData.setId(PASSPORT_UPLOAD_ID);
         documentData.setData(new byte[] { 5, 6 });
         documentData.setTimestampCreated(new Date());
+        documentData.setDocumentVerificationId(PASSPORT_DOCUMENT_ID);
         documentDataRepository.save(documentData);
 
         final var identityVerification = identityVerificationRepository.findById("e0a627b9-9829-4bec-8c8d-db3be4ff03c1").orElseThrow();

--- a/enrollment-server-onboarding-provider-microblink/src/test/java/com/wultra/app/onboardingserver/provider/microblink/MicroblinkDocumentVerificationProviderIntTest.java
+++ b/enrollment-server-onboarding-provider-microblink/src/test/java/com/wultra/app/onboardingserver/provider/microblink/MicroblinkDocumentVerificationProviderIntTest.java
@@ -28,7 +28,6 @@ import com.wultra.app.onboardingserver.common.database.entity.DocumentDataEntity
 import com.wultra.app.onboardingserver.common.database.entity.DocumentResultEntity;
 import com.wultra.app.onboardingserver.common.database.entity.DocumentVerificationEntity;
 import com.wultra.app.onboardingserver.common.database.entity.ProcessedDocumentDataEntity;
-import com.wultra.app.onboardingserver.common.errorhandling.RemoteCommunicationException;
 import okhttp3.mockwebserver.MockWebServer;
 import org.json.JSONException;
 import org.junit.jupiter.api.AfterEach;
@@ -349,7 +348,7 @@ class MicroblinkDocumentVerificationProviderIntTest {
     }
 
     @Test
-    void testSubmitDocuments_microblinkClientException_exceptionIsThrown() {
+    void testSubmitDocuments_microblinkClientException_failedResultIsReturned() throws Exception {
         // given
         final var submittedDocuments = buildSubmittedDocuments(List.of(idCardFrontDocument, idCardBackDocument));
 
@@ -358,12 +357,13 @@ class MicroblinkDocumentVerificationProviderIntTest {
                 .setBody("Service Not Available"));
 
         // when
-        final var exception = assertThrows(RemoteCommunicationException.class,
-                () -> microblinkDocumentVerificationProvider.submitDocuments(ownerId, submittedDocuments)
-        );
+        final var result = microblinkDocumentVerificationProvider.submitDocuments(ownerId, submittedDocuments);
 
         // then
-        assertEquals("Failed REST API call to Microblink, statusCode=503 SERVICE_UNAVAILABLE, responseBody='Service Not Available'", exception.getMessage());
+        assertEquals("Failed REST API call to Microblink, statusCode=503 SERVICE_UNAVAILABLE, responseBody='Service Not Available'", result.getErrorDetail());
+        assertEquals(2, result.getResults().size());
+        result.getResults()
+                .forEach(documentResult -> assertDoesNotThrow(() -> UUID.fromString(documentResult.getUploadId())));
     }
 
     @Test

--- a/enrollment-server-onboarding-provider-microblink/src/test/java/com/wultra/app/onboardingserver/provider/microblink/MicroblinkDocumentVerificationProviderTest.java
+++ b/enrollment-server-onboarding-provider-microblink/src/test/java/com/wultra/app/onboardingserver/provider/microblink/MicroblinkDocumentVerificationProviderTest.java
@@ -244,7 +244,7 @@ class MicroblinkDocumentVerificationProviderTest {
     }
 
     @Test
-    void testSubmitDocuments_multipleDocumentsOfSameTypeAndSide_exceptionIsThrown() throws Exception {
+    void testSubmitDocuments_multipleDocumentsOfSameTypeAndSide_resultWithError() throws Exception {
         // given
         submittedDocumentIdCardBack.setSide(CardSide.FRONT);
 
@@ -258,7 +258,7 @@ class MicroblinkDocumentVerificationProviderTest {
     }
 
     @Test
-    void testSubmitDocuments_clientThrowsException_exceptionIsThrown() throws Exception {
+    void testSubmitDocuments_clientThrowsException_resultWithError() throws Exception {
         // given
         final var submittedDocuments = List.of(submittedDocumentIdCardFront, submittedDocumentIdCardBack);
 
@@ -280,7 +280,7 @@ class MicroblinkDocumentVerificationProviderTest {
     }
 
     @Test
-    void testSubmitDocuments_clientResponseWithoutBody_exceptionIsThrown() throws Exception {
+    void testSubmitDocuments_clientResponseWithoutBody_resultWithError() throws Exception {
         // given
         final var submittedDocuments = List.of(submittedDocumentIdCardFront, submittedDocumentIdCardBack);
 
@@ -302,7 +302,7 @@ class MicroblinkDocumentVerificationProviderTest {
     }
 
     @Test
-    void testSubmitDocuments_exceptionWhenParsingResponseBody_exceptionIsThrown() throws Exception {
+    void testSubmitDocuments_exceptionWhenParsingResponseBody_resultWithError() throws Exception {
         // given
         final var submittedDocuments = List.of(submittedDocumentIdCardFront, submittedDocumentIdCardBack);
 
@@ -1041,7 +1041,7 @@ class MicroblinkDocumentVerificationProviderTest {
 
         assertEquals(documentResults.size(), storedEntities.size());
 
-        final var documentIdToDocumentData = documentResults.stream()
+        final var documentUploadIdToDocumentData = documentResults.stream()
                 .collect(Collectors.toMap(
                         DocumentSubmitResult::getDocumentId,
                         i -> storedEntities.stream()
@@ -1050,13 +1050,15 @@ class MicroblinkDocumentVerificationProviderTest {
                                 .orElseThrow()
                 ));
 
-        final var idCardFrontDocumentData = documentIdToDocumentData.get(DOCUMENT_ID_CARD_FRONT_ID);
+        final var idCardFrontDocumentData = documentUploadIdToDocumentData.get(DOCUMENT_ID_CARD_FRONT_ID);
         assertDoesNotThrow(() -> UUID.fromString(idCardFrontDocumentData.getId()));
+        assertEquals(DOCUMENT_ID_CARD_FRONT_ID, idCardFrontDocumentData.getDocumentVerificationId());
         assertArrayEquals(verificationDocumentCardIdFront.image().getData(), idCardFrontDocumentData.getData());
         assertEquals(new Date().getTime(), idCardFrontDocumentData.getTimestampCreated().getTime(), TIMESTAMP_ASSERT_DELTA_MS);
 
-        final var idCardBackDocumentData = documentIdToDocumentData.get(DOCUMENT_ID_CARD_BACK_ID);
+        final var idCardBackDocumentData = documentUploadIdToDocumentData.get(DOCUMENT_ID_CARD_BACK_ID);
         assertDoesNotThrow(() -> UUID.fromString(idCardBackDocumentData.getId()));
+        assertEquals(DOCUMENT_ID_CARD_BACK_ID, idCardBackDocumentData.getDocumentVerificationId());
         assertArrayEquals(verificationDocumentCardIdBack.image().getData(), idCardBackDocumentData.getData());
         assertEquals(new Date().getTime(), idCardBackDocumentData.getTimestampCreated().getTime(), TIMESTAMP_ASSERT_DELTA_MS);
     }

--- a/enrollment-server-onboarding-provider-microblink/src/test/java/com/wultra/app/onboardingserver/provider/microblink/MicroblinkDocumentVerificationProviderTest.java
+++ b/enrollment-server-onboarding-provider-microblink/src/test/java/com/wultra/app/onboardingserver/provider/microblink/MicroblinkDocumentVerificationProviderTest.java
@@ -244,21 +244,21 @@ class MicroblinkDocumentVerificationProviderTest {
     }
 
     @Test
-    void testSubmitDocuments_multipleDocumentsOfSameTypeAndSide_exceptionIsThrown() {
+    void testSubmitDocuments_multipleDocumentsOfSameTypeAndSide_exceptionIsThrown() throws Exception {
         // given
         submittedDocumentIdCardBack.setSide(CardSide.FRONT);
 
         final var submittedDocuments = List.of(submittedDocumentIdCardFront, submittedDocumentIdCardBack);
 
         // when
-        final var exception = assertThrows(DocumentVerificationException.class, () -> provider.submitDocuments(ownerId, submittedDocuments));
+        final var result = provider.submitDocuments(ownerId, submittedDocuments);
 
         // then
-        assertEquals("Multiple documents of type ID_CARD and side FRONT found. Document ids: [id-card-front, id-card-back]", exception.getMessage());
+        assertEquals("Multiple documents of type ID_CARD and side FRONT found. Document ids: [id-card-front, id-card-back]", result.getErrorDetail());
     }
 
     @Test
-    void testSubmitDocuments_clientThrowsException_exceptionIsThrown() throws RestClientException {
+    void testSubmitDocuments_clientThrowsException_exceptionIsThrown() throws Exception {
         // given
         final var submittedDocuments = List.of(submittedDocumentIdCardFront, submittedDocumentIdCardBack);
 
@@ -273,15 +273,14 @@ class MicroblinkDocumentVerificationProviderTest {
         when(microblinkConfigProperties.getRequestOptions()).thenReturn(buildRequestOptions());
 
         // when
-        final var exception = assertThrows(RemoteCommunicationException.class, () -> provider.submitDocuments(ownerId, submittedDocuments));
+        final var result = provider.submitDocuments(ownerId, submittedDocuments);
 
         // then
-        assertEquals("Failed REST API call to Microblink, statusCode=503 SERVICE_UNAVAILABLE, responseBody='Test error body'", exception.getMessage());
-        assertNotNull(exception.getCause());
+        assertEquals("Failed REST API call to Microblink, statusCode=503 SERVICE_UNAVAILABLE, responseBody='Test error body'", result.getErrorDetail());
     }
 
     @Test
-    void testSubmitDocuments_clientResponseWithoutBody_exceptionIsThrown() throws RestClientException {
+    void testSubmitDocuments_clientResponseWithoutBody_exceptionIsThrown() throws Exception {
         // given
         final var submittedDocuments = List.of(submittedDocumentIdCardFront, submittedDocumentIdCardBack);
 
@@ -296,14 +295,14 @@ class MicroblinkDocumentVerificationProviderTest {
         when(microblinkConfigProperties.getRequestOptions()).thenReturn(buildRequestOptions());
 
         // when
-        final var exception = assertThrows(DocumentVerificationException.class, () -> provider.submitDocuments(ownerId, submittedDocuments));
+        final var result = provider.submitDocuments(ownerId, submittedDocuments);
 
         // then
-        assertEquals("Response body is empty", exception.getMessage());
+        assertEquals("Response body is empty", result.getErrorDetail());
     }
 
     @Test
-    void testSubmitDocuments_exceptionWhenParsingResponseBody_exceptionIsThrown() throws RestClientException {
+    void testSubmitDocuments_exceptionWhenParsingResponseBody_exceptionIsThrown() throws Exception {
         // given
         final var submittedDocuments = List.of(submittedDocumentIdCardFront, submittedDocumentIdCardBack);
 
@@ -318,10 +317,10 @@ class MicroblinkDocumentVerificationProviderTest {
         when(microblinkConfigProperties.getRequestOptions()).thenReturn(buildRequestOptions());
 
         // when
-        final var exception = assertThrows(DocumentVerificationException.class, () -> provider.submitDocuments(ownerId, submittedDocuments));
+        final var result = provider.submitDocuments(ownerId, submittedDocuments);
 
         // then
-        assertEquals("Failed to parse Microblink API response. Microblink traceId: 123", exception.getMessage());
+        assertEquals("Failed to parse Microblink API response. Microblink traceId: 123", result.getErrorDetail());
     }
 
     @Test

--- a/enrollment-server-onboarding-provider-microblink/src/test/java/com/wultra/app/onboardingserver/provider/microblink/MicroblinkDocumentVerificationProviderTest.java
+++ b/enrollment-server-onboarding-provider-microblink/src/test/java/com/wultra/app/onboardingserver/provider/microblink/MicroblinkDocumentVerificationProviderTest.java
@@ -1065,7 +1065,7 @@ class MicroblinkDocumentVerificationProviderTest {
             final MicroblinkDocumentVerificationProvider.DocumentVerificationData documentVerificationData
     ) {
         final var document = new SubmittedDocument();
-        document.setDocumentId(documentVerificationData.documentId());
+        document.setDocumentId(documentVerificationData.documentVerificationId());
         document.setType(documentVerificationData.type());
         document.setSide(documentVerificationData.side());
         document.setPhoto(
@@ -1092,7 +1092,7 @@ class MicroblinkDocumentVerificationProviderTest {
                 .build();
 
         return MicroblinkDocumentVerificationProvider.DocumentVerificationData.builder()
-                .documentId(documentId)
+                .documentVerificationId(documentId)
                 .uploadId(uploadId)
                 .type(type)
                 .side(side)

--- a/enrollment-server-onboarding-provider-microblink/src/test/java/com/wultra/app/onboardingserver/provider/microblink/MicroblinkDocumentVerificationProviderTest.java
+++ b/enrollment-server-onboarding-provider-microblink/src/test/java/com/wultra/app/onboardingserver/provider/microblink/MicroblinkDocumentVerificationProviderTest.java
@@ -60,6 +60,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyIterable;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -254,7 +255,7 @@ class MicroblinkDocumentVerificationProviderTest {
         final var result = provider.submitDocuments(ownerId, submittedDocuments);
 
         // then
-        assertEquals("Multiple documents of type ID_CARD and side FRONT found. Document ids: [id-card-front, id-card-back]", result.getErrorDetail());
+        assertEquals("Microblink provider exception: DocumentVerificationException Multiple documents of type ID_CARD and side FRONT found. Document ids: [id-card-front, id-card-back]", result.getErrorDetail());
     }
 
     @Test
@@ -276,7 +277,7 @@ class MicroblinkDocumentVerificationProviderTest {
         final var result = provider.submitDocuments(ownerId, submittedDocuments);
 
         // then
-        assertEquals("Failed REST API call to Microblink, statusCode=503 SERVICE_UNAVAILABLE, responseBody='Test error body'", result.getErrorDetail());
+        assertEquals("Microblink provider exception: RemoteCommunicationException Failed REST API call to Microblink, statusCode=503 SERVICE_UNAVAILABLE, responseBody='Test error body'", result.getErrorDetail());
     }
 
     @Test
@@ -298,7 +299,7 @@ class MicroblinkDocumentVerificationProviderTest {
         final var result = provider.submitDocuments(ownerId, submittedDocuments);
 
         // then
-        assertEquals("Response body is empty", result.getErrorDetail());
+        assertEquals("Microblink provider exception: DocumentVerificationException Response body is empty", result.getErrorDetail());
     }
 
     @Test
@@ -320,7 +321,21 @@ class MicroblinkDocumentVerificationProviderTest {
         final var result = provider.submitDocuments(ownerId, submittedDocuments);
 
         // then
-        assertEquals("Failed to parse Microblink API response. Microblink traceId: 123", result.getErrorDetail());
+        assertEquals("Microblink provider exception: DocumentVerificationException Failed to parse Microblink API response. Microblink traceId: 123", result.getErrorDetail());
+    }
+
+    @Test
+    void testSubmitDocuments_exceptionWithoutMessageIsThrown_resultWithError() throws Exception {
+        // given
+        final var submittedDocuments = List.of(submittedDocumentIdCardFront, submittedDocumentIdCardBack);
+
+        when(documentDataRepository.saveAll(anyIterable())).thenThrow(new RuntimeException());
+
+        // when
+        final var result = provider.submitDocuments(ownerId, submittedDocuments);
+
+        // then
+        assertEquals("Microblink provider exception: RuntimeException null", result.getErrorDetail());
     }
 
     @Test

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/configuration/IdentityVerificationConfig.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/configuration/IdentityVerificationConfig.java
@@ -59,6 +59,12 @@ public class IdentityVerificationConfig {
     @Value("${enrollment-server-onboarding.identity-verification.max-failed-attempts-document-upload:5}")
     private int documentUploadMaxFailedAttempts;
 
+    /**
+     * How long are identity data (e.g. selfie, uploaded documents) kept in database after the process is completed.
+     */
+    @Value("${enrollment-server-onboarding.identity-verification.data-retention:1h}")
+    private Duration dataRetention;
+
     @Value("${enrollment-server-onboarding.presence-check.max-failed-attempts:5}")
     private int presenceCheckMaxFailedAttempts;
 

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/configuration/OnboardingConfig.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/configuration/OnboardingConfig.java
@@ -59,4 +59,10 @@ public class OnboardingConfig extends CommonOnboardingConfig {
     @Value("${enrollment-server-onboarding.onboarding-process.default-type:}")
     private String defaultProcessType;
 
+    /**
+     * How long are identity data (e.g. selfie, uploaded documents) kept in database after the process is completed.
+     */
+    @Value("${enrollment-server-onboarding.onboarding-process.completedProcessDataRetentionTime:1h}")
+    private Duration completedProcessDataRetentionTime;
+
 }

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/configuration/OnboardingConfig.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/configuration/OnboardingConfig.java
@@ -58,4 +58,10 @@ public class OnboardingConfig extends CommonOnboardingConfig {
      */
     @Value("${enrollment-server-onboarding.onboarding-process.default-type:}")
     private String defaultProcessType;
+
+    /**
+     * Maximum number of records processed in a single cleaning task run.
+     */
+    @Value("${enrollment-server-onboarding.onboarding-process.cleanup-limit:10000}")
+    private int cleanupLimit;
 }

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/configuration/OnboardingConfig.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/configuration/OnboardingConfig.java
@@ -58,11 +58,4 @@ public class OnboardingConfig extends CommonOnboardingConfig {
      */
     @Value("${enrollment-server-onboarding.onboarding-process.default-type:}")
     private String defaultProcessType;
-
-    /**
-     * How long are identity data (e.g. selfie, uploaded documents) kept in database after the process is completed.
-     */
-    @Value("${enrollment-server-onboarding.onboarding-process.completedProcessDataRetentionTime:1h}")
-    private Duration completedProcessDataRetentionTime;
-
 }

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/document/DocumentProcessingService.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/document/DocumentProcessingService.java
@@ -373,6 +373,8 @@ public class DocumentProcessingService {
 
     private void processDocsSubmitResults(OwnerId ownerId, DocumentVerificationEntity docVerification,
                                           DocumentsSubmitResult docsSubmitResults, DocumentSubmitResult docSubmitResult) {
+        docVerification.setUploadId(docSubmitResult.getUploadId());
+
         if (StringUtils.isNotBlank(docSubmitResult.getErrorDetail())) {
             docVerification.setStatus(DocumentStatus.FAILED);
             docVerification.setErrorDetail(ErrorDetail.DOCUMENT_VERIFICATION_FAILED);
@@ -393,7 +395,6 @@ public class DocumentProcessingService {
             if (docVerification.getTimestampUploaded() == null) {
                 docVerification.setTimestampUploaded(ownerId.getTimestamp());
             }
-            docVerification.setUploadId(docSubmitResult.getUploadId());
 
             if (docVerification.getType() == DocumentType.SELFIE_PHOTO) {
                 final DocumentStatus status = identityVerificationConfig.isVerifySelfieWithDocumentsEnabled() ? DocumentStatus.VERIFICATION_PENDING : DocumentStatus.ACCEPTED;

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/cleaning/CleaningService.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/cleaning/CleaningService.java
@@ -214,7 +214,6 @@ class CleaningService {
     private void cleanDocumentData(final List<OnboardingProcessPersonalDataIdsProjection> personalDataIds) {
         final var ids = personalDataIds.stream()
                 .map(OnboardingProcessPersonalDataIdsProjection::getDocumentVerificationId)
-                .filter(Objects::nonNull)
                 .toList();
 
         logger.debug("Deleting document data for {} document verifications", ids.size());

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/cleaning/CleaningService.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/cleaning/CleaningService.java
@@ -32,9 +32,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
-import java.util.Collection;
-import java.util.Date;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -133,34 +131,6 @@ class CleaningService {
     }
 
     /**
-     * Clean selfie images.
-     *
-     * @return Number of deleted selfie images.
-     * @implSpec Right now, the selfie images are deleted based on the process expiration time.
-     * In the future, it could be improved, for example, by cleaning immediately after the process is finished (but the expired ones have to be still handled here).
-     */
-    @Transactional
-    public int cleanSelfies() {
-        return selfieRepository.cleanup(getProcessExpirationTime());
-    }
-
-    /**
-     * Clean document data.
-     */
-    @Transactional
-    public int cleanupDocumentData() {
-        return documentDataRepository.cleanupDocumentData(getProcessExpirationTime());
-    }
-
-    /**
-     * Clean processed document data.
-     */
-    @Transactional
-    public int cleanupProcessedDocumentData() {
-        return processedDocumentDataRepository.cleanup(getProcessExpirationTime());
-    }
-
-    /**
      * Terminate expired document verifications.
      */
     @Transactional
@@ -197,8 +167,51 @@ class CleaningService {
         }
     }
 
-    private Date getProcessExpirationTime() {
-        return DateUtil.convertExpirationToCreatedDate(onboardingConfig.getProcessExpirationTime());
+    /**
+     * Cleanup identity data of completed processes after the retention time.
+     */
+    @Transactional
+    public void cleanupCompletedProcessIdentityData() {
+        final var retentionTime = DateUtil.convertExpirationToCreatedDate(onboardingConfig.getCompletedProcessDataRetentionTime());
+
+        final var dataIds = onboardingProcessRepository.findIdentityDataForCleanup(OnboardingStatus.COMPLETED, retentionTime);
+        logger.debug("Data records of completed processes to be deleted: count={}, retentionTime={}", dataIds.size(), retentionTime);
+
+        if (dataIds.isEmpty()) {
+            return;
+        }
+
+        final var identityVerificationIds = new HashSet<String>();
+        final var documentVerificationIds = new HashSet<String>();
+        final var uploadIds = new HashSet<String>();
+
+        var counter = 0;
+        for (final var dataIdsItem : dataIds) {
+            identityVerificationIds.add(dataIdsItem.getIdentityVerificationId());
+            documentVerificationIds.add(dataIdsItem.getDocumentVerificationId());
+            uploadIds.add(dataIdsItem.getUploadId());
+            counter++;
+
+            if (counter % BATCH_SIZE == 0) {
+                cleanCompletedProcessIdentityData(identityVerificationIds, documentVerificationIds, uploadIds);
+
+                identityVerificationIds.clear();
+                documentVerificationIds.clear();
+                uploadIds.clear();
+            }
+        }
+
+        if (counter % BATCH_SIZE != 0) {
+            cleanCompletedProcessIdentityData(identityVerificationIds, documentVerificationIds, uploadIds);
+        }
+
+        logger.info("Deleted {} data records of completed processes", counter);
+    }
+
+    private void cleanCompletedProcessIdentityData(final Set<String> identityVerificationIds, final Set<String> documentVerificationIds, final Set<String> uploadIds) {
+        selfieRepository.deleteAllByIdentityVerificationIds(identityVerificationIds);
+        processedDocumentDataRepository.deleteAllByDocumentVerificationIds(documentVerificationIds);
+        documentDataRepository.deleteAllById(uploadIds);
     }
 
     private Date getVerificationExpirationTime() {

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/cleaning/CleaningService.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/cleaning/CleaningService.java
@@ -175,26 +175,29 @@ class CleaningService {
         final var retentionTime = DateUtil.convertExpirationToCreatedDate(onboardingConfig.getCompletedProcessDataRetentionTime());
 
         final var dataIds = onboardingProcessRepository.findIdentityDataForCleanup(OnboardingStatus.COMPLETED, retentionTime);
-        logger.debug("Data records of completed processes to be deleted: count={}, retentionTime={}", dataIds.size(), retentionTime);
+        logger.info("Found {} data records of completed processes for cleanup. Retention time: {}", dataIds.size(), retentionTime);
 
         if (dataIds.isEmpty()) {
             return;
         }
 
+        final var processIds = new HashSet<String>();
         final var identityVerificationIds = new HashSet<String>();
         final var documentVerificationIds = new HashSet<String>();
         final var uploadIds = new HashSet<String>();
 
         var counter = 0;
         for (final var dataIdsItem : dataIds) {
+            processIds.add(dataIdsItem.getProcessId());
             identityVerificationIds.add(dataIdsItem.getIdentityVerificationId());
             documentVerificationIds.add(dataIdsItem.getDocumentVerificationId());
             uploadIds.add(dataIdsItem.getUploadId());
             counter++;
 
             if (counter % BATCH_SIZE == 0) {
-                cleanCompletedProcessIdentityData(identityVerificationIds, documentVerificationIds, uploadIds);
+                cleanCompletedProcessIdentityData(processIds, identityVerificationIds, documentVerificationIds, uploadIds);
 
+                processIds.clear();
                 identityVerificationIds.clear();
                 documentVerificationIds.clear();
                 uploadIds.clear();
@@ -202,16 +205,22 @@ class CleaningService {
         }
 
         if (counter % BATCH_SIZE != 0) {
-            cleanCompletedProcessIdentityData(identityVerificationIds, documentVerificationIds, uploadIds);
+            cleanCompletedProcessIdentityData(processIds, identityVerificationIds, documentVerificationIds, uploadIds);
         }
 
         logger.info("Deleted {} data records of completed processes", counter);
     }
 
-    private void cleanCompletedProcessIdentityData(final Set<String> identityVerificationIds, final Set<String> documentVerificationIds, final Set<String> uploadIds) {
+    private void cleanCompletedProcessIdentityData(
+            final Set<String> processIds,
+            final Set<String> identityVerificationIds,
+            final Set<String> documentVerificationIds,
+            final Set<String> uploadIds
+    ) {
         selfieRepository.deleteAllByIdentityVerificationIds(identityVerificationIds);
         processedDocumentDataRepository.deleteAllByDocumentVerificationIds(documentVerificationIds);
         documentDataRepository.deleteAllById(uploadIds);
+        onboardingProcessRepository.updateIdentityDataCleanup(processIds, new Date());
     }
 
     private Date getVerificationExpirationTime() {

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/cleaning/CleaningService.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/cleaning/CleaningService.java
@@ -191,7 +191,9 @@ class CleaningService {
             processIds.add(dataIdsItem.getProcessId());
             identityVerificationIds.add(dataIdsItem.getIdentityVerificationId());
             documentVerificationIds.add(dataIdsItem.getDocumentVerificationId());
-            uploadIds.add(dataIdsItem.getUploadId());
+            Optional.of(dataIdsItem.getUploadId())
+                    .ifPresent(uploadIds::add);
+
             counter++;
 
             if (counter % BATCH_SIZE == 0) {

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/cleaning/CleaningService.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/cleaning/CleaningService.java
@@ -29,6 +29,7 @@ import com.wultra.app.onboardingserver.configuration.OnboardingConfig;
 import com.wultra.app.onboardingserver.impl.util.DateUtil;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -177,8 +178,9 @@ class CleaningService {
     @Transactional
     public void cleanupCompletedProcessPersonalData() {
         final var retentionTime = DateUtil.convertExpirationToCreatedDate(identityVerificationConfig.getDataRetention());
+        final var limit = onboardingConfig.getCleanupLimit();
 
-        final var dataIds = onboardingProcessRepository.findIdentityDataForCleanup(OnboardingStatus.COMPLETED, retentionTime);
+        final var dataIds = onboardingProcessRepository.findIdentityDataForCleanup(OnboardingStatus.COMPLETED, retentionTime, PageRequest.of(0, limit));
         logger.info("Found {} data records of completed processes for cleanup. Retention time: {}", dataIds.size(), retentionTime);
 
         if (dataIds.isEmpty()) {

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/cleaning/CleaningService.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/cleaning/CleaningService.java
@@ -191,7 +191,7 @@ class CleaningService {
             processIds.add(dataIdsItem.getProcessId());
             identityVerificationIds.add(dataIdsItem.getIdentityVerificationId());
             documentVerificationIds.add(dataIdsItem.getDocumentVerificationId());
-            Optional.of(dataIdsItem.getUploadId())
+            Optional.ofNullable(dataIdsItem.getUploadId())
                     .ifPresent(uploadIds::add);
 
             counter++;

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/cleaning/CleaningService.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/cleaning/CleaningService.java
@@ -172,10 +172,10 @@ class CleaningService {
     }
 
     /**
-     * Cleanup identity data of completed processes after the retention time.
+     * Cleanup personal data of completed processes after the retention time.
      */
     @Transactional
-    public void cleanupCompletedProcessIdentityData() {
+    public void cleanupCompletedProcessPersonalData() {
         final var retentionTime = DateUtil.convertExpirationToCreatedDate(identityVerificationConfig.getDataRetention());
 
         final var dataIds = onboardingProcessRepository.findIdentityDataForCleanup(OnboardingStatus.COMPLETED, retentionTime);

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/cleaning/CleaningService.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/cleaning/CleaningService.java
@@ -184,30 +184,26 @@ class CleaningService {
         final var processIds = new HashSet<String>();
         final var identityVerificationIds = new HashSet<String>();
         final var documentVerificationIds = new HashSet<String>();
-        final var uploadIds = new HashSet<String>();
 
         var counter = 0;
         for (final var dataIdsItem : dataIds) {
             processIds.add(dataIdsItem.getProcessId());
             identityVerificationIds.add(dataIdsItem.getIdentityVerificationId());
             documentVerificationIds.add(dataIdsItem.getDocumentVerificationId());
-            Optional.ofNullable(dataIdsItem.getUploadId())
-                    .ifPresent(uploadIds::add);
 
             counter++;
 
             if (counter % BATCH_SIZE == 0) {
-                cleanCompletedProcessIdentityData(processIds, identityVerificationIds, documentVerificationIds, uploadIds);
+                cleanCompletedProcessIdentityData(processIds, identityVerificationIds, documentVerificationIds);
 
                 processIds.clear();
                 identityVerificationIds.clear();
                 documentVerificationIds.clear();
-                uploadIds.clear();
             }
         }
 
         if (counter % BATCH_SIZE != 0) {
-            cleanCompletedProcessIdentityData(processIds, identityVerificationIds, documentVerificationIds, uploadIds);
+            cleanCompletedProcessIdentityData(processIds, identityVerificationIds, documentVerificationIds);
         }
 
         logger.info("Deleted {} data records of completed processes", counter);
@@ -216,12 +212,11 @@ class CleaningService {
     private void cleanCompletedProcessIdentityData(
             final Set<String> processIds,
             final Set<String> identityVerificationIds,
-            final Set<String> documentVerificationIds,
-            final Set<String> uploadIds
+            final Set<String> documentVerificationIds
     ) {
         selfieRepository.deleteAllByIdentityVerificationIds(identityVerificationIds);
         processedDocumentDataRepository.deleteAllByDocumentVerificationIds(documentVerificationIds);
-        documentDataRepository.deleteAllById(uploadIds);
+        documentDataRepository.deleteAllByDocumentVerificationIds(documentVerificationIds);
         onboardingProcessRepository.updateIdentityDataCleanup(processIds, new Date());
     }
 

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/cleaning/CleaningService.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/cleaning/CleaningService.java
@@ -22,6 +22,7 @@ import com.wultra.app.enrollmentserver.model.enumeration.ErrorOrigin;
 import com.wultra.app.enrollmentserver.model.enumeration.OnboardingStatus;
 import com.wultra.app.onboardingserver.common.database.*;
 import com.wultra.app.onboardingserver.common.database.entity.OnboardingProcessEntity;
+import com.wultra.app.onboardingserver.common.database.entity.OnboardingProcessPersonalDataIdsProjection;
 import com.wultra.app.onboardingserver.common.service.AuditService;
 import com.wultra.app.onboardingserver.configuration.IdentityVerificationConfig;
 import com.wultra.app.onboardingserver.configuration.OnboardingConfig;
@@ -32,7 +33,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
-import java.util.*;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -181,43 +184,56 @@ class CleaningService {
             return;
         }
 
-        final var processIds = new HashSet<String>();
-        final var identityVerificationIds = new HashSet<String>();
-        final var documentVerificationIds = new HashSet<String>();
+        setProcessCleanupTime(dataIds);
+        cleanDocumentData(dataIds);
+        cleanSelfieData(dataIds);
 
-        var counter = 0;
-        for (final var dataIdsItem : dataIds) {
-            processIds.add(dataIdsItem.getProcessId());
-            identityVerificationIds.add(dataIdsItem.getIdentityVerificationId());
-            documentVerificationIds.add(dataIdsItem.getDocumentVerificationId());
-
-            counter++;
-
-            if (counter % BATCH_SIZE == 0) {
-                cleanCompletedProcessIdentityData(processIds, identityVerificationIds, documentVerificationIds);
-
-                processIds.clear();
-                identityVerificationIds.clear();
-                documentVerificationIds.clear();
-            }
-        }
-
-        if (counter % BATCH_SIZE != 0) {
-            cleanCompletedProcessIdentityData(processIds, identityVerificationIds, documentVerificationIds);
-        }
-
-        logger.info("Deleted {} data records of completed processes", counter);
+        logger.info("Personal data records of completed processes deleted");
     }
 
-    private void cleanCompletedProcessIdentityData(
-            final Set<String> processIds,
-            final Set<String> identityVerificationIds,
-            final Set<String> documentVerificationIds
-    ) {
-        selfieRepository.deleteAllByIdentityVerificationIds(identityVerificationIds);
-        processedDocumentDataRepository.deleteAllByDocumentVerificationIds(documentVerificationIds);
-        documentDataRepository.deleteAllByDocumentVerificationIds(documentVerificationIds);
-        onboardingProcessRepository.updateIdentityDataCleanup(processIds, new Date());
+    private void setProcessCleanupTime(final List<OnboardingProcessPersonalDataIdsProjection> personalDataIds) {
+        final var cleanupTime = new Date();
+
+        final var processIds = personalDataIds.stream()
+                .map(OnboardingProcessPersonalDataIdsProjection::getProcessId)
+                .toList();
+
+        logger.debug("Setting cleanup time {} for {} processes", cleanupTime, processIds.size());
+
+        for (final var processIdsBatch : ListUtils.partition(processIds, BATCH_SIZE)) {
+            onboardingProcessRepository.updateIdentityDataCleanup(processIdsBatch, cleanupTime);
+        }
+
+        logger.debug("Cleanup time set for processes");
+    }
+
+    private void cleanDocumentData(final List<OnboardingProcessPersonalDataIdsProjection> personalDataIds) {
+        final var ids = personalDataIds.stream()
+                .map(OnboardingProcessPersonalDataIdsProjection::getDocumentVerificationId)
+                .toList();
+
+        logger.debug("Deleting document data for {} document verifications", ids.size());
+
+        for (final var idsBatch : ListUtils.partition(ids, BATCH_SIZE)) {
+            processedDocumentDataRepository.deleteAllByDocumentVerificationIds(idsBatch);
+            documentDataRepository.deleteAllByDocumentVerificationIds(idsBatch);
+        }
+
+        logger.debug("Document data deleted");
+    }
+
+    private void cleanSelfieData(final List<OnboardingProcessPersonalDataIdsProjection> personalDataIds) {
+        final var ids = personalDataIds.stream()
+                .map(OnboardingProcessPersonalDataIdsProjection::getIdentityVerificationId)
+                .toList();
+
+        logger.debug("Deleting selfie data for {} identity verifications", ids.size());
+
+        for (final var idsBatch : ListUtils.partition(ids, BATCH_SIZE)) {
+            selfieRepository.deleteAllByIdentityVerificationIds(idsBatch);
+        }
+
+        logger.debug("Selfie data deleted");
     }
 
     private Date getVerificationExpirationTime() {

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/cleaning/CleaningService.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/cleaning/CleaningService.java
@@ -36,6 +36,7 @@ import java.time.Duration;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -211,6 +212,7 @@ class CleaningService {
     private void cleanDocumentData(final List<OnboardingProcessPersonalDataIdsProjection> personalDataIds) {
         final var ids = personalDataIds.stream()
                 .map(OnboardingProcessPersonalDataIdsProjection::getDocumentVerificationId)
+                .filter(Objects::nonNull)
                 .toList();
 
         logger.debug("Deleting document data for {} document verifications", ids.size());

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/cleaning/CleaningService.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/cleaning/CleaningService.java
@@ -175,7 +175,7 @@ class CleaningService {
      */
     @Transactional
     public void cleanupCompletedProcessIdentityData() {
-        final var retentionTime = DateUtil.convertExpirationToCreatedDate(onboardingConfig.getCompletedProcessDataRetentionTime());
+        final var retentionTime = DateUtil.convertExpirationToCreatedDate(identityVerificationConfig.getDataRetention());
 
         final var dataIds = onboardingProcessRepository.findIdentityDataForCleanup(OnboardingStatus.COMPLETED, retentionTime);
         logger.info("Found {} data records of completed processes for cleanup. Retention time: {}", dataIds.size(), retentionTime);
@@ -196,6 +196,7 @@ class CleaningService {
 
         final var processIds = personalDataIds.stream()
                 .map(OnboardingProcessPersonalDataIdsProjection::getProcessId)
+                .distinct()
                 .toList();
 
         logger.debug("Setting cleanup time {} for {} processes", cleanupTime, processIds.size());
@@ -225,6 +226,7 @@ class CleaningService {
     private void cleanSelfieData(final List<OnboardingProcessPersonalDataIdsProjection> personalDataIds) {
         final var ids = personalDataIds.stream()
                 .map(OnboardingProcessPersonalDataIdsProjection::getIdentityVerificationId)
+                .distinct()
                 .toList();
 
         logger.debug("Deleting selfie data for {} identity verifications", ids.size());

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/cleaning/CleaningTask.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/cleaning/CleaningTask.java
@@ -88,42 +88,6 @@ public class CleaningTask {
         cleaningService.terminateExpiredProcesses();
     }
 
-    /**
-     * Clean selfie images.
-     */
-    @Scheduled(fixedDelayString = "PT10M", initialDelayString = "PT20S")
-    @SchedulerLock(name = SchedulerLockNames.CLEANUP_SELFIES_LOCK, lockAtMostFor = "5m")
-    public void cleanupSelfies() {
-        logger.info("action: cleanupSelfies, state: initiated");
-        LockAssert.assertLocked();
-        final int count = cleaningService.cleanSelfies();
-        logger.info("action: cleanupSelfies, state: succeeded, count: {}", count);
-    }
-
-    /**
-     * Cleanup of document data older than retention time.
-     */
-    @Scheduled(fixedDelayString = "PT10M", initialDelayString = "PT15S")
-    @SchedulerLock(name = SchedulerLockNames.DOCUMENT_DATA_LOCK, lockAtMostFor = "5m")
-    public void cleanupDocumentData() {
-        LockAssert.assertLocked();
-        logger.debug("action: cleanupDocumentData, state: initiated");
-        final var count = cleaningService.cleanupDocumentData();
-        logger.debug("action: cleanupDocumentData, state: succeeded, cleanedRecords: {}", count);
-    }
-
-    /**
-     * Cleanup of processed document data older than retention time.
-     */
-    @Scheduled(fixedDelayString = "PT10M", initialDelayString = "PT15S")
-    @SchedulerLock(name = SchedulerLockNames.PROCESSED_DOCUMENT_DATA_LOCK, lockAtMostFor = "5m")
-    public void cleanupProcessedDocumentData() {
-        LockAssert.assertLocked();
-        logger.debug("action: cleanupProcessedDocumentData, state: initiated");
-        final var count = cleaningService.cleanupProcessedDocumentData();
-        logger.debug("action: cleanupProcessedDocumentData, state: succeeded, cleanedRecords: {}", count);
-    }
-
     @Scheduled(fixedDelayString = "PT10M", initialDelayString = "PT20S")
     @SchedulerLock(name = SchedulerLockNames.EXPIRE_DOCUMENT_VERIFICATION_LOCK, lockAtMostFor = "5m")
     public void terminateExpiredDocumentVerifications() {
@@ -149,5 +113,17 @@ public class CleaningTask {
         LockAssert.assertLocked();
         logger.debug("cleanupActivations");
         activationCleaningService.cleanupActivations();
+    }
+
+    /**
+     * Cleanup identity data of completed onboarding processes.
+     */
+    @Scheduled(fixedDelayString = "PT15S", initialDelayString = "PT10S")
+    @SchedulerLock(name = SchedulerLockNames.CLEANUP_COMPLETED_PROCESS_IDENTITY_DATA_LOCK, lockAtMostFor = "5m")
+    public void cleanupCompletedProcessIdentityData() {
+        logger.info("action: cleanupCompletedProcessIdentityData, state: initiated");
+        LockAssert.assertLocked();
+        cleaningService.cleanupCompletedProcessIdentityData();
+        logger.info("action: cleanupCompletedProcessIdentityData, state: succeeded");
     }
 }

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/cleaning/CleaningTask.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/cleaning/CleaningTask.java
@@ -116,14 +116,14 @@ public class CleaningTask {
     }
 
     /**
-     * Cleanup identity data of completed onboarding processes.
+     * Cleanup personal data of completed onboarding processes.
      */
-    @Scheduled(fixedDelayString = "PT15S", initialDelayString = "PT10S")
-    @SchedulerLock(name = SchedulerLockNames.CLEANUP_COMPLETED_PROCESS_IDENTITY_DATA_LOCK, lockAtMostFor = "5m")
-    public void cleanupCompletedProcessIdentityData() {
-        logger.info("action: cleanupCompletedProcessIdentityData, state: initiated");
+    @Scheduled(fixedDelayString = "PT60S", initialDelayString = "PT30S")
+    @SchedulerLock(name = SchedulerLockNames.CLEANUP_COMPLETED_PROCESS_PERSONAL_DATA_LOCK, lockAtMostFor = "5m")
+    public void cleanupCompletedProcessPersonalData() {
+        logger.info("action: cleanupCompletedProcessPersonalData, state: initiated");
         LockAssert.assertLocked();
-        cleaningService.cleanupCompletedProcessIdentityData();
-        logger.info("action: cleanupCompletedProcessIdentityData, state: succeeded");
+        cleaningService.cleanupCompletedProcessPersonalData();
+        logger.info("action: cleanupCompletedProcessPersonalData, state: succeeded");
     }
 }

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/consts/SchedulerLockNames.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/consts/SchedulerLockNames.java
@@ -38,6 +38,6 @@ public final class SchedulerLockNames {
 
     public static final String CLEANUP_ACTIVATIONS_LOCK = "cleanupActivationsLock";
 
-    public static final String CLEANUP_COMPLETED_PROCESS_IDENTITY_DATA_LOCK = "cleanupCompletedProcessIdentityDataLock";
+    public static final String CLEANUP_COMPLETED_PROCESS_PERSONAL_DATA_LOCK = "cleanupCompletedProcessPersonalDataLock";
 
 }

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/consts/SchedulerLockNames.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/consts/SchedulerLockNames.java
@@ -34,20 +34,10 @@ public final class SchedulerLockNames {
 
     public static final String ONBOARDING_OTP_LOCK = "onboardingOtpLock";
 
-    public static final String DOCUMENT_SUBMIT_SYNC_LOCK = "documentSubmitCheckLock";
-
-    public static final String DOCUMENT_SUBMIT_VERIFICATION_LOCK = "documentSubmitVerificationsLock";
-
-    public static final String DOCUMENT_VERIFICATION_LOCK = "documentVerificationsLock";
-
-    public static final String DOCUMENT_DATA_LOCK = "documentDataDataLock";
-
-    public static final String PROCESSED_DOCUMENT_DATA_LOCK = "processedDocumentDataLock";
-
     public static final String EXPIRE_DOCUMENT_VERIFICATION_LOCK = "expireDocumentVerificationLock";
 
     public static final String CLEANUP_ACTIVATIONS_LOCK = "cleanupActivationsLock";
 
-    public static final String CLEANUP_SELFIES_LOCK = "cleanupSelfiesLock";
+    public static final String CLEANUP_COMPLETED_PROCESS_IDENTITY_DATA_LOCK = "cleanupCompletedProcessIdentityDataLock";
 
 }

--- a/enrollment-server-onboarding/src/test/java/com/wultra/app/onboardingserver/impl/service/document/DocumentProcessingServiceTest.java
+++ b/enrollment-server-onboarding/src/test/java/com/wultra/app/onboardingserver/impl/service/document/DocumentProcessingServiceTest.java
@@ -175,6 +175,35 @@ class DocumentProcessingServiceTest {
     }
 
     @Test
+    void testSubmitDocuments_rejectedUploadIdIsStored() throws Exception {
+        final var identityVerification = identityVerificationRepository.findById("v1").get();
+        assertNotNull(identityVerification);
+
+        final OwnerId ownerId = createOwnerId();
+
+        final var request = DocumentSubmitV2Request.builder()
+                .processId("p1")
+                .documents(List.of(
+                        DocumentSubmitV2Request.Document.builder()
+                                .filename("unexpected_filename.png")
+                                .data(Base64.getEncoder().encodeToString("img1".getBytes()))
+                                .type(DocumentType.ID_CARD)
+                                .side(CardSide.FRONT)
+                                .build()
+                ))
+                .build();
+
+        tested.submitDocuments(identityVerification, request, ownerId);
+
+        final var documents = documentVerificationRepository.findAll();
+        assertEquals(1, documents.size());
+
+        final var rejectedDocument = documents.get(0);
+        assertEquals(DocumentStatus.REJECTED, rejectedDocument.getStatus());
+        assertNotNull(rejectedDocument.getUploadId());
+    }
+
+    @Test
     void testSubmitDocuments_missingData() throws Exception {
         final IdentityVerificationEntity identityVerification = identityVerificationRepository.findById("v1").get();
         assertNotNull(identityVerification);

--- a/enrollment-server-onboarding/src/test/java/com/wultra/app/onboardingserver/task/cleaning/CleaningServiceTest.java
+++ b/enrollment-server-onboarding/src/test/java/com/wultra/app/onboardingserver/task/cleaning/CleaningServiceTest.java
@@ -261,11 +261,13 @@ class CleaningServiceTest {
 
         final var failedDocumentUploadId = "upload-cleanup-failed";
         final var successfulDocumentUploadId = "upload-cleanup-success";
+        final var successfulDisposedDocumentUploadId = "upload-cleanup-success-disposed";
         final var inProgressDocumentUploadId = "upload-cleanup-progress";
         final var recentFailedDocumentUploadId = "upload-cleanup-recent-failed";
 
         final var failedProcessedDocumentId = "processed-cleanup-failed";
         final var successfulProcessedDocumentId = "processed-cleanup-success";
+        final var successfulDisposedProcessedDocumentId = "processed-cleanup-success-disposed";
         final var inProgressProcessedDocumentId = "processed-cleanup-progress";
         final var recentFailedProcessedDocumentId = "processed-cleanup-recent-failed";
 
@@ -292,11 +294,13 @@ class CleaningServiceTest {
 
         assertNull(fetchProcessedDocumentData(failedProcessedDocumentId));
         assertNull(fetchProcessedDocumentData(successfulProcessedDocumentId));
+        assertNull(fetchProcessedDocumentData(successfulDisposedProcessedDocumentId));
         assertNotNull(fetchProcessedDocumentData(inProgressProcessedDocumentId));
         assertNotNull(fetchProcessedDocumentData(recentFailedProcessedDocumentId));
 
         assertNull(fetchDocumentData(failedDocumentUploadId));
         assertNull(fetchDocumentData(successfulDocumentUploadId));
+        assertNull(fetchDocumentData(successfulDisposedDocumentUploadId));
         assertNotNull(fetchDocumentData(inProgressDocumentUploadId));
         assertNotNull(fetchDocumentData(recentFailedDocumentUploadId));
     }

--- a/enrollment-server-onboarding/src/test/java/com/wultra/app/onboardingserver/task/cleaning/CleaningServiceTest.java
+++ b/enrollment-server-onboarding/src/test/java/com/wultra/app/onboardingserver/task/cleaning/CleaningServiceTest.java
@@ -45,6 +45,8 @@ import static org.junit.jupiter.api.Assertions.*;
 @ActiveProfiles("test")
 @Transactional
 class CleaningServiceTest {
+    
+    private static final long TIME_ASSERT_DELTA = 3_000;
 
     @Autowired
     private CleaningService tested;
@@ -244,6 +246,61 @@ class CleaningServiceTest {
         assertEquals(List.of("a", "b", "c", "d", "e", "f", "g", "h"), result.iterator().next());
     }
 
+    @Test
+    @Sql
+    void testCleanupCompletedProcessIdentityData() {
+        final var failedProcessId = "11111111-aaaa-4053-bb3d-3970979baf5d";
+        final var successfulProcessId = "22222222-aaaa-4053-bb3d-3970979baf5d";
+        final var inProgressProcessId = "33333333-aaaa-4053-bb3d-3970979baf5d";
+        final var recentFailedProcessId = "44444444-aaaa-4053-bb3d-3970979baf5d";
+
+        final var failedSelfieId = 1L;
+        final var successfulSelfieId = 2L;
+        final var inProgressSelfieId = 3L;
+        final var recentFailedSelfieId = 4L;
+
+        final var failedDocumentUploadId = "upload-cleanup-failed";
+        final var successfulDocumentUploadId = "upload-cleanup-success";
+        final var inProgressDocumentUploadId = "upload-cleanup-progress";
+        final var recentFailedDocumentUploadId = "upload-cleanup-recent-failed";
+
+        final var failedProcessedDocumentId = "processed-cleanup-failed";
+        final var successfulProcessedDocumentId = "processed-cleanup-success";
+        final var inProgressProcessedDocumentId = "processed-cleanup-progress";
+        final var recentFailedProcessedDocumentId = "processed-cleanup-recent-failed";
+
+        tested.cleanupCompletedProcessIdentityData();
+        entityManager.flush();
+        entityManager.clear();
+
+        final var failedProcess = fetchOnboardingProcess(failedProcessId);
+        assertEquals(System.currentTimeMillis(), failedProcess.getTimestampIdentityDataCleaned().getTime(), TIME_ASSERT_DELTA);
+
+        final var successfulProcess = fetchOnboardingProcess(successfulProcessId);
+        assertEquals(System.currentTimeMillis(), successfulProcess.getTimestampIdentityDataCleaned().getTime(), TIME_ASSERT_DELTA);
+
+        final var inProgressProcess = fetchOnboardingProcess(inProgressProcessId);
+        assertNull(inProgressProcess.getTimestampIdentityDataCleaned());
+
+        final var recentFailedProcess = fetchOnboardingProcess(recentFailedProcessId);
+        assertNull(recentFailedProcess.getTimestampIdentityDataCleaned());
+
+        assertNull(fetchSelfie(failedSelfieId));
+        assertNull(fetchSelfie(successfulSelfieId));
+        assertNotNull(fetchSelfie(inProgressSelfieId));
+        assertNotNull(fetchSelfie(recentFailedSelfieId));
+
+        assertNull(fetchProcessedDocumentData(failedProcessedDocumentId));
+        assertNull(fetchProcessedDocumentData(successfulProcessedDocumentId));
+        assertNotNull(fetchProcessedDocumentData(inProgressProcessedDocumentId));
+        assertNotNull(fetchProcessedDocumentData(recentFailedProcessedDocumentId));
+
+        assertNull(fetchDocumentData(failedDocumentUploadId));
+        assertNull(fetchDocumentData(successfulDocumentUploadId));
+        assertNotNull(fetchDocumentData(inProgressDocumentUploadId));
+        assertNotNull(fetchDocumentData(recentFailedDocumentUploadId));
+    }
+
     private void assertStatus(final String id, final DocumentStatus status) {
         final DocumentVerificationEntity documentVerification = fetchDocumentVerification(id);
         assertEquals(status, documentVerification.getStatus(), "status of " + id);
@@ -287,5 +344,9 @@ class CleaningServiceTest {
 
     private ProcessedDocumentDataEntity fetchProcessedDocumentData(final String id) {
         return entityManager.find(ProcessedDocumentDataEntity.class, id);
+    }
+
+    private SelfieEntity fetchSelfie(final Long id) {
+        return entityManager.find(SelfieEntity.class, id);
     }
 }

--- a/enrollment-server-onboarding/src/test/java/com/wultra/app/onboardingserver/task/cleaning/CleaningServiceTest.java
+++ b/enrollment-server-onboarding/src/test/java/com/wultra/app/onboardingserver/task/cleaning/CleaningServiceTest.java
@@ -90,30 +90,6 @@ class CleaningServiceTest {
 
     @Test
     @Sql
-    void testCleanupDocumentData() {
-        final String id1 = "93a41939-a808-4fe4-a673-f527a294f33e";
-        final String id2 = "54bcf744-3e78-4a17-b84e-eea065d733a6";
-
-        tested.cleanupDocumentData();
-
-        assertNotNull(fetchDocumentData(id1));
-        assertNull(fetchDocumentData(id2), "document data ID: " + id2 + " should be deleted");
-    }
-
-    @Test
-    @Sql
-    void testCleanupProcessedDocumentData() {
-        final var idToBeKept = "e3b0c442-98fc-4c4a-9c1f-0e4e2b7b5b6a";
-        final var idToBeDeleted = "7f6d2c3a-1b4e-4a8e-9d7c-3f2e1a5c9b8d";
-
-        tested.cleanupProcessedDocumentData();
-
-        assertNotNull(fetchProcessedDocumentData(idToBeKept));
-        assertNull(fetchProcessedDocumentData(idToBeDeleted));
-    }
-
-    @Test
-    @Sql
     void testTerminateExpiredProcesses() {
         final String processId1 = "11111111-df91-4053-bb3d-3970979baf5d";
         final String processId2 = "22222222-df91-4053-bb3d-3970979baf5d";

--- a/enrollment-server-onboarding/src/test/java/com/wultra/app/onboardingserver/task/cleaning/CleaningServiceTest.java
+++ b/enrollment-server-onboarding/src/test/java/com/wultra/app/onboardingserver/task/cleaning/CleaningServiceTest.java
@@ -253,13 +253,11 @@ class CleaningServiceTest {
         final var successfulProcessId = "22222222-aaaa-4053-bb3d-3970979baf5d";
         final var inProgressProcessId = "33333333-aaaa-4053-bb3d-3970979baf5d";
         final var recentFailedProcessId = "44444444-aaaa-4053-bb3d-3970979baf5d";
-        final var failedNoDocumentProcessId = "55555555-aaaa-4053-bb3d-3970979baf5d";
 
         final var failedSelfieId = 1L;
         final var successfulSelfieId = 2L;
         final var inProgressSelfieId = 3L;
         final var recentFailedSelfieId = 4L;
-        final var failedNoDocumentSelfieId = 5L;
 
         final var failedDocumentUploadId = "upload-cleanup-failed";
         final var successfulDocumentUploadId = "upload-cleanup-success";
@@ -289,14 +287,10 @@ class CleaningServiceTest {
         final var recentFailedProcess = fetchOnboardingProcess(recentFailedProcessId);
         assertNull(recentFailedProcess.getTimestampPersonalDataCleaned());
 
-        final var failedNoDocumentProcess = fetchOnboardingProcess(failedNoDocumentProcessId);
-        assertEquals(System.currentTimeMillis(), failedNoDocumentProcess.getTimestampPersonalDataCleaned().getTime(), TIME_ASSERT_DELTA);
-
         assertNull(fetchSelfie(failedSelfieId));
         assertNull(fetchSelfie(successfulSelfieId));
         assertNotNull(fetchSelfie(inProgressSelfieId));
         assertNotNull(fetchSelfie(recentFailedSelfieId));
-        assertNull(fetchSelfie(failedNoDocumentSelfieId));
 
         assertNull(fetchProcessedDocumentData(failedProcessedDocumentId));
         assertNull(fetchProcessedDocumentData(successfulProcessedDocumentId));

--- a/enrollment-server-onboarding/src/test/java/com/wultra/app/onboardingserver/task/cleaning/CleaningServiceTest.java
+++ b/enrollment-server-onboarding/src/test/java/com/wultra/app/onboardingserver/task/cleaning/CleaningServiceTest.java
@@ -273,7 +273,7 @@ class CleaningServiceTest {
         final var inProgressProcessedDocumentId = "processed-cleanup-progress";
         final var recentFailedProcessedDocumentId = "processed-cleanup-recent-failed";
 
-        tested.cleanupCompletedProcessIdentityData();
+        tested.cleanupCompletedProcessPersonalData();
         entityManager.flush();
         entityManager.clear();
 

--- a/enrollment-server-onboarding/src/test/java/com/wultra/app/onboardingserver/task/cleaning/CleaningServiceTest.java
+++ b/enrollment-server-onboarding/src/test/java/com/wultra/app/onboardingserver/task/cleaning/CleaningServiceTest.java
@@ -253,11 +253,13 @@ class CleaningServiceTest {
         final var successfulProcessId = "22222222-aaaa-4053-bb3d-3970979baf5d";
         final var inProgressProcessId = "33333333-aaaa-4053-bb3d-3970979baf5d";
         final var recentFailedProcessId = "44444444-aaaa-4053-bb3d-3970979baf5d";
+        final var failedNoDocumentProcessId = "55555555-aaaa-4053-bb3d-3970979baf5d";
 
         final var failedSelfieId = 1L;
         final var successfulSelfieId = 2L;
         final var inProgressSelfieId = 3L;
         final var recentFailedSelfieId = 4L;
+        final var failedNoDocumentSelfieId = 5L;
 
         final var failedDocumentUploadId = "upload-cleanup-failed";
         final var successfulDocumentUploadId = "upload-cleanup-success";
@@ -287,10 +289,14 @@ class CleaningServiceTest {
         final var recentFailedProcess = fetchOnboardingProcess(recentFailedProcessId);
         assertNull(recentFailedProcess.getTimestampPersonalDataCleaned());
 
+        final var failedNoDocumentProcess = fetchOnboardingProcess(failedNoDocumentProcessId);
+        assertEquals(System.currentTimeMillis(), failedNoDocumentProcess.getTimestampPersonalDataCleaned().getTime(), TIME_ASSERT_DELTA);
+
         assertNull(fetchSelfie(failedSelfieId));
         assertNull(fetchSelfie(successfulSelfieId));
         assertNotNull(fetchSelfie(inProgressSelfieId));
         assertNotNull(fetchSelfie(recentFailedSelfieId));
+        assertNull(fetchSelfie(failedNoDocumentSelfieId));
 
         assertNull(fetchProcessedDocumentData(failedProcessedDocumentId));
         assertNull(fetchProcessedDocumentData(successfulProcessedDocumentId));

--- a/enrollment-server-onboarding/src/test/java/com/wultra/app/onboardingserver/task/cleaning/CleaningServiceTest.java
+++ b/enrollment-server-onboarding/src/test/java/com/wultra/app/onboardingserver/task/cleaning/CleaningServiceTest.java
@@ -276,16 +276,16 @@ class CleaningServiceTest {
         entityManager.clear();
 
         final var failedProcess = fetchOnboardingProcess(failedProcessId);
-        assertEquals(System.currentTimeMillis(), failedProcess.getTimestampIdentityDataCleaned().getTime(), TIME_ASSERT_DELTA);
+        assertEquals(System.currentTimeMillis(), failedProcess.getTimestampPersonalDataCleaned().getTime(), TIME_ASSERT_DELTA);
 
         final var successfulProcess = fetchOnboardingProcess(successfulProcessId);
-        assertEquals(System.currentTimeMillis(), successfulProcess.getTimestampIdentityDataCleaned().getTime(), TIME_ASSERT_DELTA);
+        assertEquals(System.currentTimeMillis(), successfulProcess.getTimestampPersonalDataCleaned().getTime(), TIME_ASSERT_DELTA);
 
         final var inProgressProcess = fetchOnboardingProcess(inProgressProcessId);
-        assertNull(inProgressProcess.getTimestampIdentityDataCleaned());
+        assertNull(inProgressProcess.getTimestampPersonalDataCleaned());
 
         final var recentFailedProcess = fetchOnboardingProcess(recentFailedProcessId);
-        assertNull(recentFailedProcess.getTimestampIdentityDataCleaned());
+        assertNull(recentFailedProcess.getTimestampPersonalDataCleaned());
 
         assertNull(fetchSelfie(failedSelfieId));
         assertNull(fetchSelfie(successfulSelfieId));

--- a/enrollment-server-onboarding/src/test/resources/com/wultra/app/onboardingserver/task/cleaning/CleaningServiceTest.testCleanupCompletedProcessIdentityData.sql
+++ b/enrollment-server-onboarding/src/test/resources/com/wultra/app/onboardingserver/task/cleaning/CleaningServiceTest.testCleanupCompletedProcessIdentityData.sql
@@ -11,9 +11,9 @@ INSERT INTO es_document_verification(id, activation_id, identity_verification_id
 VALUES
 	('11111111-cccc-4a30-92cd-04876172ebca', 'cleanup-a1', '11111111-bbbb-45dd-b68e-29f4cd991a5c', 'ID_CARD', 'FAILED', 'failed.png', 'upload-cleanup-failed', true, now() - interval '7200' second, now() - interval '7200' second);
 
-INSERT INTO es_document_data(id, data, timestamp_created)
+INSERT INTO es_document_data(id, data, timestamp_created, document_verification_id)
 VALUES
-	('upload-cleanup-failed', 'failed-document-data', now() - interval '7200' second);
+	('upload-cleanup-failed', 'failed-document-data', now() - interval '7200' second, '11111111-cccc-4a30-92cd-04876172ebca');
 
 INSERT INTO es_processed_document_data(id, data, data_type, timestamp_created, document_verification_id)
 VALUES
@@ -23,7 +23,7 @@ INSERT INTO es_selfie(id, image, identity_verification_id, timestamp_created)
 VALUES
 	(1, X'01', '11111111-bbbb-45dd-b68e-29f4cd991a5c', now() - interval '7200' second);
 
--- successful process eligible for cleanup
+-- successful process eligible for cleanup with 1 disposed document
 INSERT INTO es_onboarding_process(id, identification_data, status, error_score, custom_data, timestamp_created, timestamp_finished, timestamp_failed)
 VALUES
 	('22222222-aaaa-4053-bb3d-3970979baf5d', '{}', 'FINISHED', 0, '{}', now() - interval '7200' second, now() - interval '7200' second, null);
@@ -34,15 +34,18 @@ VALUES
 
 INSERT INTO es_document_verification(id, activation_id, identity_verification_id, type, status, filename, upload_id, used_for_verification, timestamp_created, timestamp_last_updated)
 VALUES
-	('22222222-cccc-4a30-92cd-04876172ebca', 'cleanup-a2', '22222222-bbbb-45dd-b68e-29f4cd991a5c', 'ID_CARD', 'ACCEPTED', 'success.png', 'upload-cleanup-success', true, now() - interval '7200' second, now() - interval '7200' second);
+	('22222222-cccc-4a30-92cd-04876172ebca', 'cleanup-a2', '22222222-bbbb-45dd-b68e-29f4cd991a5c', 'ID_CARD', 'ACCEPTED', 'success.png', 'upload-cleanup-success', true, now() - interval '7200' second, now() - interval '7200' second),
+	('22222222-dddd-4a30-92cd-04876172ebca', 'cleanup-a2', '22222222-bbbb-45dd-b68e-29f4cd991a5c', 'PASSPORT', 'DISPOSED', 'disposed.png', 'upload-cleanup-success-disposed', false, now() - interval '7200' second, now() - interval '7200' second);
 
-INSERT INTO es_document_data(id, data, timestamp_created)
+INSERT INTO es_document_data(id, data, timestamp_created, document_verification_id)
 VALUES
-	('upload-cleanup-success', 'successful-document-data', now() - interval '7200' second);
+	('upload-cleanup-success', 'successful-document-data', now() - interval '7200' second, '22222222-cccc-4a30-92cd-04876172ebca'),
+    ('upload-cleanup-success-disposed', 'successful-document-data-disposed', now() - interval '7200' second, '22222222-dddd-4a30-92cd-04876172ebca');
 
 INSERT INTO es_processed_document_data(id, data, data_type, timestamp_created, document_verification_id)
 VALUES
-	('processed-cleanup-success', 'successful-processed-document', 'FACE_IMAGE', now() - interval '7200' second, '22222222-cccc-4a30-92cd-04876172ebca');
+	('processed-cleanup-success', 'successful-processed-document', 'FACE_IMAGE', now() - interval '7200' second, '22222222-cccc-4a30-92cd-04876172ebca'),
+    ('processed-cleanup-success-disposed', 'successful-processed-document-disposed', 'FACE_IMAGE', now() - interval '7200' second, '22222222-dddd-4a30-92cd-04876172ebca');
 
 INSERT INTO es_selfie(id, image, identity_verification_id, timestamp_created)
 VALUES
@@ -61,9 +64,9 @@ INSERT INTO es_document_verification(id, activation_id, identity_verification_id
 VALUES
 	('33333333-cccc-4a30-92cd-04876172ebca', 'cleanup-a3', '33333333-bbbb-45dd-b68e-29f4cd991a5c', 'ID_CARD', 'VERIFICATION_PENDING', 'progress.png', 'upload-cleanup-progress', true, now() - interval '7200' second, now() - interval '7200' second);
 
-INSERT INTO es_document_data(id, data, timestamp_created)
+INSERT INTO es_document_data(id, data, timestamp_created, document_verification_id)
 VALUES
-	('upload-cleanup-progress', 'in-progress-document-data', now() - interval '7200' second);
+	('upload-cleanup-progress', 'in-progress-document-data', now() - interval '7200' second, '33333333-cccc-4a30-92cd-04876172ebca');
 
 INSERT INTO es_processed_document_data(id, data, data_type, timestamp_created, document_verification_id)
 VALUES
@@ -86,9 +89,9 @@ INSERT INTO es_document_verification(id, activation_id, identity_verification_id
 VALUES
 	('44444444-cccc-4a30-92cd-04876172ebca', 'cleanup-a4', '44444444-bbbb-45dd-b68e-29f4cd991a5c', 'ID_CARD', 'FAILED', 'recent-failed.png', 'upload-cleanup-recent-failed', true, now() - interval '1800' second, now() - interval '1800' second);
 
-INSERT INTO es_document_data(id, data, timestamp_created)
+INSERT INTO es_document_data(id, data, timestamp_created, document_verification_id)
 VALUES
-	('upload-cleanup-recent-failed', 'recent-failed-document-data', now() - interval '1800' second);
+	('upload-cleanup-recent-failed', 'recent-failed-document-data', now() - interval '1800' second, '44444444-cccc-4a30-92cd-04876172ebca');
 
 INSERT INTO es_processed_document_data(id, data, data_type, timestamp_created, document_verification_id)
 VALUES

--- a/enrollment-server-onboarding/src/test/resources/com/wultra/app/onboardingserver/task/cleaning/CleaningServiceTest.testCleanupCompletedProcessIdentityData.sql
+++ b/enrollment-server-onboarding/src/test/resources/com/wultra/app/onboardingserver/task/cleaning/CleaningServiceTest.testCleanupCompletedProcessIdentityData.sql
@@ -51,19 +51,6 @@ INSERT INTO es_selfie(id, image, identity_verification_id, timestamp_created)
 VALUES
 	(2, X'02', '22222222-bbbb-45dd-b68e-29f4cd991a5c', now() - interval '7200' second);
 
--- failed process eligible for cleanup without document verification
-INSERT INTO es_onboarding_process(id, identification_data, status, error_score, custom_data, timestamp_created, timestamp_finished, timestamp_failed)
-VALUES
-	('55555555-aaaa-4053-bb3d-3970979baf5d', '{}', 'FAILED', 0, '{}', now() - interval '7200' second, null, now() - interval '7200' second);
-
-INSERT INTO es_identity_verification(id, activation_id, user_id, process_id, status, phase, timestamp_created, timestamp_last_updated, timestamp_finished, timestamp_failed)
-VALUES
-	('55555555-bbbb-45dd-b68e-29f4cd991a5c', 'cleanup-a5', 'cleanup-u5', '55555555-aaaa-4053-bb3d-3970979baf5d', 'FAILED', 'COMPLETED', now() - interval '7200' second, now() - interval '7200' second, null, now() - interval '7200' second);
-
-INSERT INTO es_selfie(id, image, identity_verification_id, timestamp_created)
-VALUES
-	(5, X'05', '55555555-bbbb-45dd-b68e-29f4cd991a5c', now() - interval '7200' second);
-
 -- in progress process kept intact
 INSERT INTO es_onboarding_process(id, identification_data, status, error_score, custom_data, timestamp_created, timestamp_finished, timestamp_failed)
 VALUES

--- a/enrollment-server-onboarding/src/test/resources/com/wultra/app/onboardingserver/task/cleaning/CleaningServiceTest.testCleanupCompletedProcessIdentityData.sql
+++ b/enrollment-server-onboarding/src/test/resources/com/wultra/app/onboardingserver/task/cleaning/CleaningServiceTest.testCleanupCompletedProcessIdentityData.sql
@@ -51,6 +51,19 @@ INSERT INTO es_selfie(id, image, identity_verification_id, timestamp_created)
 VALUES
 	(2, X'02', '22222222-bbbb-45dd-b68e-29f4cd991a5c', now() - interval '7200' second);
 
+-- failed process eligible for cleanup without document verification
+INSERT INTO es_onboarding_process(id, identification_data, status, error_score, custom_data, timestamp_created, timestamp_finished, timestamp_failed)
+VALUES
+	('55555555-aaaa-4053-bb3d-3970979baf5d', '{}', 'FAILED', 0, '{}', now() - interval '7200' second, null, now() - interval '7200' second);
+
+INSERT INTO es_identity_verification(id, activation_id, user_id, process_id, status, phase, timestamp_created, timestamp_last_updated, timestamp_finished, timestamp_failed)
+VALUES
+	('55555555-bbbb-45dd-b68e-29f4cd991a5c', 'cleanup-a5', 'cleanup-u5', '55555555-aaaa-4053-bb3d-3970979baf5d', 'FAILED', 'COMPLETED', now() - interval '7200' second, now() - interval '7200' second, null, now() - interval '7200' second);
+
+INSERT INTO es_selfie(id, image, identity_verification_id, timestamp_created)
+VALUES
+	(5, X'05', '55555555-bbbb-45dd-b68e-29f4cd991a5c', now() - interval '7200' second);
+
 -- in progress process kept intact
 INSERT INTO es_onboarding_process(id, identification_data, status, error_score, custom_data, timestamp_created, timestamp_finished, timestamp_failed)
 VALUES

--- a/enrollment-server-onboarding/src/test/resources/com/wultra/app/onboardingserver/task/cleaning/CleaningServiceTest.testCleanupCompletedProcessIdentityData.sql
+++ b/enrollment-server-onboarding/src/test/resources/com/wultra/app/onboardingserver/task/cleaning/CleaningServiceTest.testCleanupCompletedProcessIdentityData.sql
@@ -1,0 +1,100 @@
+-- failed process eligible for cleanup
+INSERT INTO es_onboarding_process(id, identification_data, status, error_score, custom_data, timestamp_created, timestamp_finished, timestamp_failed)
+VALUES
+	('11111111-aaaa-4053-bb3d-3970979baf5d', '{}', 'FAILED', 0, '{}', now() - interval '7200' second, null, now() - interval '7200' second);
+
+INSERT INTO es_identity_verification(id, activation_id, user_id, process_id, status, phase, timestamp_created, timestamp_last_updated, timestamp_finished, timestamp_failed)
+VALUES
+	('11111111-bbbb-45dd-b68e-29f4cd991a5c', 'cleanup-a1', 'cleanup-u1', '11111111-aaaa-4053-bb3d-3970979baf5d', 'FAILED', 'COMPLETED', now() - interval '7200' second, now() - interval '7200' second, null, now() - interval '7200' second);
+
+INSERT INTO es_document_verification(id, activation_id, identity_verification_id, type, status, filename, upload_id, used_for_verification, timestamp_created, timestamp_last_updated)
+VALUES
+	('11111111-cccc-4a30-92cd-04876172ebca', 'cleanup-a1', '11111111-bbbb-45dd-b68e-29f4cd991a5c', 'ID_CARD', 'FAILED', 'failed.png', 'upload-cleanup-failed', true, now() - interval '7200' second, now() - interval '7200' second);
+
+INSERT INTO es_document_data(id, data, timestamp_created)
+VALUES
+	('upload-cleanup-failed', 'failed-document-data', now() - interval '7200' second);
+
+INSERT INTO es_processed_document_data(id, data, data_type, timestamp_created, document_verification_id)
+VALUES
+	('processed-cleanup-failed', 'failed-processed-document', 'FACE_IMAGE', now() - interval '7200' second, '11111111-cccc-4a30-92cd-04876172ebca');
+
+INSERT INTO es_selfie(id, image, identity_verification_id, timestamp_created)
+VALUES
+	(1, X'01', '11111111-bbbb-45dd-b68e-29f4cd991a5c', now() - interval '7200' second);
+
+-- successful process eligible for cleanup
+INSERT INTO es_onboarding_process(id, identification_data, status, error_score, custom_data, timestamp_created, timestamp_finished, timestamp_failed)
+VALUES
+	('22222222-aaaa-4053-bb3d-3970979baf5d', '{}', 'FINISHED', 0, '{}', now() - interval '7200' second, now() - interval '7200' second, null);
+
+INSERT INTO es_identity_verification(id, activation_id, user_id, process_id, status, phase, timestamp_created, timestamp_last_updated, timestamp_finished, timestamp_failed)
+VALUES
+	('22222222-bbbb-45dd-b68e-29f4cd991a5c', 'cleanup-a2', 'cleanup-u2', '22222222-aaaa-4053-bb3d-3970979baf5d', 'ACCEPTED', 'COMPLETED', now() - interval '7200' second, now() - interval '7200' second, now() - interval '7200' second, null);
+
+INSERT INTO es_document_verification(id, activation_id, identity_verification_id, type, status, filename, upload_id, used_for_verification, timestamp_created, timestamp_last_updated)
+VALUES
+	('22222222-cccc-4a30-92cd-04876172ebca', 'cleanup-a2', '22222222-bbbb-45dd-b68e-29f4cd991a5c', 'ID_CARD', 'ACCEPTED', 'success.png', 'upload-cleanup-success', true, now() - interval '7200' second, now() - interval '7200' second);
+
+INSERT INTO es_document_data(id, data, timestamp_created)
+VALUES
+	('upload-cleanup-success', 'successful-document-data', now() - interval '7200' second);
+
+INSERT INTO es_processed_document_data(id, data, data_type, timestamp_created, document_verification_id)
+VALUES
+	('processed-cleanup-success', 'successful-processed-document', 'FACE_IMAGE', now() - interval '7200' second, '22222222-cccc-4a30-92cd-04876172ebca');
+
+INSERT INTO es_selfie(id, image, identity_verification_id, timestamp_created)
+VALUES
+	(2, X'02', '22222222-bbbb-45dd-b68e-29f4cd991a5c', now() - interval '7200' second);
+
+-- in progress process kept intact
+INSERT INTO es_onboarding_process(id, identification_data, status, error_score, custom_data, timestamp_created, timestamp_finished, timestamp_failed)
+VALUES
+	('33333333-aaaa-4053-bb3d-3970979baf5d', '{}', 'VERIFICATION_IN_PROGRESS', 0, '{}', now() - interval '7200' second, null, null);
+
+INSERT INTO es_identity_verification(id, activation_id, user_id, process_id, status, phase, timestamp_created, timestamp_last_updated, timestamp_finished, timestamp_failed)
+VALUES
+	('33333333-bbbb-45dd-b68e-29f4cd991a5c', 'cleanup-a3', 'cleanup-u3', '33333333-aaaa-4053-bb3d-3970979baf5d', 'IN_PROGRESS', 'DOCUMENT_VERIFICATION_FINAL', now() - interval '7200' second, now() - interval '7200' second, null, null);
+
+INSERT INTO es_document_verification(id, activation_id, identity_verification_id, type, status, filename, upload_id, used_for_verification, timestamp_created, timestamp_last_updated)
+VALUES
+	('33333333-cccc-4a30-92cd-04876172ebca', 'cleanup-a3', '33333333-bbbb-45dd-b68e-29f4cd991a5c', 'ID_CARD', 'VERIFICATION_PENDING', 'progress.png', 'upload-cleanup-progress', true, now() - interval '7200' second, now() - interval '7200' second);
+
+INSERT INTO es_document_data(id, data, timestamp_created)
+VALUES
+	('upload-cleanup-progress', 'in-progress-document-data', now() - interval '7200' second);
+
+INSERT INTO es_processed_document_data(id, data, data_type, timestamp_created, document_verification_id)
+VALUES
+	('processed-cleanup-progress', 'in-progress-processed-document', 'FACE_IMAGE', now() - interval '7200' second, '33333333-cccc-4a30-92cd-04876172ebca');
+
+INSERT INTO es_selfie(id, image, identity_verification_id, timestamp_created)
+VALUES
+	(3, X'03', '33333333-bbbb-45dd-b68e-29f4cd991a5c', now() - interval '7200' second);
+
+-- recent failed process not eligible for cleanup
+INSERT INTO es_onboarding_process(id, identification_data, status, error_score, custom_data, timestamp_created, timestamp_finished, timestamp_failed)
+VALUES
+	('44444444-aaaa-4053-bb3d-3970979baf5d', '{}', 'FAILED', 0, '{}', now() - interval '1800' second, null, now() - interval '1800' second);
+
+INSERT INTO es_identity_verification(id, activation_id, user_id, process_id, status, phase, timestamp_created, timestamp_last_updated, timestamp_finished, timestamp_failed)
+VALUES
+	('44444444-bbbb-45dd-b68e-29f4cd991a5c', 'cleanup-a4', 'cleanup-u4', '44444444-aaaa-4053-bb3d-3970979baf5d', 'FAILED', 'COMPLETED', now() - interval '1800' second, now() - interval '1800' second, null, now() - interval '1800' second);
+
+INSERT INTO es_document_verification(id, activation_id, identity_verification_id, type, status, filename, upload_id, used_for_verification, timestamp_created, timestamp_last_updated)
+VALUES
+	('44444444-cccc-4a30-92cd-04876172ebca', 'cleanup-a4', '44444444-bbbb-45dd-b68e-29f4cd991a5c', 'ID_CARD', 'FAILED', 'recent-failed.png', 'upload-cleanup-recent-failed', true, now() - interval '1800' second, now() - interval '1800' second);
+
+INSERT INTO es_document_data(id, data, timestamp_created)
+VALUES
+	('upload-cleanup-recent-failed', 'recent-failed-document-data', now() - interval '1800' second);
+
+INSERT INTO es_processed_document_data(id, data, data_type, timestamp_created, document_verification_id)
+VALUES
+	('processed-cleanup-recent-failed', 'recent-failed-processed-document', 'FACE_IMAGE', now() - interval '1800' second, '44444444-cccc-4a30-92cd-04876172ebca');
+
+INSERT INTO es_selfie(id, image, identity_verification_id, timestamp_created)
+VALUES
+	(4, X'04', '44444444-bbbb-45dd-b68e-29f4cd991a5c', now() - interval '1800' second);
+

--- a/enrollment-server-onboarding/src/test/resources/com/wultra/app/onboardingserver/task/cleaning/CleaningServiceTest.testCleanupDocumentData.sql
+++ b/enrollment-server-onboarding/src/test/resources/com/wultra/app/onboardingserver/task/cleaning/CleaningServiceTest.testCleanupDocumentData.sql
@@ -1,8 +1,0 @@
-INSERT INTO es_identity_verification(id, activation_id, user_id, process_id, status, phase, timestamp_created, timestamp_last_updated) VALUES
-    ('a6055e8b-4ac0-45dd-b68e-29f4cd991a5c', 'a1', 'u1', 'p1', 'IN_PROGRESS', 'PRESENCE_CHECK', now(), now()),
-    ('8d036a18-f51f-4a30-92cd-04876172ebca', 'a2', 'u2', 'p2', 'IN_PROGRESS', 'PRESENCE_CHECK', now() - 1, now() - 1), -- to be terminated
-    ('c918e1c4-5ca7-47da-8765-afc92082f717', 'a3', 'u3', 'p3', 'ACCEPTED', 'COMPLETED', now() - 1, now() - 1);
-
-INSERT INTO es_document_data(id, data, timestamp_created) VALUES
-    ('93a41939-a808-4fe4-a673-f527a294f33e', 'data1', DATEADD('MINUTE', -175, NOW())),
-    ('54bcf744-3e78-4a17-b84e-eea065d733a6', 'data2', DATEADD('MINUTE', -185, NOW())); -- to be deleted

--- a/enrollment-server-onboarding/src/test/resources/com/wultra/app/onboardingserver/task/cleaning/CleaningServiceTest.testCleanupProcessedDocumentData.sql
+++ b/enrollment-server-onboarding/src/test/resources/com/wultra/app/onboardingserver/task/cleaning/CleaningServiceTest.testCleanupProcessedDocumentData.sql
@@ -1,3 +1,0 @@
-INSERT INTO es_processed_document_data(id, data, data_type, timestamp_created) VALUES
-    ('e3b0c442-98fc-4c4a-9c1f-0e4e2b7b5b6a', 'data1', 'FACE_IMAGE', DATEADD('MINUTE', -175, NOW())),
-    ('7f6d2c3a-1b4e-4a8e-9d7c-3f2e1a5c9b8d', 'data2', 'FACE_IMAGE', DATEADD('MINUTE', -185, NOW()));


### PR DESCRIPTION
The property `enrollment-server-onboarding.identity-verification.data-retention` controls personal data retention for completed processes. There is only one retention period for all process types.
A process is considered complete when it is in the `FINISHED` or `FAILED` state.

The retention time is counted from `timestamp_finished` or `timestamp_failed` from `es_onboarding_proces` table, with a default value of 1 hour (we can change it). After the retention period, records related to the process are deleted from the following tables:
- `es_document_data`
- `es_processed_document`
- `es_selfie`

A new column `es_onboarding_process.timestamp_personal_data_cleaned` has been added. It is used by the cleaning task to ensure that each process is cleaned only once.