### PR TITLE
fix: source appname from spring.application.name in logback configs (#1689)

### DIFF
--- a/enrollment-server-onboarding/docker/conf/logback/eso-logback.xml
+++ b/enrollment-server-onboarding/docker/conf/logback/eso-logback.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
+    <springProperty scope="context" name="appname" source="spring.application.name"/>
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">
             <includeMdc>true</includeMdc>
-            <customFields>{"appname":"enrollment-server-onboarding"}</customFields>
+            <omitEmptyFields>true</omitEmptyFields>
+            <customFields>{"appname":"${appname}"}</customFields>
         </encoder>
     </appender>
 

--- a/enrollment-server-onboarding/docker/conf/logback/eso-logback.xml
+++ b/enrollment-server-onboarding/docker/conf/logback/eso-logback.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-    <springProperty scope="context" name="appname" source="spring.application.name"/>
+    <springProperty scope="context" name="appname" source="spring.application.name" defaultValue="unknown"/>
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">
             <includeMdc>true</includeMdc>

--- a/enrollment-server/docker/conf/logback/es-logback.xml
+++ b/enrollment-server/docker/conf/logback/es-logback.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
+    <springProperty scope="context" name="appname" source="spring.application.name"/>
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">
             <includeMdc>true</includeMdc>
-            <customFields>{"appname":"enrollment-server"}</customFields>
+            <omitEmptyFields>true</omitEmptyFields>
+            <customFields>{"appname":"${appname}"}</customFields>
         </encoder>
     </appender>
 

--- a/enrollment-server/docker/conf/logback/es-logback.xml
+++ b/enrollment-server/docker/conf/logback/es-logback.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-    <springProperty scope="context" name="appname" source="spring.application.name"/>
+    <springProperty scope="context" name="appname" source="spring.application.name" defaultValue="unknown"/>
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">
             <includeMdc>true</includeMdc>


### PR DESCRIPTION
## Summary

Fixes #1689 — JSON Logging Foundation for `enrollment-server`.

### Changes

- **L3**: Replace hardcoded `appname` in `customFields` with `<springProperty>` sourced from `spring.application.name` in both module logback configs
- **+**: Add `<omitEmptyFields>true</omitEmptyFields>` to suppress empty MDC fields from JSON output

### Affected files

- `enrollment-server/docker/conf/logback/es-logback.xml`
- `enrollment-server-onboarding/docker/conf/logback/eso-logback.xml`

### Notes

- `spring.application.name` is already set in `application.properties` for both modules ✅
- `logstash-logback-encoder` version `8.1` is already the latest — no version bump needed ✅
- `enrollment-server-onboarding` appname now correctly resolves to `onboarding-server` (aligned to `spring.application.name`; previously hardcoded as `enrollment-server-onboarding`)

### References

- Issue: #1689
- Epic: wultra/tasklist#863 (JSON Logging Foundation)
- Logging Guideline: https://github.com/wultra/development-internal/wiki/Logging-Guideline

---

### Follow-up: defaultValue for springProperty

Added `defaultValue="unknown"` to `<springProperty>` in all logback configs.

`<springProperty>` is fully supported when the config is loaded via Spring Boot's Logback configurator (standard production path via `logging.config`). The `defaultValue` is a safety net for the edge case where the file is loaded as a plain Logback config outside of Spring Boot — in that scenario `spring.application.name` cannot be resolved and the fallback prevents `appname_IS_UNDEFINED` appearing in log output.