### PR TITLE
Fix #1722: Implicit validation of encryptionContext and PowerAuthApiAuthentication

### DIFF
--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/controller/api/IdentityVerificationController.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/controller/api/IdentityVerificationController.java
@@ -35,7 +35,6 @@ import com.wultra.security.powerauth.rest.api.spring.annotation.EncryptedRequest
 import com.wultra.security.powerauth.rest.api.spring.annotation.PowerAuth;
 import com.wultra.security.powerauth.rest.api.spring.annotation.PowerAuthEncryption;
 import com.wultra.security.powerauth.rest.api.spring.annotation.PowerAuthToken;
-import com.wultra.security.powerauth.rest.api.spring.authentication.PowerAuthActivation;
 import com.wultra.security.powerauth.rest.api.spring.authentication.PowerAuthApiAuthentication;
 import com.wultra.security.powerauth.rest.api.spring.encryption.EncryptionContext;
 import com.wultra.security.powerauth.rest.api.spring.encryption.EncryptionScope;
@@ -59,7 +58,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static com.wultra.app.onboardingserver.controller.api.LoggingUtils.extractActivation;
+import static com.wultra.app.onboardingserver.controller.api.LoggingUtils.extractActivationId;
 import static com.wultra.app.onboardingserver.controller.api.LoggingUtils.extractRequest;
 
 /**
@@ -124,7 +123,7 @@ public class IdentityVerificationController {
             final @Parameter(hidden = true) PowerAuthApiAuthentication apiAuthentication)
             throws PowerAuthAuthenticationException, RemoteCommunicationException, OnboardingProcessException {
 
-        logger.info("action: checkIdentityVerificationStatus, state: initiated, activationId: {}", extractActivation(apiAuthentication).map(PowerAuthActivation::getActivationId).orElse(null));
+        logger.info("action: checkIdentityVerificationStatus, state: initiated, activationId: {}", extractActivationId(apiAuthentication));
         final var response = identityVerificationRestService.checkIdentityVerificationStatus(request.getRequestObject(), apiAuthentication);
         logger.info("action: checkIdentityVerificationStatus, state: succeeded, phase: {}, status: {}",
                 response.getResponseObject().getIdentityVerificationPhase(), response.getResponseObject().getIdentityVerificationStatus());

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/controller/api/LoggingUtils.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/controller/api/LoggingUtils.java
@@ -20,6 +20,7 @@ package com.wultra.app.onboardingserver.controller.api;
 import com.wultra.core.rest.model.base.request.ObjectRequest;
 import com.wultra.security.powerauth.rest.api.spring.authentication.PowerAuthActivation;
 import com.wultra.security.powerauth.rest.api.spring.authentication.PowerAuthApiAuthentication;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Optional;
 
@@ -47,13 +48,15 @@ final class LoggingUtils {
     }
 
     /**
-     * Extract activation from authentication.
+     * Extract activation ID from authentication.
      *
      * @param apiAuthentication authentication
-     * @return PowerAuthActivation as optional
+     * @return activation ID or {@code null} if not available
      */
-    // TODO (racansky, 2026-02-25, #1589) remove when validation of apiAuthentication made implicit
-    public static Optional<PowerAuthActivation> extractActivation(final PowerAuthApiAuthentication apiAuthentication) {
-        return Optional.ofNullable(apiAuthentication).map(PowerAuthApiAuthentication::getActivationContext);
+    public static @Nullable String extractActivationId(final PowerAuthApiAuthentication apiAuthentication) {
+        return Optional.ofNullable(apiAuthentication)
+                .map(PowerAuthApiAuthentication::getActivationContext)
+                .map(PowerAuthActivation::getActivationId)
+                .orElse(null);
     }
 }

--- a/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/controller/api/LoggingUtils.java
+++ b/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/controller/api/LoggingUtils.java
@@ -53,7 +53,6 @@ final class LoggingUtils {
      * @param apiAuthentication authentication
      * @return activation ID or {@code null} if not available
      */
-    // TODO (racansky, 2026-02-25, #1589) remove when validation of apiAuthentication made implicit
     public static @Nullable String extractActivationId(final PowerAuthApiAuthentication apiAuthentication) {
         return Optional.ofNullable(apiAuthentication)
                 .map(PowerAuthApiAuthentication::getActivationContext)

--- a/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/controller/api/MobileTokenController.java
+++ b/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/controller/api/MobileTokenController.java
@@ -108,19 +108,17 @@ public class MobileTokenController {
     })
     public ObjectResponse<OperationListResponse> operationList(@Parameter(hidden = true) PowerAuthApiAuthentication auth, @Parameter(hidden = true) Locale locale) throws MobileTokenException, MobileTokenConfigurationException, RemoteCommunicationException {
         logger.info("action: operationList, state: initiated, activationId: {}", extractActivationId(auth));
+        validateApiAuthentication(auth);
+
         try {
-            if (auth != null) {
-                final String userId = auth.getUserId();
-                final String applicationId = auth.getApplicationId();
-                final String activationId = auth.getActivationContext().getActivationId();
-                final String language = locale.getLanguage();
-                final OperationListResponse listResponse = mobileTokenService.operationListForUser(userId, applicationId, language, activationId, true);
-                logger.info("action: operationList, state: succeeded");
-                final Date currentTimestamp = new Date();
-                return new MobileTokenResponse<>(listResponse, currentTimestamp);
-            } else {
-                throw new MobileTokenAuthException();
-            }
+            final String userId = auth.getUserId();
+            final String applicationId = auth.getApplicationId();
+            final String activationId = auth.getActivationContext().getActivationId();
+            final String language = locale.getLanguage();
+            final OperationListResponse listResponse = mobileTokenService.operationListForUser(userId, applicationId, language, activationId, true);
+            logger.info("action: operationList, state: succeeded");
+            final Date currentTimestamp = new Date();
+            return new MobileTokenResponse<>(listResponse, currentTimestamp);
         } catch (PowerAuthClientException e) {
             final String errorCode = e.getPowerAuthError().map(PowerAuthError::getCode).orElse("ERROR_CODE_MISSING");
             switch (errorCode) {
@@ -161,19 +159,16 @@ public class MobileTokenController {
 
         logger.info("action: fetchOperationDetail, state: initiated, activationId: {}, operationId: {}",
                 extractActivationId(auth), extractRequest(request).map(OperationDetailRequest::getId).orElse(null));
+        validateApiAuthentication(auth);
 
         try {
-            if (auth != null) {
-                final String operationId = request.getRequestObject().getId();
-                final String language = locale.getLanguage();
-                final String userId = auth.getUserId();
-                final Operation response = mobileTokenService.fetchOperationDetail(operationId, language, userId);
-                logger.info("action: fetchOperationDetail, state: succeeded");
-                final Date currentTimestamp = new Date();
-                return new MobileTokenResponse<>(response, currentTimestamp);
-            } else {
-                throw new MobileTokenAuthException();
-            }
+            final String operationId = request.getRequestObject().getId();
+            final String language = locale.getLanguage();
+            final String userId = auth.getUserId();
+            final Operation response = mobileTokenService.fetchOperationDetail(operationId, language, userId);
+            logger.info("action: fetchOperationDetail, state: succeeded");
+            final Date currentTimestamp = new Date();
+            return new MobileTokenResponse<>(response, currentTimestamp);
         } catch (PowerAuthClientException e) {
             final String errorCode = e.getPowerAuthError().map(PowerAuthError::getCode).orElse("ERROR_CODE_MISSING");
             switch (errorCode) {
@@ -214,19 +209,16 @@ public class MobileTokenController {
 
         logger.info("action: claimOperation, state: initiated, activationId: {}, operationId: {}",
                 extractActivationId(auth), extractRequest(request).map(OperationDetailRequest::getId).orElse(null));
+        validateApiAuthentication(auth);
 
         try {
-            if (auth != null) {
-                final String operationId = request.getRequestObject().getId();
-                final String language = locale.getLanguage();
-                final String userId = auth.getUserId();
-                final Operation response = mobileTokenService.claimOperation(operationId, language, userId);
-                logger.info("action: claimOperation, state: succeeded");
-                final Date currentTimestamp = new Date();
-                return new MobileTokenResponse<>(response, currentTimestamp);
-            } else {
-                throw new MobileTokenAuthException();
-            }
+            final String operationId = request.getRequestObject().getId();
+            final String language = locale.getLanguage();
+            final String userId = auth.getUserId();
+            final Operation response = mobileTokenService.claimOperation(operationId, language, userId);
+            logger.info("action: claimOperation, state: succeeded");
+            final Date currentTimestamp = new Date();
+            return new MobileTokenResponse<>(response, currentTimestamp);
         } catch (PowerAuthClientException e) {
             final String errorCode = e.getPowerAuthError().map(PowerAuthError::getCode).orElse("ERROR_CODE_MISSING");
             switch (errorCode) {
@@ -262,18 +254,16 @@ public class MobileTokenController {
     })
     public ObjectResponse<OperationListResponse> operationListAll(@Parameter(hidden = true) PowerAuthApiAuthentication auth, @Parameter(hidden = true) Locale locale) throws MobileTokenException, MobileTokenConfigurationException, RemoteCommunicationException {
         logger.info("action: operationListAll, state: initiated, activationId: {}", extractActivationId(auth));
+        validateApiAuthentication(auth);
+
         try {
-            if (auth != null) {
-                final String userId = auth.getUserId();
-                final String applicationId = auth.getApplicationId();
-                final String activationId = auth.getActivationContext().getActivationId();
-                final String language = locale.getLanguage();
-                final OperationListResponse listResponse = mobileTokenService.operationListForUser(userId, applicationId, language, activationId, false);
-                logger.info("action: operationListAll, state: succeeded");
-                return new ObjectResponse<>(listResponse);
-            } else {
-                throw new MobileTokenAuthException();
-            }
+            final String userId = auth.getUserId();
+            final String applicationId = auth.getApplicationId();
+            final String activationId = auth.getActivationContext().getActivationId();
+            final String language = locale.getLanguage();
+            final OperationListResponse listResponse = mobileTokenService.operationListForUser(userId, applicationId, language, activationId, false);
+            logger.info("action: operationListAll, state: succeeded");
+            return new ObjectResponse<>(listResponse);
         } catch (PowerAuthClientException e) {
             final String errorCode = e.getPowerAuthError().map(PowerAuthError::getCode).orElse("ERROR_CODE_MISSING");
             switch (errorCode) {
@@ -460,6 +450,13 @@ public class MobileTokenController {
                     throw new RemoteCommunicationException("Unable to call upstream service.", e);
                 }
             }
+        }
+    }
+
+    private static void validateApiAuthentication(final PowerAuthApiAuthentication auth) throws MobileTokenAuthException {
+        if (auth == null) {
+            logger.warn("API authentication is missing");
+            throw new MobileTokenAuthException();
         }
     }
 }

--- a/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/controller/api/PushRegistrationController.java
+++ b/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/controller/api/PushRegistrationController.java
@@ -67,10 +67,7 @@ public class PushRegistrationController {
             PowerAuthCodeType.POSSESSION_KNOWLEDGE
     })
     public Response registerDeviceDefault(@RequestBody ObjectRequest<PushRegisterRequest> request, @Parameter(hidden = true) PowerAuthApiAuthentication apiAuthentication) throws PowerAuthAuthenticationException, InvalidRequestObjectException, PushRegistrationFailedException {
-        if (apiAuthentication == null) {
-            logger.error("Unable to verify device registration");
-            throw new PowerAuthAuthenticationException("Unable to verify device registration");
-        }
+        validateApiAuthentication(apiAuthentication);
 
         logger.info("action: registerDeviceDefault, state: initiated, userId: {}", apiAuthentication.getUserId());
         final Response response = pushRegistrationService.registerDevice(request, apiAuthentication);
@@ -95,15 +92,19 @@ public class PushRegistrationController {
             PowerAuthCodeType.POSSESSION_KNOWLEDGE
     })
     public Response registerDeviceToken(@RequestBody ObjectRequest<PushRegisterRequest> request, @Parameter(hidden = true) PowerAuthApiAuthentication apiAuthentication) throws PowerAuthAuthenticationException, InvalidRequestObjectException, PushRegistrationFailedException {
-        if (apiAuthentication == null) {
-            logger.error("Unable to verify device registration");
-            throw new PowerAuthAuthenticationException("Unable to verify device registration");
-        }
+        validateApiAuthentication(apiAuthentication);
 
         logger.info("action: registerDeviceToken, state: initiated, userId: {}", apiAuthentication.getUserId());
         final Response response = pushRegistrationService.registerDevice(request, apiAuthentication);
         logger.info("action: registerDeviceToken, state: succeeded");
         return response;
+    }
+
+    private static void validateApiAuthentication(final PowerAuthApiAuthentication apiAuthentication) throws PowerAuthAuthenticationException {
+        if (apiAuthentication == null) {
+            logger.error("Unable to verify device registration");
+            throw new PowerAuthAuthenticationException("Unable to verify device registration");
+        }
     }
 
 }


### PR DESCRIPTION
Should be merged after release 2.1

Just cleanup, because unfortunately, `io.swagger.v3.oas.annotations.Parameter#required` is only for documentation purposes. `@NotNull` is not enough, since `MobileTokenController` throws `MobileTokenAuthException` and returns 401.