### PR TITLE
Fix #1752: [release/2.1.x] Remove duplicated es_document_data index

### DIFF
--- a/docs/db/changelog/changesets/enrollment-server-onboarding/2.0.x/20260116-add-processed-document-data-table.xml
+++ b/docs/db/changelog/changesets/enrollment-server-onboarding/2.0.x/20260116-add-processed-document-data-table.xml
@@ -64,18 +64,6 @@
     </changeSet>
 
     <changeSet id="6" logicalFilePath="enrollment-server-onboarding/2.0.x/20260116-add-processed-document-data-table.xml" author="Michal Rozehnal">
-        <preConditions onFail="MARK_RAN">
-            <not>
-                <indexExists tableName="es_document_data" indexName="es_document_data_timestamp_created_idx"/>
-            </not>
-        </preConditions>
-        <comment>Add index for table es_document_data column timestamp_created</comment>
-        <createIndex tableName="es_document_data" indexName="es_document_data_timestamp_created_idx">
-            <column name="timestamp_created" />
-        </createIndex>
-    </changeSet>
-
-    <changeSet id="7" logicalFilePath="enrollment-server-onboarding/2.0.x/20260116-add-processed-document-data-table.xml" author="Michal Rozehnal">
         <preConditions>
             <not>
                 <indexExists tableName="es_document_verification" indexName="es_document_verification_upload_id_idx"/>

--- a/docs/sql/oracle/onboarding/create-schema.sql
+++ b/docs/sql/oracle/onboarding/create-schema.sql
@@ -288,10 +288,6 @@ ALTER TABLE es_document_data DROP COLUMN identity_verification_id;
 ALTER TABLE es_document_data DROP COLUMN filename;
 
 -- Changeset enrollment-server-onboarding/2.0.x/20260116-add-processed-document-data-table.xml::6::Michal Rozehnal
--- Add index for table es_document_data column timestamp_created
-CREATE INDEX es_document_data_timestamp_created_idx ON es_document_data(timestamp_created);
-
--- Changeset enrollment-server-onboarding/2.0.x/20260116-add-processed-document-data-table.xml::7::Michal Rozehnal
 -- Add index for table es_document_verification column upload_id
 CREATE INDEX es_document_verification_upload_id_idx ON es_document_verification(upload_id);
 

--- a/docs/sql/oracle/onboarding/migration_1.10.0_2.1.0.sql
+++ b/docs/sql/oracle/onboarding/migration_1.10.0_2.1.0.sql
@@ -37,10 +37,6 @@ ALTER TABLE es_document_data DROP COLUMN identity_verification_id;
 ALTER TABLE es_document_data DROP COLUMN filename;
 
 -- Changeset enrollment-server-onboarding/2.0.x/20260116-add-processed-document-data-table.xml::6::Michal Rozehnal
--- Add index for table es_document_data column timestamp_created
-CREATE INDEX es_document_data_timestamp_created_idx ON es_document_data(timestamp_created);
-
--- Changeset enrollment-server-onboarding/2.0.x/20260116-add-processed-document-data-table.xml::7::Michal Rozehnal
 -- Add index for table es_document_verification column upload_id
 CREATE INDEX es_document_verification_upload_id_idx ON es_document_verification(upload_id);
 

--- a/docs/sql/postgresql/onboarding/create-schema.sql
+++ b/docs/sql/postgresql/onboarding/create-schema.sql
@@ -265,10 +265,6 @@ ALTER TABLE es_document_data DROP COLUMN identity_verification_id;
 ALTER TABLE es_document_data DROP COLUMN filename;
 
 -- Changeset enrollment-server-onboarding/2.0.x/20260116-add-processed-document-data-table.xml::6::Michal Rozehnal
--- Add index for table es_document_data column timestamp_created
-CREATE INDEX es_document_data_timestamp_created_idx ON es_document_data(timestamp_created);
-
--- Changeset enrollment-server-onboarding/2.0.x/20260116-add-processed-document-data-table.xml::7::Michal Rozehnal
 -- Add index for table es_document_verification column upload_id
 CREATE INDEX es_document_verification_upload_id_idx ON es_document_verification(upload_id);
 

--- a/docs/sql/postgresql/onboarding/migration_1.10.0_2.1.0.sql
+++ b/docs/sql/postgresql/onboarding/migration_1.10.0_2.1.0.sql
@@ -37,10 +37,6 @@ ALTER TABLE es_document_data DROP COLUMN identity_verification_id;
 ALTER TABLE es_document_data DROP COLUMN filename;
 
 -- Changeset enrollment-server-onboarding/2.0.x/20260116-add-processed-document-data-table.xml::6::Michal Rozehnal
--- Add index for table es_document_data column timestamp_created
-CREATE INDEX es_document_data_timestamp_created_idx ON es_document_data(timestamp_created);
-
--- Changeset enrollment-server-onboarding/2.0.x/20260116-add-processed-document-data-table.xml::7::Michal Rozehnal
 -- Add index for table es_document_verification column upload_id
 CREATE INDEX es_document_verification_upload_id_idx ON es_document_verification(upload_id);
 


### PR DESCRIPTION
(cherrypick of https://github.com/wultra/enrollment-server/commit/8c26443569afb475a2cdc244eb9e23555d282748)