### PR TITLE
Fix #1773: Structured Log Quality

### DIFF
--- a/enrollment-server-onboarding-common/pom.xml
+++ b/enrollment-server-onboarding-common/pom.xml
@@ -63,6 +63,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.wultra.core</groupId>
+            <artifactId>logging-support</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa-test</artifactId>
             <scope>test</scope>

--- a/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/service/ActivationFlagService.java
+++ b/enrollment-server-onboarding-common/src/main/java/com/wultra/app/onboardingserver/common/service/ActivationFlagService.java
@@ -80,9 +80,8 @@ public class ActivationFlagService {
 
             updateActivationFlags(ownerId, activationFlags);
         } catch (PowerAuthClientException ex) {
-            logger.warn("Activation flag request failed, error: {}", ex.getMessage());
-            logger.debug(ex.getMessage(), ex);
-            throw new RemoteCommunicationException("Communication with PowerAuth server failed");
+            logger.warn("Activation flag request failed");
+            throw new RemoteCommunicationException("Communication with PowerAuth server failed", ex);
         }
     }
 
@@ -105,9 +104,8 @@ public class ActivationFlagService {
 
             updateActivationFlags(ownerId, activationFlags);
         } catch (PowerAuthClientException ex) {
-            logger.warn("Activation flag request failed, error: {}", ex.getMessage());
-            logger.debug(ex.getMessage(), ex);
-            throw new RemoteCommunicationException("Communication with PowerAuth server failed");
+            logger.warn("Activation flag request failed");
+            throw new RemoteCommunicationException("Communication with PowerAuth server failed", ex);
         }
     }
 
@@ -127,9 +125,8 @@ public class ActivationFlagService {
             // Remove flag VERIFICATION_IN_PROGRESS
             removeActivationFlags(ownerId, Collections.singletonList(ACTIVATION_FLAG_VERIFICATION_IN_PROGRESS));
         } catch (PowerAuthClientException ex) {
-            logger.warn("Activation flag request failed, error: {}", ex.getMessage());
-            logger.debug(ex.getMessage(), ex);
-            throw new RemoteCommunicationException("Communication with PowerAuth server failed");
+            logger.warn("Activation flag request failed");
+            throw new RemoteCommunicationException("Communication with PowerAuth server failed", ex);
         }
     }
 
@@ -145,9 +142,8 @@ public class ActivationFlagService {
             final List<String> flags = listActivationFlagsInternal(activationId);
             return flags.contains(ACTIVATION_FLAG_VERIFICATION_PENDING);
         } catch (PowerAuthClientException ex) {
-            logger.warn("Activation flag request failed, error: {}", ex.getMessage());
-            logger.debug(ex.getMessage(), ex);
-            throw new RemoteCommunicationException("Communication with PowerAuth server failed");
+            logger.warn("Activation flag request failed");
+            throw new RemoteCommunicationException("Communication with PowerAuth server failed", ex);
         }
     }
 

--- a/enrollment-server-onboarding-common/src/test/resources/logback-test.xml
+++ b/enrollment-server-onboarding-common/src/test/resources/logback-test.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ PowerAuth Enrollment Server
+  ~ Copyright (C) 2026 Wultra s.r.o.
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as published
+  ~ by the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<configuration>
+    <conversionRule conversionWord="sa" converterClass="com.wultra.core.logging.logback.StructuredArgumentsConverter"/>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%sa%n</pattern>
+        </encoder>
+    </appender>
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/enrollment-server-onboarding-provider-innovatrics/pom.xml
+++ b/enrollment-server-onboarding-provider-innovatrics/pom.xml
@@ -44,6 +44,17 @@
         </dependency>
 
         <dependency>
+            <groupId>net.logstash.logback</groupId>
+            <artifactId>logstash-logback-encoder</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.wultra.core</groupId>
+            <artifactId>logging-support</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>mockwebserver</artifactId>
             <scope>test</scope>

--- a/enrollment-server-onboarding-provider-innovatrics/src/main/java/com/wultra/app/onboardingserver/provider/innovatrics/InnovatricsLivenessController.java
+++ b/enrollment-server-onboarding-provider-innovatrics/src/main/java/com/wultra/app/onboardingserver/provider/innovatrics/InnovatricsLivenessController.java
@@ -42,6 +42,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Optional;
 
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 
 /**
  * Controller publishing REST services for uploading Innovatrics liveness data.
@@ -77,7 +79,7 @@ class InnovatricsLivenessController {
             @Parameter(hidden = true) final EncryptionContext encryptionContext,
             @Parameter(hidden = true) final PowerAuthApiAuthentication apiAuthentication) throws IdentityVerificationException, PowerAuthAuthenticationException, PowerAuthEncryptionException, RemoteCommunicationException {
 
-        logger.info("action: upload, state: initiated, activationId: {}", extractActivationId(apiAuthentication));
+        logger.info("", kv("action", "upload"), kv("state", "initiated"), kv("activationId", extractActivationId(apiAuthentication)));
         if (apiAuthentication == null) {
             throw new PowerAuthTokenInvalidException("Unable to verify device registration when uploading liveness");
         }
@@ -87,7 +89,7 @@ class InnovatricsLivenessController {
         }
 
         innovatricsLivenessService.upload(requestData, encryptionContext);
-        logger.info("action: upload, state: succeeded");
+        logger.info("", kv("action", "upload"), kv("state", "succeeded"));
         return new Response();
     }
 

--- a/enrollment-server-onboarding-provider-innovatrics/src/test/resources/logback-test.xml
+++ b/enrollment-server-onboarding-provider-innovatrics/src/test/resources/logback-test.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ PowerAuth Enrollment Server
+  ~ Copyright (C) 2026 Wultra s.r.o.
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as published
+  ~ by the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<configuration>
+    <conversionRule conversionWord="sa" converterClass="com.wultra.core.logging.logback.StructuredArgumentsConverter"/>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%sa%n</pattern>
+        </encoder>
+    </appender>
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/enrollment-server-onboarding-provider-iproov/pom.xml
+++ b/enrollment-server-onboarding-provider-iproov/pom.xml
@@ -48,6 +48,12 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>com.wultra.core</groupId>
+            <artifactId>logging-support</artifactId>
+            <scope>test</scope>
+        </dependency>
+
 
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>

--- a/enrollment-server-onboarding-provider-iproov/src/test/resources/logback-test.xml
+++ b/enrollment-server-onboarding-provider-iproov/src/test/resources/logback-test.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ PowerAuth Enrollment Server
+  ~ Copyright (C) 2026 Wultra s.r.o.
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as published
+  ~ by the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<configuration>
+    <conversionRule conversionWord="sa" converterClass="com.wultra.core.logging.logback.StructuredArgumentsConverter"/>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%sa%n</pattern>
+        </encoder>
+    </appender>
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/enrollment-server-onboarding-provider-microblink/pom.xml
+++ b/enrollment-server-onboarding-provider-microblink/pom.xml
@@ -48,6 +48,17 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>net.logstash.logback</groupId>
+            <artifactId>logstash-logback-encoder</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.wultra.core</groupId>
+            <artifactId>logging-support</artifactId>
+            <scope>test</scope>
+        </dependency>
+
 
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>

--- a/enrollment-server-onboarding-provider-microblink/src/main/java/com/wultra/app/onboardingserver/provider/microblink/MicroblinkDocumentVerificationProvider.java
+++ b/enrollment-server-onboarding-provider-microblink/src/main/java/com/wultra/app/onboardingserver/provider/microblink/MicroblinkDocumentVerificationProvider.java
@@ -56,6 +56,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 /**
  * Implementation of the {@link DocumentVerificationProvider} with <a href="https://www.microblink.com/">Microblink</a>.
  *
@@ -113,7 +115,7 @@ public class MicroblinkDocumentVerificationProvider implements DocumentVerificat
 
     @Override
     public DocumentsSubmitResult checkDocumentUpload(OwnerId ownerId, DocumentVerificationEntity document) {
-        logger.info("action: checkDocumentUpload, state: unsupported, provider: microblink, ownerId: {}", ownerId);
+        logger.info("", kv("action", "checkDocumentUpload"), kv("state", "unsupported"), kv("provider", "microblink"), kv("ownerId", ownerId));
         throw new UnsupportedOperationException("Method checkDocumentUpload is not supported by Microblink provider.");
     }
 
@@ -123,7 +125,7 @@ public class MicroblinkDocumentVerificationProvider implements DocumentVerificat
                 .map(SubmittedDocument::getDocumentId)
                 .toList();
 
-        logger.info("action: submitDocuments, state: initiated, provider: microblink, ownerId: {}, documentIds: {}", ownerId, documentIds);
+        logger.info("", kv("action", "submitDocuments"), kv("state", "initiated"), kv("provider", "microblink"), kv("ownerId", ownerId), kv("documentIds", documentIds));
 
         final var documentsVerificationData = submittedDocuments.stream()
                 .map(MicroblinkDocumentVerificationProvider::buildDocumentVerificationData)
@@ -153,20 +155,20 @@ public class MicroblinkDocumentVerificationProvider implements DocumentVerificat
             result.setRejectReason("Rejected documents: " + rejectedDocuments);
         }
 
-        logger.info("action: submitDocuments, state: succeeded, provider: microblink, rejectReason: {}", result.getRejectReason());
+        logger.info("", kv("action", "submitDocuments"), kv("state", "succeeded"), kv("provider", "microblink"), kv("rejectReason", result.getRejectReason()));
         return result;
     }
 
     @Override
     public DocumentsVerificationResult getVerificationResult(OwnerId ownerId, String verificationId) {
-        logger.info("action: getVerificationResult, state: unsupported, provider: microblink, ownerId: {}, verificationId: {}", ownerId, verificationId);
+        logger.info("", kv("action", "getVerificationResult"), kv("state", "unsupported"), kv("provider", "microblink"), kv("ownerId", ownerId), kv("verificationId", verificationId));
         throw new UnsupportedOperationException("Method getVerificationResult is not supported by Microblink provider.");
     }
 
     @Override
     public Image getPhoto(String photoId) throws DocumentVerificationException {
         try {
-            logger.info("action: getPhoto, state: initiated, provider: microblink, photoId: {}", photoId);
+            logger.info("", kv("action", "getPhoto"), kv("state", "initiated"), kv("provider", "microblink"), kv("photoId", photoId));
 
             final var photoDocumentData = processedDocumentDataRepository.findById(photoId)
                     .orElseThrow(() -> new DocumentVerificationException("Photo with id %s not found".formatted(photoId)));
@@ -176,32 +178,32 @@ public class MicroblinkDocumentVerificationProvider implements DocumentVerificat
                     .data(photoDocumentData.getData())
                     .build();
 
-            logger.info("action: getPhoto, state: succeeded, provider: microblink");
+            logger.info("", kv("action", "getPhoto"), kv("state", "succeeded"), kv("provider", "microblink"));
             return image;
         } catch (final DocumentVerificationException e) {
-            logger.info("action: getPhoto, state: failed, provider: microblink, error: {}", e.getMessage());
+            logger.info("", kv("action", "getPhoto"), kv("state", "failed"), kv("provider", "microblink"));
             throw e;
         }
     }
 
     @Override
     public void cleanupDocuments(OwnerId ownerId, List<String> uploadIds) {
-        logger.debug("action: cleanupDocuments, state: skipped, provider: microblink, ownerId: {}, uploadIds: {}", ownerId, uploadIds);
+        logger.debug("", kv("action", "cleanupDocuments"), kv("state", "skipped"), kv("provider", "microblink"), kv("ownerId", ownerId), kv("uploadIds", uploadIds));
     }
 
     @Override
     public List<String> parseRejectionReasons(DocumentResultEntity docResult) {
-        logger.info("action: parseRejectionReasons, state: initiated, provider: microblink, documentResultId: {}", docResult.getId());
+        logger.info("", kv("action", "parseRejectionReasons"), kv("state", "initiated"), kv("provider", "microblink"), kv("documentResultId", docResult.getId()));
 
         final var result = List.of(docResult.getVerificationResult());
 
-        logger.info("action: parseRejectionReasons, state: succeeded, provider: microblink, rejectionReasons: {}", String.join(",", result));
+        logger.info("", kv("action", "parseRejectionReasons"), kv("state", "succeeded"), kv("provider", "microblink"), kv("rejectionReasons", String.join(",", result)));
         return result;
     }
 
     @Override
     public VerificationSdkInfo initVerificationSdk(OwnerId ownerId, Map<String, String> initAttributes) {
-        logger.info("action: initVerificationSdk, state: initiated, provider: microblink, ownerId: {}, initAttributes: {}", ownerId, initAttributes);
+        logger.info("", kv("action", "initVerificationSdk"), kv("state", "initiated"), kv("provider", "microblink"), kv("ownerId", ownerId), kv("initAttributes", initAttributes));
 
         final var origin = initAttributes.getOrDefault("origin", null);
         final var platform = initAttributes.getOrDefault("platform", null);
@@ -212,13 +214,13 @@ public class MicroblinkDocumentVerificationProvider implements DocumentVerificat
                 .map(it -> new VerificationSdkInfo(Map.of("license-key", it)))
                 .orElse(new VerificationSdkInfo());
 
-        logger.info("action: initVerificationSdk, state: succeeded, provider: microblink, sdkInfo: {}", MicroblinkLogSanitizationUtils.sanitizeSdkInfo(sdkInfo));
+        logger.info("", kv("action", "initVerificationSdk"), kv("state", "succeeded"), kv("provider", "microblink"), kv("sdkInfo", MicroblinkLogSanitizationUtils.sanitizeSdkInfo(sdkInfo)));
         return sdkInfo;
     }
 
     @Override
     public boolean shouldStoreSelfie() {
-        logger.info("action: shouldStoreSelfie, state: succeeded, provider: microblink, result: false");
+        logger.info("", kv("action", "shouldStoreSelfie"), kv("state", "succeeded"), kv("provider", "microblink"), kv("result", false));
         return false;
     }
 
@@ -226,21 +228,15 @@ public class MicroblinkDocumentVerificationProvider implements DocumentVerificat
     public DocumentsVerificationResult verifyDocuments(OwnerId ownerId, List<String> uploadIds) {
         final var verificationId = UUID.randomUUID().toString();
 
-        logger.info(
-                "action: verifyDocuments, state: initiated, provider: microblink, ownerId: {}, uploadIds: {}, verificationId: {}",
-                ownerId,
-                uploadIds,
-                verificationId
-        );
+        logger.info("", kv("action", "verifyDocuments"), kv("state", "initiated"), kv("provider", "microblink"), kv("ownerId", ownerId), kv("uploadIds", uploadIds), kv("verificationId", verificationId));
 
         try {
             final var result = verifyDocuments(uploadIds, verificationId);
 
-            logger.info("action: verifyDocuments, state: succeeded, provider: microblink, result: {}", result.getStatus());
+            logger.info("", kv("action", "verifyDocuments"), kv("state", "succeeded"), kv("provider", "microblink"), kv("result", result.getStatus()));
             return result;
         } catch (final DocumentVerificationException | RuntimeException e) {
-            logger.info("action: verifyDocuments, state: failed, provider: microblink, error: {}", e.getMessage());
-            logger.warn("action: verifyDocuments, state: failed, provider: microblink", e);
+            logger.warn("", kv("action", "verifyDocuments"), kv("state", "failed"), kv("provider", "microblink"), e);
 
             final var errorMessage = "Microblink provider exception: %s %s".formatted(e.getClass().getSimpleName(), e.getMessage());
 
@@ -320,14 +316,11 @@ public class MicroblinkDocumentVerificationProvider implements DocumentVerificat
             final DocumentVerificationData frontDocument,
             final DocumentVerificationData backDocument
     ) throws DocumentVerificationException, RemoteCommunicationException {
-        logger.info("action: sendMicroblinkRequest, state: initiated, frontDocumentUploadId: {}, backDocumentUploadId: {}",
-                frontDocument != null ? frontDocument.uploadId() : null,
-                backDocument != null ? backDocument.uploadId() : null);
+        logger.info("", kv("action", "sendMicroblinkRequest"), kv("state", "initiated"), kv("frontDocumentUploadId", frontDocument != null ? frontDocument.uploadId() : null), kv("backDocumentUploadId", backDocument != null ? backDocument.uploadId() : null));
 
         try {
             final var request = buildRequest(frontDocument, backDocument);
-            logger.debug("action: sendMicroblinkRequest, state: initiated, requestBody: {}",
-                    (Supplier<String>) () -> MicroblinkLogSanitizationUtils.sanitizeDocumentVerificationRequest(request));
+            logger.debug("", kv("action", "sendMicroblinkRequest"), kv("state", "initiated"), kv("requestBody", (Supplier<String>) () -> MicroblinkLogSanitizationUtils.sanitizeDocumentVerificationRequest(request)));
 
             final var response = microblinkRestClient.post("/api/v2/docver", request, new ParameterizedTypeReference<String>() {});
             final var body = Optional.ofNullable(response)
@@ -337,23 +330,17 @@ public class MicroblinkDocumentVerificationProvider implements DocumentVerificat
             final var parsedResponse = parseMicroblinkResponse(body)
                     .orElseThrow(() -> new DocumentVerificationException("Failed to parse Microblink API response"));
 
-            logger.info("action: sendMicroblinkRequest, state: succeeded, verificationResult: {}, microblinkTraceId: {}",
-                    Optional.ofNullable(parsedResponse.getParsedResponseBody())
-                            .map(DocumentVerificationResponse::verification)
-                            .map(DocumentVerificationResponse.Verification::result)
-                            .orElse(null),
-                    Optional.ofNullable(parsedResponse.getParsedResponseBody())
-                            .map(DocumentVerificationResponse::runtime)
-                            .map(DocumentVerificationResponse.Runtime::traceId)
-                            .orElse(null)
-            );
+            logger.info("", kv("action", "sendMicroblinkRequest"), kv("state", "succeeded"), kv("verificationResult", Optional.ofNullable(parsedResponse.getParsedResponseBody())
+                    .map(DocumentVerificationResponse::verification)
+                    .map(DocumentVerificationResponse.Verification::result)
+                    .orElse(null)), kv("microblinkTraceId", Optional.ofNullable(parsedResponse.getParsedResponseBody())
+                    .map(DocumentVerificationResponse::runtime)
+                    .map(DocumentVerificationResponse.Runtime::traceId)
+                    .orElse(null)));
 
             return parsedResponse;
         } catch (final RestClientException e) {
-            logger.info("action: sendMicroblinkRequest, state: failed, exceptionMessage: {}, statusCode: {}, response: {}",
-                    e.getMessage(),
-                    e.getStatusCode(),
-                    e.getResponse());
+            logger.info("", kv("action", "sendMicroblinkRequest"), kv("state", "failed"), kv("statusCode", e.getStatusCode()), kv("response", e.getResponse()));
 
             throw new RemoteCommunicationException(
                     "Failed REST API call to Microblink, statusCode=%s, responseBody='%s'".formatted(
@@ -378,7 +365,7 @@ public class MicroblinkDocumentVerificationProvider implements DocumentVerificat
                     .map(matcher -> matcher.group(1))
                     .orElse(null);
 
-            logger.warn("Failed to parse Microblink API response, response body is not valid JSON. Microblink traceId: {}", traceId, e);
+            logger.warn("Failed to parse Microblink API response, response body is not valid JSON. Microblink traceId: {}", traceId, kv("traceId", traceId), e);
             return Optional.empty();
         }
     }
@@ -542,7 +529,7 @@ public class MicroblinkDocumentVerificationProvider implements DocumentVerificat
         final var facePhotoDocumentData = buildProcessedDocumentDataEntity(ProcessedDocumentDataType.FACE_IMAGE, documentVerificationId, faceImageBase64);
 
         final var facePhotoDocumentId = facePhotoDocumentData.getId();
-        logger.info("Face photo extracted from document type {} and stored with id {}", facePhotoDocumentType, facePhotoDocumentId);
+        logger.info("Face photo extracted from document type {} and stored with id {}", facePhotoDocumentType, facePhotoDocumentId, kv("facePhotoDocumentId", facePhotoDocumentId));
 
         return facePhotoDocumentData;
     }
@@ -623,7 +610,7 @@ public class MicroblinkDocumentVerificationProvider implements DocumentVerificat
         if (properties.isExtractedDataCheckEnabled() && rejectReasons.isEmpty()) {
             final var crosscheckFailedFields = performDocumentsCrosscheck(documentVerificationResultBundles);
             final var crosscheckPassed = crosscheckFailedFields.isEmpty();
-            logger.info("Document data crosscheck passed: {}, failedFields: {}, uploadIds: {}", crosscheckPassed, crosscheckFailedFields, uploadIds);
+            logger.info("Document data crosscheck passed: {}, failedFields: {}, uploadIds: {}", crosscheckPassed, crosscheckFailedFields, uploadIds, kv("uploadIds", uploadIds));
 
             if (!crosscheckPassed) {
                 rejectReasons.add("Document data crosscheck failed for fields: %s".formatted(crosscheckFailedFields));
@@ -855,7 +842,7 @@ public class MicroblinkDocumentVerificationProvider implements DocumentVerificat
 
     private static boolean verifyDocumentType(final String uploadId, final DocumentType claimedDocumentType, final String extractedType) {
         if (extractedType == null) {
-            logger.warn("Extracted document type is missing for document uploadId={}", uploadId);
+            logger.warn("Extracted document type is missing for document uploadId={}", uploadId, kv("uploadId", uploadId));
             return false;
         }
 
@@ -867,7 +854,7 @@ public class MicroblinkDocumentVerificationProvider implements DocumentVerificat
         };
 
         if (extractedDocumentType == DocumentType.UNKNOWN) {
-            logger.warn("Unsupported document type '{}' for document uploadId={}", extractedType, uploadId);
+            logger.warn("Unsupported document type '{}' for document uploadId={}", extractedType, uploadId, kv("uploadId", uploadId));
             return false;
         }
 

--- a/enrollment-server-onboarding-provider-microblink/src/test/resources/logback-test.xml
+++ b/enrollment-server-onboarding-provider-microblink/src/test/resources/logback-test.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ PowerAuth Enrollment Server
+  ~ Copyright (C) 2026 Wultra s.r.o.
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as published
+  ~ by the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<configuration>
+    <conversionRule conversionWord="sa" converterClass="com.wultra.core.logging.logback.StructuredArgumentsConverter"/>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%sa%n</pattern>
+        </encoder>
+    </appender>
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/enrollment-server-onboarding-provider-zenid/pom.xml
+++ b/enrollment-server-onboarding-provider-zenid/pom.xml
@@ -50,6 +50,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.wultra.core</groupId>
+            <artifactId>logging-support</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>mockwebserver</artifactId>
             <scope>test</scope>

--- a/enrollment-server-onboarding-provider-zenid/src/test/resources/logback-test.xml
+++ b/enrollment-server-onboarding-provider-zenid/src/test/resources/logback-test.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ PowerAuth Enrollment Server
+  ~ Copyright (C) 2026 Wultra s.r.o.
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as published
+  ~ by the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<configuration>
+    <conversionRule conversionWord="sa" converterClass="com.wultra.core.logging.logback.StructuredArgumentsConverter"/>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%sa%n</pattern>
+        </encoder>
+    </appender>
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/enrollment-server-onboarding/pom.xml
+++ b/enrollment-server-onboarding/pom.xml
@@ -82,6 +82,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.wultra.core</groupId>
+            <artifactId>logging-support</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.wultra.security</groupId>
             <artifactId>user-data-store-rest-client</artifactId>
         </dependency>

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/controller/api/ConfigurationController.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/controller/api/ConfigurationController.java
@@ -45,6 +45,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 /**
  * Configuration controller.
  *
@@ -71,7 +73,7 @@ public class ConfigurationController {
             @Parameter(hidden = true) final EncryptionContext encryptionContext) throws PowerAuthEncryptionException, InvalidRequestObjectException {
 
         final String processType = request.getRequestObject().processType();
-        logger.info("action: fetchConfiguration, state: initiated, processType: {}", processType);
+        logger.info("", kv("action", "fetchConfiguration"), kv("state", "initiated"), kv("processType", processType));
 
         if (encryptionContext == null) {
             throw new PowerAuthEncryptionException("ECIES decryption failed");
@@ -84,8 +86,8 @@ public class ConfigurationController {
                 .otpResendPeriodSeconds(onboardingConfig.getOtpResendPeriod().getSeconds())
                 .build();
 
-        logger.info("action: fetchConfiguration, state: succeeded");
-        logger.debug("action: fetchConfiguration, state: succeeded, result: {}", result);
+        logger.info("", kv("action", "fetchConfiguration"), kv("state", "succeeded"));
+        logger.debug("", kv("action", "fetchConfiguration"), kv("state", "succeeded"), kv("result", result));
 
         return new ObjectResponse<>(result);
     }

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/controller/api/IdentityVerificationController.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/controller/api/IdentityVerificationController.java
@@ -59,6 +59,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static com.wultra.app.onboardingserver.controller.api.LoggingUtils.extractActivationId;
+import static net.logstash.logback.argument.StructuredArguments.kv;
 
 /**
  * Controller publishing REST services for identity document verification.
@@ -97,9 +98,9 @@ public class IdentityVerificationController {
             final @Parameter(hidden = true) PowerAuthApiAuthentication apiAuthentication) throws PowerAuthAuthenticationException, IdentityVerificationException, OnboardingProcessException {
 
         final IdentityVerificationInitRequest requestObject = request.getRequestObject();
-        logger.info("action: initializeIdentityVerification, state: initiated, processId: {}", requestObject.getProcessId());
+        logger.info("", kv("action", "initializeIdentityVerification"), kv("state", "initiated"), kv("processId", requestObject.getProcessId()));
         final var response = identityVerificationRestService.initializeIdentityVerification(requestObject, apiAuthentication);
-        logger.info("action: initializeIdentityVerification, state: succeeded");
+        logger.info("", kv("action", "initializeIdentityVerification"), kv("state", "succeeded"));
         return response;
     }
 
@@ -122,10 +123,9 @@ public class IdentityVerificationController {
             final @Parameter(hidden = true) PowerAuthApiAuthentication apiAuthentication)
             throws PowerAuthAuthenticationException, RemoteCommunicationException, OnboardingProcessException {
 
-        logger.info("action: checkIdentityVerificationStatus, state: initiated, activationId: {}", extractActivationId(apiAuthentication));
+        logger.info("", kv("action", "checkIdentityVerificationStatus"), kv("state", "initiated"), kv("activationId", extractActivationId(apiAuthentication)));
         final var response = identityVerificationRestService.checkIdentityVerificationStatus(request.getRequestObject(), apiAuthentication);
-        logger.info("action: checkIdentityVerificationStatus, state: succeeded, phase: {}, status: {}",
-                response.getResponseObject().getIdentityVerificationPhase(), response.getResponseObject().getIdentityVerificationStatus());
+        logger.info("", kv("action", "checkIdentityVerificationStatus"), kv("state", "succeeded"), kv("phase", response.getResponseObject().getIdentityVerificationPhase()), kv("status", response.getResponseObject().getIdentityVerificationStatus()));
         return response;
     }
 
@@ -160,9 +160,9 @@ public class IdentityVerificationController {
             throws PowerAuthAuthenticationException, PowerAuthEncryptionException, DocumentSubmitException, OnboardingProcessException, IdentityVerificationLimitException, RemoteCommunicationException, IdentityVerificationException, OnboardingProcessLimitException {
 
         final DocumentSubmitRequest requestObject = request.getRequestObject();
-        logger.info("action: submitDocuments, state: initiated, processId: {}", requestObject.getProcessId());
+        logger.info("", kv("action", "submitDocuments"), kv("state", "initiated"), kv("processId", requestObject.getProcessId()));
         final Response response = identityVerificationRestService.submitDocuments(requestObject, encryptionContext, apiAuthentication);
-        logger.info("action: submitDocuments, state: succeeded");
+        logger.info("", kv("action", "submitDocuments"), kv("state", "succeeded"));
         return response;
     }
 
@@ -183,10 +183,10 @@ public class IdentityVerificationController {
             final @Parameter(hidden = true) PowerAuthApiAuthentication apiAuthentication) throws PowerAuthAuthenticationException, OnboardingProcessException {
 
         final DocumentStatusRequest requestObject = request.getRequestObject();
-        logger.info("action: checkDocumentStatus, state: initiated, processId: {}", requestObject.getProcessId());
+        logger.info("", kv("action", "checkDocumentStatus"), kv("state", "initiated"), kv("processId", requestObject.getProcessId()));
         final var result = identityVerificationRestService.checkDocumentStatus(requestObject, apiAuthentication);
 
-        logger.info("action: checkDocumentStatus, state: succeeded, statuses: {}", collectDocumentStatuses(result));
+        logger.info("", kv("action", "checkDocumentStatus"), kv("state", "succeeded"), kv("statuses", collectDocumentStatuses(result)));
         return result;
     }
 
@@ -224,9 +224,9 @@ public class IdentityVerificationController {
             throws PowerAuthAuthenticationException, DocumentVerificationException, PowerAuthEncryptionException, OnboardingProcessException, RemoteCommunicationException {
 
         final DocumentVerificationSdkInitRequest requestObject = request.getRequestObject();
-        logger.info("action: initVerificationSdk, state: initiated, processId: {}", requestObject.getProcessId());
+        logger.info("", kv("action", "initVerificationSdk"), kv("state", "initiated"), kv("processId", requestObject.getProcessId()));
         final var response = identityVerificationRestService.initVerificationSdk(requestObject, encryptionContext, apiAuthentication);
-        logger.info("action: initVerificationSdk, state: succeeded");
+        logger.info("", kv("action", "initVerificationSdk"), kv("state", "succeeded"));
         return response;
     }
 
@@ -254,9 +254,9 @@ public class IdentityVerificationController {
             throws IdentityVerificationException, PowerAuthAuthenticationException, PowerAuthEncryptionException, OnboardingProcessException {
 
         final PresenceCheckInitRequest requestObject = request.getRequestObject();
-        logger.info("action: initPresenceCheck, state: initiated, processId: {}", requestObject.getProcessId());
+        logger.info("", kv("action", "initPresenceCheck"), kv("state", "initiated"), kv("processId", requestObject.getProcessId()));
         final var response = identityVerificationRestService.initPresenceCheck(requestObject, encryptionContext, apiAuthentication);
-        logger.info("action: initPresenceCheck, state: succeeded");
+        logger.info("", kv("action", "initPresenceCheck"), kv("state", "succeeded"));
         return response;
     }
 
@@ -277,9 +277,9 @@ public class IdentityVerificationController {
             final @Parameter(hidden = true) PowerAuthApiAuthentication apiAuthentication) throws IdentityVerificationException, PowerAuthAuthenticationException, OnboardingProcessException {
 
         final PresenceCheckSubmitRequest requestObject = request.getRequestObject();
-        logger.info("action: submitPresenceCheck, state: initiated, processId: {}", requestObject.getProcessId());
+        logger.info("", kv("action", "submitPresenceCheck"), kv("state", "initiated"), kv("processId", requestObject.getProcessId()));
         final var response = identityVerificationRestService.submitPresenceCheck(requestObject, apiAuthentication);
-        logger.info("action: submitPresenceCheck, state: succeeded");
+        logger.info("", kv("action", "submitPresenceCheck"), kv("state", "succeeded"));
         return response;
     }
 
@@ -299,9 +299,9 @@ public class IdentityVerificationController {
             final @Parameter(hidden = true) PowerAuthApiAuthentication apiAuthentication) throws IdentityVerificationException, OnboardingProcessException, PowerAuthTokenInvalidException {
 
         final IdentityVerificationOtpSendRequest requestObject = request.getRequestObject();
-        logger.info("action: resendOtp, state: initiated, processId: {}", requestObject.getProcessId());
+        logger.info("", kv("action", "resendOtp"), kv("state", "initiated"), kv("processId", requestObject.getProcessId()));
         final var response = identityVerificationRestService.resendOtp(requestObject, apiAuthentication);
-        logger.info("action: resendOtp, state: succeeded");
+        logger.info("", kv("action", "resendOtp"), kv("state", "succeeded"));
         return response;
     }
 
@@ -321,9 +321,9 @@ public class IdentityVerificationController {
             throws PowerAuthEncryptionException, OnboardingProcessException {
 
         final IdentityVerificationOtpVerifyRequest requestObject = request.getRequestObject();
-        logger.info("action: verifyOtp, state: initiated, processId: {}", requestObject.getProcessId());
+        logger.info("", kv("action", "verifyOtp"), kv("state", "initiated"), kv("processId", requestObject.getProcessId()));
         final var response = identityVerificationRestService.verifyOtp(requestObject, encryptionContext);
-        logger.info("action: verifyOtp, state: succeeded");
+        logger.info("", kv("action", "verifyOtp"), kv("state", "succeeded"));
         return response;
     }
 
@@ -349,9 +349,9 @@ public class IdentityVerificationController {
             throws PowerAuthAuthenticationException, DocumentVerificationException, PresenceCheckException, RemoteCommunicationException, OnboardingProcessException, IdentityVerificationException, OnboardingProcessLimitException {
 
         final IdentityVerificationCleanupRequest requestObject = request.getRequestObject();
-        logger.info("action: cleanup, state: initiated, processId: {}", requestObject.getProcessId());
+        logger.info("", kv("action", "cleanup"), kv("state", "initiated"), kv("processId", requestObject.getProcessId()));
         final Response response = identityVerificationRestService.cleanup(requestObject, apiAuthentication);
-        logger.info("action: cleanup, state: succeeded");
+        logger.info("", kv("action", "cleanup"), kv("state", "succeeded"));
         return response;
     }
 
@@ -376,9 +376,9 @@ public class IdentityVerificationController {
             final @Parameter(hidden = true) PowerAuthApiAuthentication apiAuthentication) throws OnboardingProcessException, PowerAuthTokenInvalidException {
 
         final OnboardingConsentTextRequest requestObject = request.getRequestObject();
-        logger.info("action: fetchConsentText, state: initiated, processId: {}", requestObject.getProcessId());
+        logger.info("", kv("action", "fetchConsentText"), kv("state", "initiated"), kv("processId", requestObject.getProcessId()));
         final var response = identityVerificationRestService.fetchConsentText(requestObject, apiAuthentication);
-        logger.info("action: fetchConsentText, state: succeeded");
+        logger.info("", kv("action", "fetchConsentText"), kv("state", "succeeded"));
         return response;
     }
 
@@ -401,9 +401,9 @@ public class IdentityVerificationController {
             final @Parameter(hidden = true) PowerAuthApiAuthentication apiAuthentication) throws OnboardingProcessException, PowerAuthAuthenticationException {
 
         final OnboardingConsentApprovalRequest requestObject = request.getRequestObject();
-        logger.info("action: approveConsent, state: initiated, processId: {}, approved: {}", requestObject.getProcessId(), requestObject.isApproved());
+        logger.info("", kv("action", "approveConsent"), kv("state", "initiated"), kv("processId", requestObject.getProcessId()), kv("approved", requestObject.isApproved()));
         final Response response = identityVerificationRestService.approveConsent(requestObject, apiAuthentication);
-        logger.info("action: approveConsent, state: succeeded");
+        logger.info("", kv("action", "approveConsent"), kv("state", "succeeded"));
         return response;
     }
 
@@ -428,9 +428,9 @@ public class IdentityVerificationController {
             @Parameter(hidden = true) @NotNull final PowerAuthApiAuthentication apiAuthentication) throws OnboardingProcessException, RemoteCommunicationException {
 
         final CreateTargetActivationRequest requestObject = request.getRequestObject();
-        logger.info("action: createTargetActivation, state: initiated, processId: {}", requestObject.processId());
+        logger.info("", kv("action", "createTargetActivation"), kv("state", "initiated"), kv("processId", requestObject.processId()));
         final CreateTargetActivationResponse response = identityVerificationTargetActivationService.createTargetActivation(requestObject, apiAuthentication);
-        logger.info("action: createTargetActivation, state: succeeded");
+        logger.info("", kv("action", "createTargetActivation"), kv("state", "succeeded"));
 
         return new ObjectResponse<>(response);
     }

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/controller/api/OnboardingController.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/controller/api/OnboardingController.java
@@ -49,6 +49,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 /**
  * Controller publishing REST services for the onboarding process.
  *
@@ -83,7 +85,7 @@ public class OnboardingController {
             final HttpServletRequest servletRequest) throws OnboardingProcessException, OnboardingOtpDeliveryException, PowerAuthEncryptionException, TooManyProcessesException, InvalidRequestObjectException, RemoteCommunicationException {
 
         final OnboardingStartRequest requestObject = request.getRequestObject();
-        logger.info("action: start, state: initiated, processType: {}", requestObject.processType());
+        logger.info("", kv("action", "start"), kv("state", "initiated"), kv("processType", requestObject.processType()));
         // Check if the request was correctly decrypted
         if (encryptionContext == null) {
             throw new PowerAuthEncryptionException("ECIES decryption failed during onboarding");
@@ -92,7 +94,7 @@ public class OnboardingController {
         final RequestContext requestContext = RequestContextConverter.convert(servletRequest);
 
         final OnboardingStartResponse response = onboardingService.startOnboarding(requestObject, requestContext, encryptionContext);
-        logger.info("action: start, state: succeeded");
+        logger.info("", kv("action", "start"), kv("state", "succeeded"));
         return new ObjectResponse<>(response);
     }
 
@@ -114,14 +116,14 @@ public class OnboardingController {
             throws PowerAuthEncryptionException, OnboardingProcessException, OnboardingOtpDeliveryException {
 
         final OnboardingOtpResendRequest requestObject = request.getRequestObject();
-        logger.info("action: resendOtp, state: initiated, processId: {}", requestObject.getProcessId());
+        logger.info("", kv("action", "resendOtp"), kv("state", "initiated"), kv("processId", requestObject.getProcessId()));
         // Check if the request was correctly decrypted
         if (encryptionContext == null) {
             throw new PowerAuthEncryptionException("ECIES decryption failed while resending OTP code");
         }
 
         final Response response = onboardingService.resendOtp(requestObject);
-        logger.info("action: resendOtp, state: succeeded");
+        logger.info("", kv("action", "resendOtp"), kv("state", "succeeded"));
         return response;
     }
 
@@ -141,15 +143,15 @@ public class OnboardingController {
             @Parameter(hidden = true) final EncryptionContext encryptionContext) throws PowerAuthEncryptionException, OnboardingProcessException {
 
         final OnboardingStatusRequest requestObject = request.getRequestObject();
-        logger.info("action: status, state: initiated, processId: {}", requestObject.getProcessId());
+        logger.info("", kv("action", "status"), kv("state", "initiated"), kv("processId", requestObject.getProcessId()));
         // Check if the request was correctly decrypted
         if (encryptionContext == null) {
             throw new PowerAuthEncryptionException("ECIES decryption failed while getting status");
         }
 
-        logger.debug("Onboarding process will not be locked, {}", requestObject.getProcessId());
+        logger.debug("Onboarding process will not be locked, {}", requestObject.getProcessId(), kv("processId", requestObject.getProcessId()));
         final OnboardingStatusResponse response = onboardingService.getStatus(requestObject);
-        logger.info("action: status, state: succeeded");
+        logger.info("", kv("action", "status"), kv("state", "succeeded"));
         return new ObjectResponse<>(response);
     }
 
@@ -169,14 +171,14 @@ public class OnboardingController {
             @Parameter(hidden = true) final EncryptionContext encryptionContext) throws PowerAuthEncryptionException, OnboardingProcessException {
 
         final OnboardingCleanupRequest requestObject = request.getRequestObject();
-        logger.info("action: cleanup, state: initiated, processId: {}", requestObject.getProcessId());
+        logger.info("", kv("action", "cleanup"), kv("state", "initiated"), kv("processId", requestObject.getProcessId()));
         // Check if the request was correctly decrypted
         if (encryptionContext == null) {
             throw new PowerAuthEncryptionException("ECIES decryption failed during cleanup");
         }
 
         final Response response = onboardingService.performCleanup(requestObject);
-        logger.info("action: cleanup, state: succeeded");
+        logger.info("", kv("action", "cleanup"), kv("state", "succeeded"));
         return response;
     }
 }

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/controller/api/PrivateClientController.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/controller/api/PrivateClientController.java
@@ -30,6 +30,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 /**
  * Controller to acknowledge asynchronous actions. These endpoints are private and secured.
  *
@@ -50,10 +52,10 @@ class PrivateClientController {
      */
     @PostMapping("approve")
     public AcknowledgeApproveClientResponse acknowledgeApproveClient(final @Valid @RequestBody AcknowledgeApproveClientRequest request) {
-        logger.info("action: acknowledgeApproveClient, state: initiated, processId: {}", request.processId());
+        logger.info("", kv("action", "acknowledgeApproveClient"), kv("state", "initiated"), kv("processId", request.processId()));
 
         if (request.approvalResult() == AcknowledgeApproveClientRequest.ApprovalResult.WAIT) {
-            logger.info("action: acknowledgeApproveClient, state: skipped, reason: approvalResult is WAIT");
+            logger.info("", kv("action", "acknowledgeApproveClient"), kv("state", "skipped"), kv("reason", "approvalResult is WAIT"));
             return AcknowledgeApproveClientResponse.builder()
                     .result(AcknowledgeApproveClientResponse.Result.OK)
                     .build();
@@ -62,9 +64,9 @@ class PrivateClientController {
         final AcknowledgeApproveClientResponse response = acknowledgeService.acknowledgeApproveClient(request);
 
         if (response.result() == AcknowledgeApproveClientResponse.Result.OK) {
-            logger.info("action: acknowledgeApproveClient, state: succeeded");
+            logger.info("", kv("action", "acknowledgeApproveClient"), kv("state", "succeeded"));
         } else {
-            logger.info("action: acknowledgeApproveClient, state: failed, reason: {}", response.resultReason());
+            logger.info("", kv("action", "acknowledgeApproveClient"), kv("state", "failed"), kv("reason", response.resultReason()));
         }
 
         return response;
@@ -72,10 +74,10 @@ class PrivateClientController {
 
     @PostMapping("evaluate")
     public AcknowledgeEvaluationClientResponse acknowledgeEvaluationClient(final @Valid @RequestBody AcknowledgeEvaluationClientRequest request) {
-        logger.info("action: acknowledgeEvaluationClient, state: initiated, processId: {}", request.processId());
+        logger.info("", kv("action", "acknowledgeEvaluationClient"), kv("state", "initiated"), kv("processId", request.processId()));
 
         if (request.evaluationResult() == AcknowledgeEvaluationClientRequest.EvaluationResult.WAIT) {
-            logger.info("action: acknowledgeEvaluationClient, state: skipped, reason: evaluationResult is WAIT");
+            logger.info("", kv("action", "acknowledgeEvaluationClient"), kv("state", "skipped"), kv("reason", "evaluationResult is WAIT"));
             return AcknowledgeEvaluationClientResponse.builder()
                     .result(AcknowledgeEvaluationClientResponse.Result.OK)
                     .build();
@@ -84,9 +86,9 @@ class PrivateClientController {
         final AcknowledgeEvaluationClientResponse response = acknowledgeService.acknowledgeEvaluationClient(request);
 
         if (response.result() == AcknowledgeEvaluationClientResponse.Result.OK) {
-            logger.info("action: acknowledgeEvaluationClient, state: succeeded");
+            logger.info("", kv("action", "acknowledgeEvaluationClient"), kv("state", "succeeded"));
         } else {
-            logger.info("action: acknowledgeEvaluationClient, state: failed, reason: {}", response.resultReason());
+            logger.info("", kv("action", "acknowledgeEvaluationClient"), kv("state", "failed"), kv("reason", response.resultReason()));
         }
 
         return response;

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/controller/api/v2/IdentityVerificationV2Controller.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/controller/api/v2/IdentityVerificationV2Controller.java
@@ -48,6 +48,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 /**
  * Identity Verification V2 REST API Controller.
  *
@@ -102,15 +104,15 @@ class IdentityVerificationV2Controller {
     ) throws OnboardingProcessException, RemoteCommunicationException, IdentityVerificationLimitException, DocumentSubmitException, PowerAuthEncryptionException, IdentityVerificationException, OnboardingProcessLimitException, PowerAuthAuthenticationException {
 
         final DocumentSubmitV2Request requestObject = request.getRequestObject();
-        logger.info("action: submitDocumentsV2, state: initiated, processId: {}", requestObject.processId());
+        logger.info("", kv("action", "submitDocumentsV2"), kv("state", "initiated"), kv("processId", requestObject.processId()));
 
         try {
             final var response = identityVerificationRestService.submitDocumentsV2(requestObject, encryptionContext, apiAuthentication);
 
-            logger.info("action: submitDocumentsV2, state: succeeded");
+            logger.info("", kv("action", "submitDocumentsV2"), kv("state", "succeeded"));
             return response;
         } catch (final Exception e) {
-            logger.error("action: submitDocumentsV2, state: failed, error: {}", e.getMessage());
+            logger.error("", kv("action", "submitDocumentsV2"), kv("state", "failed"));
             throw e;
         }
     }

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/errorhandling/DefaultExceptionHandler.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/errorhandling/DefaultExceptionHandler.java
@@ -268,8 +268,7 @@ public class DefaultExceptionHandler {
     @ExceptionHandler(NoResourceFoundException.class)
     @ResponseStatus(HttpStatus.NOT_FOUND)
     public @ResponseBody ErrorResponse handleNoResourceFoundException(final NoResourceFoundException e) {
-        logger.warn("Error occurred when calling an API: {}", e.getMessage());
-        logger.debug("Exception detail: ", e);
+        logger.warn("Error occurred when calling an API", e);
         return new ErrorResponse("ERROR_NOT_FOUND", "Resource not found.");
     }
 
@@ -282,8 +281,7 @@ public class DefaultExceptionHandler {
     @ExceptionHandler(Base64DeserializationException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public @ResponseBody ErrorResponse handleBase64DeserializationException(final Base64DeserializationException e) {
-        logger.warn("Base64 deserialization exception: {}", e.getMessage());
-        logger.debug("Exception detail: ", e);
+        logger.warn("Base64 deserialization exception", e);
         return new ErrorResponse(INVALID_REQUEST, "Deserialization of base64 value failed.");
     }
 }

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/ClientEvaluationService.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/ClientEvaluationService.java
@@ -42,6 +42,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.Set;
 
 import static java.util.stream.Collectors.toSet;
+import static net.logstash.logback.argument.StructuredArguments.kv;
 
 /**
  * Service for client evaluation features.
@@ -146,14 +147,14 @@ public class ClientEvaluationService {
         final var maxAttempts = config.getClientEvaluationMaxFailedAttempts();
         final int attempt = context.getRetryCount() + 1;
 
-        logger.info("action: callEvaluateClient, state: initiated, attempt {}/{}", attempt, maxAttempts);
+        logger.info("", kv("action", "callEvaluateClient"), kv("state", "initiated"), kv("attempt", attempt), kv("maxAttempts", maxAttempts));
 
         try {
             final EvaluateClientResponse response = onboardingProvider.evaluateClient(request);
-            logger.info("action: callEvaluateClient, state: succeeded, evaluationResult: {}, resultReason: {}", response.getEvaluationResult(), response.getResultReason());
+            logger.info("", kv("action", "callEvaluateClient"), kv("state", "succeeded"), kv("evaluationResult", response.getEvaluationResult()), kv("resultReason", response.getResultReason()));
             return response;
         } catch (final Exception e) {
-            logger.warn("action: callEvaluateClient, state: failed, attempt {}/{}, exceptionMessage: {}", attempt, maxAttempts, e.getMessage(), e);
+            logger.warn("", kv("action", "callEvaluateClient"), kv("state", "failed"), kv("attempt", attempt), kv("maxAttempts", maxAttempts));
             throw e;
         }
     }
@@ -186,8 +187,7 @@ public class ClientEvaluationService {
     }
 
     private void processVerificationIdError(final IdentityVerificationEntity identityVerification, final OwnerId ownerId, final Exception e) {
-        logger.warn("Client evaluation failed to get verificationId for {}, {} - {}", identityVerification, ownerId, e.getMessage());
-        logger.debug("Client evaluation failed to get verificationId for {}, {}", identityVerification, ownerId, e);
+        logger.warn("Client evaluation failed to get verificationId for {}, {}", identityVerification, ownerId, e);
         identityVerification.setErrorDetail(ERROR_VERIFICATION_ID);
         identityVerification.setErrorOrigin(ErrorOrigin.CLIENT_EVALUATION);
         identityVerification.setTimestampFailed(ownerId.getTimestamp());

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/IdentityVerificationFinishService.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/IdentityVerificationFinishService.java
@@ -132,8 +132,7 @@ public class IdentityVerificationFinishService {
             }
         } catch (OnboardingProviderException e) {
             // unsuccessful event publishing does not stop the process
-            logger.info("Unable to publish finished event to the onboarding adapter: {}", e.getMessage());
-            logger.debug("Unable to publish finished event to the onboarding adapter", e);
+            logger.info("Unable to publish finished event to the onboarding adapter", e);
         }
     }
 

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/IdentityVerificationRestService.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/IdentityVerificationRestService.java
@@ -288,8 +288,7 @@ public class IdentityVerificationRestService {
 
                 documentsByFilename.putAll(extractedDocuments);
             } catch (final DocumentVerificationException e) {
-                logger.error("Unable to extract documents from {}, activationId: {}, error: {}", request, activationId, e.getMessage());
-                logger.debug("Exception when extracting documents", e);
+                logger.error("Unable to extract documents from {}, activationId: {}", request, activationId, e);
             }
         }
 

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/IdentityVerificationService.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/IdentityVerificationService.java
@@ -374,8 +374,7 @@ public class IdentityVerificationService {
             try {
                 process = processService.findProcess(idVerification.getProcessId());
             } catch (OnboardingProcessException e) {
-                logger.trace("Onboarding process not found, {}", ownerId, e);
-                logger.warn("Onboarding process not found, {}, {}", e.getMessage(), ownerId);
+                logger.warn("Onboarding process not found, {}", ownerId, e);
                 return;
             }
 

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/LookupUserService.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/LookupUserService.java
@@ -78,8 +78,7 @@ public class LookupUserService {
             }
             return Optional.of(response);
         } catch (final OnboardingProviderException e) {
-            logger.info("User lookup failed, using null user ID, error: {}", e.getMessage());
-            logger.debug("User lookup failed, using null user ID", e);
+            logger.info("User lookup failed, using null user ID", e);
             return Optional.empty();
         }
     }

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/OnboardingApprovalService.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/OnboardingApprovalService.java
@@ -40,6 +40,8 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.Base64;
 import java.util.Date;
 
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 /**
  * Onboarding approval service.
  *
@@ -105,17 +107,17 @@ public class OnboardingApprovalService {
                     .image(loadImage(identityVerification))
                     .build();
 
-            logger.info("action: callApproveClient, state: initiated");
+            logger.info("", kv("action", "callApproveClient"), kv("state", "initiated"));
             final ApproveClientResponse response = onboardingProvider.approveClient(request);
             final ApproveClientResponse.ApprovalResult approvalResult = response.result();
             final String resultReason = response.resultReason();
-            logger.info("action: callApproveClient, state: succeeded, approvalResult: {}, resultReason: {}", approvalResult, resultReason);
+            logger.info("", kv("action", "callApproveClient"), kv("state", "succeeded"), kv("approvalResult", approvalResult), kv("resultReason", resultReason));
             persistRejectReason(response, identityVerification);
 
             auditService.audit(identityVerification, "Onboarding approval result: {}, resultReason: {}", approvalResult, resultReason);
             return approvalResult;
         } catch (final OnboardingProviderException | OnboardingProcessException | RuntimeException e) {
-            logger.warn("action: callApproveClient, state: failed, exceptionMessage: {}", e.getMessage(), e);
+            logger.warn("", kv("action", "callApproveClient"), kv("state", "failed"), e);
             auditService.audit(identityVerification, "Onboarding approval result: FAILED");
             return null;
         }

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/document/DocumentProcessingService.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/document/DocumentProcessingService.java
@@ -115,8 +115,7 @@ public class DocumentProcessingService {
             try {
                 submittedDocuments.add(createSubmittedDocument(ownerId, document, docVerification));
             } catch (DocumentSubmitException e) {
-                logger.warn("Document verification ID: {}, failed: {}", docVerification.getId(), e.getMessage());
-                logger.debug("Document verification ID: {}, failed", docVerification.getId(), e);
+                logger.warn("Document verification ID: {}, failed", docVerification.getId(), e);
                 docVerification.setStatus(DocumentStatus.FAILED);
                 docVerification.setErrorDetail(ErrorDetail.DOCUMENT_VERIFICATION_FAILED);
                 docVerification.setErrorOrigin(ErrorOrigin.DOCUMENT_VERIFICATION);
@@ -230,7 +229,7 @@ public class DocumentProcessingService {
             auditVerificationResponse(results, identityVerification, ownerId);
             return results;
         } catch (DocumentVerificationException | RemoteCommunicationException e) {
-            logger.warn("Document verification ID: {}, failed: {}", docVerificationIds, e.getMessage(), e);
+            logger.warn("Document verification ID: {}, failed", docVerificationIds, e);
             final DocumentsSubmitResult results = new DocumentsSubmitResult();
             submittedDocs.forEach(doc -> {
                 final DocumentSubmitResult result = new DocumentSubmitResult();

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/userdatastore/DefaultUserDataStoreService.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/userdatastore/DefaultUserDataStoreService.java
@@ -45,6 +45,8 @@ import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 /**
  * Implementation of {@link UserDataStoreService}.
  *
@@ -98,23 +100,23 @@ class DefaultUserDataStoreService implements UserDataStoreService {
     @Transactional(readOnly = true)
     @Override
     public List<DocumentCreateRequest> collectDocumentData(final String processId) {
-        logger.info("action: collectDocumentData, state: initiated, processId: {}", processId);
+        logger.info("", kv("action", "collectDocumentData"), kv("state", "initiated"), kv("processId", processId));
 
         final var process = onboardingProcessRepository.findById(processId).orElse(null);
         if (process == null) {
-            logger.warn("action: collectDocumentData, state: failed, reason: process_not_found, processId: {}", processId);
+            logger.warn("", kv("action", "collectDocumentData"), kv("state", "failed"), kv("reason", "process_not_found"), kv("processId", processId));
             return List.of();
         }
 
         final var identityVerification = identityVerificationRepository.findFirstByActivationIdOrderByTimestampCreatedDesc(process.getActivationId()).orElse(null);
         if (identityVerification == null) {
-            logger.warn("action: collectDocumentData, state: failed, reason: identity_not_found, processId: {}", processId);
+            logger.warn("", kv("action", "collectDocumentData"), kv("state", "failed"), kv("reason", "identity_not_found"), kv("processId", processId));
             return List.of();
         }
 
         final var documentVerifications = fetchDocumentVerifications(identityVerification, config.getDocumentType());
         if (documentVerifications.primaryDocuments() == null) {
-            logger.info("action: collectDocumentData, state: skipped, reason: no_document_verification, processId: {}", processId);
+            logger.info("", kv("action", "collectDocumentData"), kv("state", "skipped"), kv("reason", "no_document_verification"), kv("processId", processId));
             return List.of();
         }
 
@@ -125,18 +127,18 @@ class DefaultUserDataStoreService implements UserDataStoreService {
             documentRequests.add(createDocumentRequest(process, entry));
         }
 
-        logger.info("action: collectDocumentData, state: finished, processId: {}, count: {}", processId, documentRequests.size());
+        logger.info("", kv("action", "collectDocumentData"), kv("state", "finished"), kv("processId", processId), kv("count", documentRequests.size()));
         return documentRequests;
     }
 
     @Override
     public void storeDocumentData(final List<DocumentCreateRequest> requests) throws UserDataStoreClientException {
-        logger.info("action: storeDocumentData, state: initiated, count: {}", requests.size());
+        logger.info("", kv("action", "storeDocumentData"), kv("state", "initiated"), kv("count", requests.size()));
 
         for (final var request : requests) {
             retryTemplate.execute(context -> callCreateDocument(request, context));
         }
-        logger.info("action: storeDocumentData, state: finished");
+        logger.info("", kv("action", "storeDocumentData"), kv("state", "finished"));
     }
 
     private List<ProcessedDocumentDataEntity> fetchProcessedDocumentData(final Collection<DocumentVerificationEntity> documentVerifications) {
@@ -211,15 +213,14 @@ class DefaultUserDataStoreService implements UserDataStoreService {
     Void callCreateDocument(final DocumentCreateRequest request, final RetryContext context) throws UserDataStoreClientException {
         final int maxAttempts = config.getMaxAttempts();
         final int attempt = context.getRetryCount() + 1;
-        logger.info("action: callCreateDocument, state: initiated, userId: {}, externalId: {}, documentType: {}, dataType: {}, attempt {}/{}",
-                request.userId(), request.externalId(), request.documentType(), request.dataType(), attempt, maxAttempts);
+        logger.info("", kv("action", "callCreateDocument"), kv("state", "initiated"), kv("userId", request.userId()), kv("externalId", request.externalId()), kv("documentType", request.documentType()), kv("dataType", request.dataType()), kv("attempt", attempt), kv("maxAttempts", maxAttempts));
 
         try {
             final var response = userDataStoreClient.createDocument(request);
-            logger.info("action: callCreateDocument, state: succeeded, documentId: {}, photoIds: {}", response.id(), collectPhotoIds(response));
+            logger.info("", kv("action", "callCreateDocument"), kv("state", "succeeded"), kv("documentId", response.id()), kv("photoIds", collectPhotoIds(response)));
             return null;
         } catch (final UserDataStoreClientException e) {
-            logger.warn("action: callCreateDocument, state: failed, attempt {}/{}, errorMessage: {}", attempt, maxAttempts, e.getMessage(), e);
+            logger.warn("", kv("action", "callCreateDocument"), kv("state", "failed"), kv("attempt", attempt), kv("maxAttempts", maxAttempts));
             throw e;
         }
     }

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/userdatastore/NoOpUserDataStoreService.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/userdatastore/NoOpUserDataStoreService.java
@@ -22,6 +22,8 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.util.List;
 
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 /**
  * Empty implementation {@link UserDataStoreService}.
  *
@@ -32,6 +34,6 @@ class NoOpUserDataStoreService implements UserDataStoreService {
 
     @Override
     public void storeDocumentData(final List<DocumentCreateRequest> documentRequests) {
-        logger.info("action: storeDocumentData, state: skipped");
+        logger.info("", kv("action", "storeDocumentData"), kv("state", "skipped"));
     }
 }

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/statemachine/event/OnboardingCompletedAcceptedListener.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/statemachine/event/OnboardingCompletedAcceptedListener.java
@@ -25,6 +25,8 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 /**
  * Listener for {@link OnboardingCompletedAcceptedEvent}.
  *
@@ -47,18 +49,15 @@ public class OnboardingCompletedAcceptedListener {
     public void onOnboardingCompletedAccepted(final OnboardingCompletedAcceptedEvent event) {
         final var processId = event.getProcessId();
 
-        logger.info("action: onOnboardingCompletedAccepted, state: initiated, processId: {}, userId: {}, activationId: {}",
-                processId,
-                event.getOwnerId().getUserId(),
-                event.getOwnerId().getActivationId());
+        logger.info("", kv("action", "onOnboardingCompletedAccepted"), kv("state", "initiated"), kv("processId", processId), kv("userId", event.getOwnerId().getUserId()), kv("activationId", event.getOwnerId().getActivationId()));
 
         try {
             final var documentData = userDataStoreService.collectDocumentData(processId);
             userDataStoreService.storeDocumentData(documentData);
 
-            logger.info("action: onOnboardingCompletedAccepted, state: succeeded, storedDocumentCount: {}", documentData.size());
+            logger.info("", kv("action", "onOnboardingCompletedAccepted"), kv("state", "succeeded"), kv("storedDocumentCount", documentData.size()));
         } catch (final UserDataStoreClientException | RuntimeException e) {
-            logger.warn("action: onOnboardingCompletedAccepted, state: failed", e);
+            logger.warn("", kv("action", "onOnboardingCompletedAccepted"), kv("state", "failed"), e);
         }
     }
 }

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/statemachine/interceptor/CustomStateMachineInterceptor.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/statemachine/interceptor/CustomStateMachineInterceptor.java
@@ -62,33 +62,27 @@ public class CustomStateMachineInterceptor extends StateMachineInterceptorAdapte
         Response response;
 
         if (e instanceof OnboardingProcessException) {
-            logger.warn("Onboarding process failed: {}", e.getMessage());
-            logger.debug("Onboarding process failed", e);
+            logger.warn("Onboarding process failed", e);
             response = new ErrorResponse("ONBOARDING_FAILED", "Onboarding process failed.");
             status = HttpStatus.BAD_REQUEST;
         } else if (e instanceof OnboardingOtpDeliveryException) {
-            logger.warn("Onboarding process failed: {}", e.getMessage());
-            logger.debug("Onboarding process failed", e);
+            logger.warn("Onboarding process failed", e);
             response = new ErrorResponse("ONBOARDING_OTP_FAILED", "Onboarding OTP delivery failed.");
             status = HttpStatus.BAD_REQUEST;
         } else if (e instanceof PresenceCheckNotEnabledException) {
-            logger.warn("Presence check transition with a not enabled presence check service: {}", e.getMessage());
-            logger.debug("Presence check transition with a not enabled presence check service", e);
+            logger.warn("Presence check transition with a not enabled presence check service", e);
             response = new ErrorResponse("PRESENCE_CHECK_NOT_ENABLED", "Presence check is not enabled.");
             status = HttpStatus.BAD_REQUEST;
         } else if (e instanceof PresenceCheckException) {
-            logger.warn("Presence check failed: {}", e.getMessage());
-            logger.debug("Presence check failed", e);
+            logger.warn("Presence check failed", e);
             response = new ErrorResponse("PRESENCE_CHECK_FAILED", "Presence check failed.");
             status = HttpStatus.BAD_REQUEST;
         } else if (e instanceof PresenceCheckLimitException) {
-            logger.warn("Presence check limit reached: {}", e.getMessage());
-            logger.debug("Presence check limit reached", e);
+            logger.warn("Presence check limit reached", e);
             response = new ErrorResponse("PRESENCE_CHECK_LIMIT_REACHED", "Presence check limit reached.");
             status = HttpStatus.TOO_MANY_REQUESTS;
         } else if (e instanceof DocumentVerificationException) {
-            logger.warn("Document verification failed: {}", e.getMessage());
-            logger.debug("Document verification failed", e);
+            logger.warn("Document verification failed", e);
             response = new ErrorResponse("DOCUMENT_VERIFICATION_FAILED", "Document verification failed.");
             status = HttpStatus.BAD_REQUEST;
         } else {
@@ -123,7 +117,7 @@ public class CustomStateMachineInterceptor extends StateMachineInterceptorAdapte
         try {
             expectedState = enrollmentStateProvider.findByPhaseAndStatus(identityVerification.getPhase(), identityVerification.getStatus());
         } catch (IdentityVerificationException e) {
-            logger.error("Failed post transition check: {}, {}", e.getMessage(), identityVerification);
+            logger.error("Failed post transition check: {}", identityVerification, e);
             return context;
         }
 

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/cleaning/PersonalDataCleaningTask.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/cleaning/PersonalDataCleaningTask.java
@@ -26,6 +26,8 @@ import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 /**
  * Task to clean personal data stored during an onboarding process.
  */
@@ -43,10 +45,10 @@ public class PersonalDataCleaningTask {
 	@Scheduled(fixedDelayString = "PT10M", initialDelayString = "PT20S")
 	@SchedulerLock(name = SchedulerLockNames.CLEANUP_SELFIES_LOCK, lockAtMostFor = "5m")
 	public void cleanupSelfies() {
-		logger.info("action: cleanupSelfies, state: initiated");
+		logger.info("", kv("action", "cleanupSelfies"), kv("state", "initiated"));
 		LockAssert.assertLocked();
 		final int count = cleaningService.cleanSelfies();
-		logger.info("action: cleanupSelfies, state: succeeded, count: {}", count);
+		logger.info("", kv("action", "cleanupSelfies"), kv("state", "succeeded"), kv("count", count));
 	}
 
 	/**
@@ -56,9 +58,9 @@ public class PersonalDataCleaningTask {
 	@SchedulerLock(name = SchedulerLockNames.DOCUMENT_DATA_LOCK, lockAtMostFor = "5m")
 	public void cleanupDocumentData() {
 		LockAssert.assertLocked();
-		logger.debug("action: cleanupDocumentData, state: initiated");
+		logger.debug("", kv("action", "cleanupDocumentData"), kv("state", "initiated"));
 		final var count = cleaningService.cleanupDocumentData();
-		logger.debug("action: cleanupDocumentData, state: succeeded, cleanedRecords: {}", count);
+		logger.debug("", kv("action", "cleanupDocumentData"), kv("state", "succeeded"), kv("cleanedRecords", count));
 	}
 
 	/**
@@ -68,9 +70,9 @@ public class PersonalDataCleaningTask {
 	@SchedulerLock(name = SchedulerLockNames.DOCUMENT_RESULT_PERSONAL_DATA_LOCK, lockAtMostFor = "5m")
 	public void cleanupDocumentResultPersonalData() {
 		LockAssert.assertLocked();
-		logger.debug("action: cleanupDocumentResultPersonalData, state: initiated");
+		logger.debug("", kv("action", "cleanupDocumentResultPersonalData"), kv("state", "initiated"));
 		final var count = cleaningService.cleanupDocumentResultPersonalData();
-		logger.debug("action: cleanupDocumentResultPersonalData, state: succeeded, cleanedRecords: {}", count);
+		logger.debug("", kv("action", "cleanupDocumentResultPersonalData"), kv("state", "succeeded"), kv("cleanedRecords", count));
 	}
 
 	/**
@@ -80,9 +82,9 @@ public class PersonalDataCleaningTask {
 	@SchedulerLock(name = SchedulerLockNames.PROCESSED_DOCUMENT_DATA_LOCK, lockAtMostFor = "5m")
 	public void cleanupProcessedDocumentData() {
 		LockAssert.assertLocked();
-		logger.debug("action: cleanupProcessedDocumentData, state: initiated");
+		logger.debug("", kv("action", "cleanupProcessedDocumentData"), kv("state", "initiated"));
 		final var count = cleaningService.cleanupProcessedDocumentData();
-		logger.debug("action: cleanupProcessedDocumentData, state: succeeded, cleanedRecords: {}", count);
+		logger.debug("", kv("action", "cleanupProcessedDocumentData"), kv("state", "succeeded"), kv("cleanedRecords", count));
 	}
 }
 

--- a/enrollment-server-onboarding/src/main/resources/application-dev.properties
+++ b/enrollment-server-onboarding/src/main/resources/application-dev.properties
@@ -13,3 +13,4 @@ spring.security.user.password=${ENROLLMENT_SERVER_ONBOARDING_DEV_SECURITY_USER_P
 logging.level.com.wultra=DEBUG
 logging.level.com.wultra.core.audit=INFO
 logging.level.com.wultra.app.onboardingserver.task=INFO
+logging.config=classpath:logback-dev.xml

--- a/enrollment-server-onboarding/src/main/resources/application.properties
+++ b/enrollment-server-onboarding/src/main/resources/application.properties
@@ -21,6 +21,8 @@ spring.profiles.active=ext
 
 spring.application.name=onboarding-server
 
+logging.config=${ENROLLMENT_SERVER_ONBOARDING_LOGGING:}
+
 banner.application.name=${spring.application.name}
 banner.application.version=@project.version@
 

--- a/enrollment-server-onboarding/src/main/resources/logback-dev.xml
+++ b/enrollment-server-onboarding/src/main/resources/logback-dev.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ PowerAuth Enrollment Server
+  ~ Copyright (C) 2026 Wultra s.r.o.
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as published
+  ~ by the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<configuration>
+    <conversionRule conversionWord="sa" converterClass="com.wultra.core.logging.logback.StructuredArgumentsConverter"/>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%sa%n</pattern>
+        </encoder>
+    </appender>
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/enrollment-server-onboarding/src/test/resources/logback-test.xml
+++ b/enrollment-server-onboarding/src/test/resources/logback-test.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ PowerAuth Enrollment Server
+  ~ Copyright (C) 2026 Wultra s.r.o.
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as published
+  ~ by the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<configuration>
+    <conversionRule conversionWord="sa" converterClass="com.wultra.core.logging.logback.StructuredArgumentsConverter"/>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%sa%n</pattern>
+        </encoder>
+    </appender>
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/enrollment-server/pom.xml
+++ b/enrollment-server/pom.xml
@@ -70,6 +70,11 @@
             <artifactId>http-common</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>com.wultra.core</groupId>
+            <artifactId>logging-support</artifactId>
+        </dependency>
+
         <!-- Spring Dependencies -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/controller/api/ActivationCodeController.java
+++ b/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/controller/api/ActivationCodeController.java
@@ -47,6 +47,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 /**
  * Controller publishing REST services for obtaining a new activation code.
  *
@@ -99,7 +101,7 @@ public class ActivationCodeController {
             @Parameter(hidden = true) final PowerAuthApiAuthentication apiAuthentication) throws PowerAuthAuthenticationException, InvalidRequestObjectException, ActivationCodeException, PowerAuthEncryptionException {
 
         final ActivationCodeRequest requestObject = request.getRequestObject();
-        logger.info("action: requestActivationCode, state: initiated, applicationId: {}", requestObject.getApplicationId());
+        logger.info("", kv("action", "requestActivationCode"), kv("state", "initiated"), kv("applicationId", requestObject.getApplicationId()));
         // Check if the authentication object is present
         if (apiAuthentication == null) {
             logger.error("Unable to verify device registration when fetching activation code");
@@ -113,7 +115,7 @@ public class ActivationCodeController {
         }
 
         final ActivationCodeResponse response = activationCodeService.requestActivationCode(requestObject, apiAuthentication);
-        logger.info("action: requestActivationCode, state: succeeded");
+        logger.info("", kv("action", "requestActivationCode"), kv("state", "succeeded"));
         return new ObjectResponse<>(response);
     }
 }

--- a/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/controller/api/ApplicationConfigurationController.java
+++ b/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/controller/api/ApplicationConfigurationController.java
@@ -39,6 +39,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 /**
  * Controller that provides application configuration.
  *
@@ -71,10 +73,10 @@ public class ApplicationConfigurationController {
             @NotNull @EncryptedRequestBody @Valid final OidcApplicationConfigurationRequest request,
             @Parameter(hidden = true) final EncryptionContext encryptionContext) throws PowerAuthEncryptionException, PowerAuthApplicationConfigurationException {
 
-        logger.info("action: fetchOidcConfiguration, state: initiated, providerId: {}", request != null ? request.getProviderId() : null);
+        logger.info("", kv("action", "fetchOidcConfiguration"), kv("state", "initiated"), kv("providerId", request != null ? request.getProviderId() : null));
 
         if (encryptionContext == null) {
-            logger.error("action: fetchOidcConfiguration, state: failed, reason: encryptionFailed");
+            logger.error("", kv("action", "fetchOidcConfiguration"), kv("state", "failed"), kv("reason", "encryptionFailed"));
             throw new PowerAuthEncryptionException("Encryption failed");
         }
 
@@ -83,7 +85,7 @@ public class ApplicationConfigurationController {
                 .applicationKey(encryptionContext.getApplicationKey())
                 .build());
         final OidcApplicationConfigurationResponse result = convert(oidcApplicationConfiguration);
-        logger.info("action: fetchOidcConfiguration, state: succeeded");
+        logger.info("", kv("action", "fetchOidcConfiguration"), kv("state", "succeeded"));
         return new ObjectResponse<>(result);
     }
 

--- a/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/controller/api/InboxController.java
+++ b/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/controller/api/InboxController.java
@@ -51,6 +51,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.Collections;
 
 import static com.wultra.app.enrollmentserver.controller.api.LoggingUtils.extractActivationId;
+import static net.logstash.logback.argument.StructuredArguments.kv;
 
 /**
  * Controller with facade for Inbox services in Push server.
@@ -73,18 +74,18 @@ public class InboxController {
             PowerAuthCodeType.POSSESSION_KNOWLEDGE
     })
     public ObjectResponse<GetInboxCountResponse> countUnreadMessages(@Parameter(hidden = true) PowerAuthApiAuthentication apiAuthentication) throws InboxException, PowerAuthAuthenticationException {
-        logger.info("action: countUnreadMessages, state: initiated, activationId: {}", extractActivationId(apiAuthentication));
+        logger.info("", kv("action", "countUnreadMessages"), kv("state", "initiated"), kv("activationId", extractActivationId(apiAuthentication)));
         checkApiAuthentication(apiAuthentication);
         final String userId = apiAuthentication.getUserId();
         final String appId = apiAuthentication.getApplicationId();
         final GetInboxCountResponse response = new GetInboxCountResponse();
         try {
             final ObjectResponse<GetInboxMessageCountResponse> pushResponse = pushClient.fetchMessageCountForUser(userId, appId);
-            logger.info("action: countUnreadMessages, state: succeeded");
+            logger.info("", kv("action", "countUnreadMessages"), kv("state", "succeeded"));
             response.setCountUnread(pushResponse.getResponseObject().getCountUnread());
             return new ObjectResponse<>(response);
         } catch (PushServerClientException ex) {
-            logger.warn("action: countUnreadMessages, state: failed, error: {}", ex.getMessage());
+            logger.warn("", kv("action", "countUnreadMessages"), kv("state", "failed"));
             throw new InboxException("Push server REST API call failed, error: " + ex.getMessage(), ex);
         }
     }
@@ -96,7 +97,7 @@ public class InboxController {
             PowerAuthCodeType.POSSESSION_KNOWLEDGE
     })
     public ObjectResponse<GetInboxListResponse> fetchMessageList(@RequestBody ObjectRequest<GetInboxListRequest> objectRequest, @Parameter(hidden = true) PowerAuthApiAuthentication apiAuthentication) throws InboxException, PowerAuthAuthenticationException {
-        logger.info("action: fetchMessageList, state: initiated, activationId: {}", extractActivationId(apiAuthentication));
+        logger.info("", kv("action", "fetchMessageList"), kv("state", "initiated"), kv("activationId", extractActivationId(apiAuthentication)));
         checkApiAuthentication(apiAuthentication);
         final String userId = apiAuthentication.getUserId();
         final String appId = apiAuthentication.getApplicationId();
@@ -107,12 +108,12 @@ public class InboxController {
         try {
             final ObjectResponse<ListOfInboxMessages> pushResponse = pushClient.fetchMessageListForUser(
                     userId, Collections.singletonList(appId), onlyUnread, page, size);
-            logger.info("action: fetchMessageList, state: succeeded");
+            logger.info("", kv("action", "fetchMessageList"), kv("state", "succeeded"));
             final GetInboxListResponse response = new GetInboxListResponse();
             pushResponse.getResponseObject().forEach(message -> response.add(convertMessageInList(message)));
             return new PagedResponse<>(response, page, size);
         } catch (PushServerClientException ex) {
-            logger.warn("action: fetchMessageList, state: failed, error: {}", ex.getMessage());
+            logger.warn("", kv("action", "fetchMessageList"), kv("state", "failed"));
             throw new InboxException("Push server REST API call failed, error: " + ex.getMessage(), ex);
         }
     }
@@ -128,19 +129,18 @@ public class InboxController {
             @Parameter(hidden = true) final PowerAuthApiAuthentication apiAuthentication) throws InboxException, PowerAuthAuthenticationException {
 
         final GetInboxDetailRequest request = objectRequest.getRequestObject();
-        logger.info("action: fetchMessageDetail, state: initiated, activationId: {}, messageId: {}",
-                extractActivationId(apiAuthentication), request.getId());
+        logger.info("", kv("action", "fetchMessageDetail"), kv("state", "initiated"), kv("activationId", extractActivationId(apiAuthentication)), kv("messageId", request.getId()));
         checkApiAuthentication(apiAuthentication);
         final String userId = apiAuthentication.getUserId();
         final String appId = apiAuthentication.getApplicationId();
 
         try {
             final GetInboxMessageDetailResponse messageDetail = fetchInboxMessageDetail(userId, appId, request.getId());
-            logger.info("action: fetchMessageDetail, state: succeeded");
+            logger.info("", kv("action", "fetchMessageDetail"), kv("state", "succeeded"));
             final GetInboxDetailResponse response = convertMessageDetail(messageDetail);
             return new ObjectResponse<>(response);
         } catch (PushServerClientException ex) {
-            logger.warn("action: fetchMessageDetail, state: failed, error: {}", ex.getMessage());
+            logger.warn("", kv("action", "fetchMessageDetail"), kv("state", "failed"));
             throw new InboxException("Push server REST API call failed, error: " + ex.getMessage(), ex);
         }
     }
@@ -156,8 +156,7 @@ public class InboxController {
             @Parameter(hidden = true) final PowerAuthApiAuthentication apiAuthentication) throws InboxException, PowerAuthAuthenticationException {
 
         final InboxReadRequest request = objectRequest.getRequestObject();
-        logger.info("action: readMessage, state: initiated, activationId: {}, messageId: {}",
-                extractActivationId(apiAuthentication), request.getId());
+        logger.info("", kv("action", "readMessage"), kv("state", "initiated"), kv("activationId", extractActivationId(apiAuthentication)), kv("messageId", request.getId()));
         checkApiAuthentication(apiAuthentication);
         final String userId = apiAuthentication.getUserId();
         final String appId = apiAuthentication.getApplicationId();
@@ -166,13 +165,13 @@ public class InboxController {
             final GetInboxMessageDetailResponse messageDetail = fetchInboxMessageDetail(userId, appId, request.getId());
             if (!messageDetail.isRead()) {
                 pushClient.readMessage(request.getId());
-                logger.info("action: readMessage, state: succeeded");
+                logger.info("", kv("action", "readMessage"), kv("state", "succeeded"));
             } else {
-                logger.info("action: readMessage, state: skipped, reason: message is already marked as read");
+                logger.info("", kv("action", "readMessage"), kv("state", "skipped"), kv("reason", "message is already marked as read"));
             }
             return new Response();
         } catch (PushServerClientException ex) {
-            logger.warn("action: readMessage, state: failed, error: {}", ex.getMessage());
+            logger.warn("", kv("action", "readMessage"), kv("state", "failed"));
             throw new InboxException("Push server REST API call failed, error: " + ex.getMessage(), ex);
         }
     }
@@ -184,16 +183,16 @@ public class InboxController {
             PowerAuthCodeType.POSSESSION_KNOWLEDGE
     })
     public Response readAllMessages(@Parameter(hidden = true) PowerAuthApiAuthentication apiAuthentication) throws InboxException, PowerAuthAuthenticationException {
-        logger.info("action: readAllMessages, state: initiated, activationId: {}", extractActivationId(apiAuthentication));
+        logger.info("", kv("action", "readAllMessages"), kv("state", "initiated"), kv("activationId", extractActivationId(apiAuthentication)));
         checkApiAuthentication(apiAuthentication);
         final String userId = apiAuthentication.getUserId();
         final String appId = apiAuthentication.getApplicationId();
         try {
             pushClient.readAllMessages(userId, appId);
-            logger.info("action: readAllMessages, state: succeeded");
+            logger.info("", kv("action", "readAllMessages"), kv("state", "succeeded"));
             return new Response();
         } catch (PushServerClientException ex) {
-            logger.warn("action: readAllMessages, state: failed, error: {}", ex.getMessage());
+            logger.warn("", kv("action", "readAllMessages"), kv("state", "failed"));
             throw new InboxException("Push server REST API call failed, error: " + ex.getMessage(), ex);
         }
     }

--- a/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/controller/api/MobileTokenController.java
+++ b/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/controller/api/MobileTokenController.java
@@ -59,6 +59,7 @@ import java.util.List;
 import java.util.Locale;
 
 import static com.wultra.app.enrollmentserver.controller.api.LoggingUtils.extractActivationId;
+import static net.logstash.logback.argument.StructuredArguments.kv;
 
 /**
  * Controller that publishes the default mobile token services.
@@ -107,7 +108,7 @@ public class MobileTokenController {
             PowerAuthCodeType.POSSESSION_KNOWLEDGE
     })
     public ObjectResponse<OperationListResponse> operationList(@Parameter(hidden = true) PowerAuthApiAuthentication auth, @Parameter(hidden = true) Locale locale) throws MobileTokenException, MobileTokenConfigurationException, RemoteCommunicationException {
-        logger.info("action: operationList, state: initiated, activationId: {}", extractActivationId(auth));
+        logger.info("", kv("action", "operationList"), kv("state", "initiated"), kv("activationId", extractActivationId(auth)));
         validateApiAuthentication(auth);
 
         try {
@@ -116,22 +117,22 @@ public class MobileTokenController {
             final String activationId = auth.getActivationContext().getActivationId();
             final String language = locale.getLanguage();
             final OperationListResponse listResponse = mobileTokenService.operationListForUser(userId, applicationId, language, activationId, true);
-            logger.info("action: operationList, state: succeeded");
+            logger.info("", kv("action", "operationList"), kv("state", "succeeded"));
             final Date currentTimestamp = new Date();
             return new MobileTokenResponse<>(listResponse, currentTimestamp);
         } catch (PowerAuthClientException e) {
             final String errorCode = e.getPowerAuthError().map(PowerAuthError::getCode).orElse("ERROR_CODE_MISSING");
             switch (errorCode) {
                 case APPLICATION_NOT_FOUND -> {
-                    logger.warn("action: operationList, state: failed, reason: applicationNotFound, error: {}", e.getMessage());
+                    logger.warn("", kv("action", "operationList"), kv("state", "failed"), kv("reason", "applicationNotFound"));
                     throw new MobileTokenException(ErrorCode.INVALID_APPLICATION, "No application was found with the provided identifier.", e);
                 }
                 case INVALID_REQUEST -> {
-                    logger.warn("action: operationList, state: failed, reason: validation, error: {}", e.getMessage());
+                    logger.warn("", kv("action", "operationList"), kv("state", "failed"), kv("reason", "validation"));
                     throw new MobileTokenException(ErrorCode.INVALID_REQUEST, "Request validation error: %s".formatted(e.getMessage()), e);
                 }
                 default -> {
-                    logger.warn("action: operationList, state: failed, reason: powerAuthConnection, error: {}", e.getMessage());
+                    logger.warn("", kv("action", "operationList"), kv("state", "failed"), kv("reason", "powerAuthConnection"));
                     throw new RemoteCommunicationException("Unable to call upstream service.", e);
                 }
             }
@@ -159,15 +160,14 @@ public class MobileTokenController {
             @Parameter(hidden = true) final Locale locale) throws MobileTokenException, MobileTokenConfigurationException, RemoteCommunicationException {
 
         final String operationId = request.getRequestObject().getId();
-        logger.info("action: fetchOperationDetail, state: initiated, activationId: {}, operationId: {}",
-                extractActivationId(auth), operationId);
+        logger.info("", kv("action", "fetchOperationDetail"), kv("state", "initiated"), kv("activationId", extractActivationId(auth)), kv("operationId", operationId));
         validateApiAuthentication(auth);
 
         try {
             final String language = locale.getLanguage();
                 final String userId = auth.getUserId();
                 final Operation response = mobileTokenService.fetchOperationDetail(operationId, language, userId);
-                logger.info("action: fetchOperationDetail, state: succeeded");
+                logger.info("", kv("action", "fetchOperationDetail"), kv("state", "succeeded"));
                 final Date currentTimestamp = new Date();
                 return new MobileTokenResponse<>(response, currentTimestamp);
 
@@ -175,15 +175,15 @@ public class MobileTokenController {
             final String errorCode = e.getPowerAuthError().map(PowerAuthError::getCode).orElse("ERROR_CODE_MISSING");
             switch (errorCode) {
                 case OPERATION_NOT_FOUND -> {
-                    logger.warn("action: fetchOperationDetail, state: failed, reason: operationNotFound, error: {}", e.getMessage());
+                    logger.warn("", kv("action", "fetchOperationDetail"), kv("state", "failed"), kv("reason", "operationNotFound"));
                     throw new MobileTokenException(ErrorCode.INVALID_OPERATION, "No operation was found with the provided identifier.", e);
                 }
                 case INVALID_REQUEST -> {
-                    logger.warn("action: fetchOperationDetail, state: failed, reason: validation, error: {}", e.getMessage());
+                    logger.warn("", kv("action", "fetchOperationDetail"), kv("state", "failed"), kv("reason", "validation"));
                     throw new MobileTokenException(ErrorCode.INVALID_REQUEST, "Request validation error: %s".formatted(e.getMessage()), e);
                 }
                 default -> {
-                    logger.warn("action: fetchOperationDetail, state: failed, reason: powerAuthConnection, error: {}", e.getMessage());
+                    logger.warn("", kv("action", "fetchOperationDetail"), kv("state", "failed"), kv("reason", "powerAuthConnection"));
                     throw new RemoteCommunicationException("Unable to call upstream service.", e);
                 }
             }
@@ -211,15 +211,14 @@ public class MobileTokenController {
             @Parameter(hidden = true) final Locale locale) throws MobileTokenException, MobileTokenConfigurationException, RemoteCommunicationException {
 
         final String operationId = request.getRequestObject().getId();
-        logger.info("action: claimOperation, state: initiated, activationId: {}, operationId: {}",
-                extractActivationId(auth), operationId);
+        logger.info("", kv("action", "claimOperation"), kv("state", "initiated"), kv("activationId", extractActivationId(auth)), kv("operationId", operationId));
         validateApiAuthentication(auth);
 
         try {
             final String language = locale.getLanguage();
                 final String userId = auth.getUserId();
                 final Operation response = mobileTokenService.claimOperation(operationId, language, userId);
-                logger.info("action: claimOperation, state: succeeded");
+                logger.info("", kv("action", "claimOperation"), kv("state", "succeeded"));
                 final Date currentTimestamp = new Date();
                 return new MobileTokenResponse<>(response, currentTimestamp);
 
@@ -227,15 +226,15 @@ public class MobileTokenController {
             final String errorCode = e.getPowerAuthError().map(PowerAuthError::getCode).orElse("ERROR_CODE_MISSING");
             switch (errorCode) {
                 case OPERATION_NOT_FOUND -> {
-                    logger.warn("action: claimOperation, state: failed, reason: operationNotFound, error: {}", e.getMessage());
+                    logger.warn("", kv("action", "claimOperation"), kv("state", "failed"), kv("reason", "operationNotFound"));
                     throw new MobileTokenException(ErrorCode.INVALID_OPERATION, "No operation was found with the provided identifier.", e);
                 }
                 case INVALID_REQUEST -> {
-                    logger.warn("action: claimOperation, state: failed, reason: validation, error: {}", e.getMessage());
+                    logger.warn("", kv("action", "claimOperation"), kv("state", "failed"), kv("reason", "validation"));
                     throw new MobileTokenException(ErrorCode.INVALID_REQUEST, "Request validation error: %s".formatted(e.getMessage()), e);
                 }
                 default -> {
-                    logger.warn("action: claimOperation, state: failed, reason: powerAuthConnection, error: {}", e.getMessage());
+                    logger.warn("", kv("action", "claimOperation"), kv("state", "failed"), kv("reason", "powerAuthConnection"));
                     throw new RemoteCommunicationException("Unable to call upstream service.", e);
                 }
             }
@@ -257,7 +256,7 @@ public class MobileTokenController {
             PowerAuthCodeType.POSSESSION_KNOWLEDGE
     })
     public ObjectResponse<OperationListResponse> operationListAll(@Parameter(hidden = true) PowerAuthApiAuthentication auth, @Parameter(hidden = true) Locale locale) throws MobileTokenException, MobileTokenConfigurationException, RemoteCommunicationException {
-        logger.info("action: operationListAll, state: initiated, activationId: {}", extractActivationId(auth));
+        logger.info("", kv("action", "operationListAll"), kv("state", "initiated"), kv("activationId", extractActivationId(auth)));
         validateApiAuthentication(auth);
 
         try {
@@ -266,21 +265,21 @@ public class MobileTokenController {
             final String activationId = auth.getActivationContext().getActivationId();
             final String language = locale.getLanguage();
             final OperationListResponse listResponse = mobileTokenService.operationListForUser(userId, applicationId, language, activationId, false);
-            logger.info("action: operationListAll, state: succeeded");
+            logger.info("", kv("action", "operationListAll"), kv("state", "succeeded"));
             return new ObjectResponse<>(listResponse);
         } catch (PowerAuthClientException e) {
             final String errorCode = e.getPowerAuthError().map(PowerAuthError::getCode).orElse("ERROR_CODE_MISSING");
             switch (errorCode) {
                 case APPLICATION_NOT_FOUND -> {
-                    logger.warn("action: operationListAll, state: failed, reason: applicationNotFound, error: {}", e.getMessage());
+                    logger.warn("", kv("action", "operationListAll"), kv("state", "failed"), kv("reason", "applicationNotFound"));
                     throw new MobileTokenException(ErrorCode.INVALID_APPLICATION, "No application was found with the provided identifier.", e);
                 }
                 case INVALID_REQUEST -> {
-                    logger.warn("action: operationListAll, state: failed, reason: validation, error: {}", e.getMessage());
+                    logger.warn("", kv("action", "operationListAll"), kv("state", "failed"), kv("reason", "validation"));
                     throw new MobileTokenException(ErrorCode.INVALID_REQUEST, "Request validation error: %s".formatted(e.getMessage()), e);
                 }
                 default -> {
-                    logger.warn("action: operationListAll, state: failed, reason: powerAuthConnection, error: {}", e.getMessage());
+                    logger.warn("", kv("action", "operationListAll"), kv("state", "failed"), kv("reason", "powerAuthConnection"));
                     throw new RemoteCommunicationException("Unable to call upstream service.", e);
                 }
             }
@@ -309,8 +308,7 @@ public class MobileTokenController {
 
         final OperationApproveRequest requestObject = request.getRequestObject();
         final String operationId = requestObject.getId();
-        logger.info("action: operationApprove, state: initiated, activationId: {}, operationId: {}",
-                extractActivationId(auth), operationId);
+        logger.info("", kv("action", "operationApprove"), kv("state", "initiated"), kv("activationId", extractActivationId(auth)), kv("operationId", operationId));
 
         try {
             final String data = requestObject.getData();
@@ -324,7 +322,7 @@ public class MobileTokenController {
                 final PowerAuthCodeType signatureFactors = auth.getAuthenticationContext().getAuthenticationCodeType();
                 final List<String> activationFlags = auth.getActivationContext().getActivationFlags();
                 if (activationFlags.stream().anyMatch(DISALLOWED_FLAGS::contains)) {
-                    logger.warn("Operation approval failed due to presence of a disallowed activation flag, operation ID: {}.", operationId);
+                    logger.warn("Operation approval failed due to presence of a disallowed activation flag, operation ID: {}.", operationId, kv("operationId", operationId));
                     throw new MobileTokenAuthException();
                 }
                 final var serviceRequest = OperationApproveParameterObject.builder()
@@ -341,31 +339,31 @@ public class MobileTokenController {
                         .build();
 
                 final Response response = mobileTokenService.operationApprove(serviceRequest);
-                logger.info("action: operationApprove, state: succeeded");
+                logger.info("", kv("action", "operationApprove"), kv("state", "succeeded"));
                 return response;
             } else {
                 // make sure to fail operation as well, to increase the failed number
                 mobileTokenService.operationFailApprove(operationId, requestContext);
-                logger.debug("Operation approval failed due to failed user authentication, operation ID: {}.", operationId);
+                logger.debug("Operation approval failed due to failed user authentication, operation ID: {}.", operationId, kv("operationId", operationId));
                 throw new MobileTokenAuthException();
             }
         } catch (PowerAuthClientException e) {
             final String errorCode = e.getPowerAuthError().map(PowerAuthError::getCode).orElse("ERROR_CODE_MISSING");
             switch (errorCode) {
                 case APPLICATION_NOT_FOUND -> {
-                    logger.warn("action: operationApprove, state: failed, reason: applicationNotFound, error: {}", e.getMessage());
+                    logger.warn("", kv("action", "operationApprove"), kv("state", "failed"), kv("reason", "applicationNotFound"));
                     throw new MobileTokenException(ErrorCode.INVALID_APPLICATION, "No application was found with the provided identifier.", e);
                 }
                 case OPERATION_NOT_FOUND, OPERATION_APPROVE_FAILURE, OPERATION_INVALID_STATE -> {
-                    logger.warn("action: operationApprove, state: failed, reason: operationNotFoundOrInvalidState, error: {}", e.getMessage());
+                    logger.warn("", kv("action", "operationApprove"), kv("state", "failed"), kv("reason", "operationNotFoundOrInvalidState"));
                     throw new MobileTokenException(ErrorCode.INVALID_OPERATION, "Operation not found or is in an unexpected state.", e);
                 }
                 case INVALID_REQUEST -> {
-                    logger.warn("action: operationApprove, state: failed, reason: validation, error: {}", e.getMessage());
+                    logger.warn("", kv("action", "operationApprove"), kv("state", "failed"), kv("reason", "validation"));
                     throw new MobileTokenException(ErrorCode.INVALID_REQUEST, "Request validation error: %s".formatted(e.getMessage()), e);
                 }
                 default -> {
-                    logger.warn("action: operationApprove, state: failed, reason: powerAuthConnection, error: {}", e.getMessage());
+                    logger.warn("", kv("action", "operationApprove"), kv("state", "failed"), kv("reason", "powerAuthConnection"));
                     throw new RemoteCommunicationException("Unable to call upstream service.", e);
                 }
             }
@@ -377,7 +375,7 @@ public class MobileTokenController {
             return null;
         }
         final var proximityCheck = requestObject.getProximityCheck().get();
-        logger.info("Operation ID: {} using proximity check OTP, timestampReceived: {}, timestampSent: {}", requestObject.getId(), proximityCheck.getTimestampReceived(), proximityCheck.getTimestampSent());
+        logger.info("Operation ID: {} using proximity check OTP, timestampReceived: {}, timestampSent: {}", requestObject.getId(), proximityCheck.getTimestampReceived(), proximityCheck.getTimestampSent(), kv("operationId", requestObject.getId()));
         return proximityCheck.getOtp();
     }
 
@@ -401,8 +399,7 @@ public class MobileTokenController {
 
         final OperationRejectRequest requestObject = request.getRequestObject();
         final String operationId = requestObject.getId();
-        logger.info("action: operationReject, state: initiated, activationId: {}, operationId: {}",
-                extractActivationId(auth), operationId);
+        logger.info("", kv("action", "operationReject"), kv("state", "initiated"), kv("activationId", extractActivationId(auth)), kv("operationId", operationId));
 
         try {
             if (auth != null && auth.getUserId() != null) {
@@ -416,7 +413,7 @@ public class MobileTokenController {
                         .requestContext(RequestContextConverter.convert(servletRequest))
                         .mobileTokenData(requestObject.getMobileTokenData())
                         .build());
-                logger.info("action: operationReject, state: succeeded");
+                logger.info("", kv("action", "operationReject"), kv("state", "succeeded"));
                 return result;
             } else {
                 throw new MobileTokenAuthException();
@@ -425,19 +422,19 @@ public class MobileTokenController {
             final String errorCode = e.getPowerAuthError().map(PowerAuthError::getCode).orElse("ERROR_CODE_MISSING");
             switch (errorCode) {
                 case APPLICATION_NOT_FOUND -> {
-                    logger.warn("action: operationReject, state: failed, reason: applicationNotFound, error: {}", e.getMessage());
+                    logger.warn("", kv("action", "operationReject"), kv("state", "failed"), kv("reason", "applicationNotFound"));
                     throw new MobileTokenException(ErrorCode.INVALID_APPLICATION, "No application was found with the provided identifier: %s".formatted(auth.getApplicationId()), e);
                 }
                 case OPERATION_NOT_FOUND, OPERATION_REJECT_FAILURE -> {
-                    logger.warn("action: operationReject, state: failed, reason: operationNotFoundOrInvalidState, error: {}", e.getMessage());
+                    logger.warn("", kv("action", "operationReject"), kv("state", "failed"), kv("reason", "operationNotFoundOrInvalidState"));
                     throw new MobileTokenException(ErrorCode.INVALID_OPERATION, "Operation not found or is in an unexpected state", e);
                 }
                 case INVALID_REQUEST -> {
-                    logger.warn("action: operationReject, state: failed, reason: validation, error: {}", e.getMessage());
+                    logger.warn("", kv("action", "operationReject"), kv("state", "failed"), kv("reason", "validation"));
                     throw new MobileTokenException(ErrorCode.INVALID_REQUEST, "Request validation error: %s".formatted(e.getMessage()), e);
                 }
                 default -> {
-                    logger.warn("action: operationReject, state: failed, reason: powerAuthConnection, error: {}", e.getMessage());
+                    logger.warn("", kv("action", "operationReject"), kv("state", "failed"), kv("reason", "powerAuthConnection"));
                     throw new RemoteCommunicationException("Unable to call upstream service.", e);
                 }
             }

--- a/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/controller/api/PushRegistrationController.java
+++ b/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/controller/api/PushRegistrationController.java
@@ -36,6 +36,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 /**
  * Controller with services related to Push Server registration.
  *
@@ -69,9 +71,9 @@ public class PushRegistrationController {
     public Response registerDeviceDefault(@RequestBody ObjectRequest<PushRegisterRequest> request, @Parameter(hidden = true) PowerAuthApiAuthentication apiAuthentication) throws PowerAuthAuthenticationException, InvalidRequestObjectException, PushRegistrationFailedException {
         validateApiAuthentication(apiAuthentication);
 
-        logger.info("action: registerDeviceDefault, state: initiated, userId: {}", apiAuthentication.getUserId());
+        logger.info("", kv("action", "registerDeviceDefault"), kv("state", "initiated"), kv("userId", apiAuthentication.getUserId()));
         final Response response = pushRegistrationService.registerDevice(request, apiAuthentication);
-        logger.info("action: registerDeviceDefault, state: succeeded");
+        logger.info("", kv("action", "registerDeviceDefault"), kv("state", "succeeded"));
         return response;
     }
 
@@ -94,9 +96,9 @@ public class PushRegistrationController {
     public Response registerDeviceToken(@RequestBody ObjectRequest<PushRegisterRequest> request, @Parameter(hidden = true) PowerAuthApiAuthentication apiAuthentication) throws PowerAuthAuthenticationException, InvalidRequestObjectException, PushRegistrationFailedException {
         validateApiAuthentication(apiAuthentication);
 
-        logger.info("action: registerDeviceToken, state: initiated, userId: {}", apiAuthentication.getUserId());
+        logger.info("", kv("action", "registerDeviceToken"), kv("state", "initiated"), kv("userId", apiAuthentication.getUserId()));
         final Response response = pushRegistrationService.registerDevice(request, apiAuthentication);
-        logger.info("action: registerDeviceToken, state: succeeded");
+        logger.info("", kv("action", "registerDeviceToken"), kv("state", "succeeded"));
         return response;
     }
 

--- a/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/controller/api/admin/AdminController.java
+++ b/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/controller/api/admin/AdminController.java
@@ -35,6 +35,8 @@ import tools.jackson.databind.ObjectMapper;
 import java.util.List;
 import java.util.Map;
 
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 /**
  * Admin controller.
  *
@@ -53,10 +55,10 @@ public class AdminController {
 
     @GetMapping("/template")
     public ObjectResponse<TemplateListResponse> templates() {
-        logger.info("action: templates, state: initiated");
+        logger.info("", kv("action", "templates"), kv("state", "initiated"));
         final TemplateListResponse response = new TemplateListResponse();
         response.addAll(convert(operationTemplateService.findAll()));
-        logger.info("action: templates, state: succeeded");
+        logger.info("", kv("action", "templates"), kv("state", "succeeded"));
         return new ObjectResponse<>(response);
     }
 

--- a/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/errorhandling/DefaultExceptionHandler.java
+++ b/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/errorhandling/DefaultExceptionHandler.java
@@ -112,7 +112,7 @@ public class DefaultExceptionHandler {
     @ExceptionHandler(MobileTokenException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public @ResponseBody ErrorResponse handleMobileTokenException(MobileTokenException ex) {
-        logger.warn("Mobile token operation failed: {}", ex.getMessage(), ex);
+        logger.warn("Mobile token operation failed", ex);
         return new ErrorResponse(ex.getCode(), ex.getMessage());
     }
 
@@ -124,7 +124,7 @@ public class DefaultExceptionHandler {
     @ExceptionHandler(MobileTokenAuthException.class)
     @ResponseStatus(HttpStatus.UNAUTHORIZED)
     public @ResponseBody ErrorResponse handleMobileTokenAuthException(MobileTokenAuthException ex) {
-        logger.warn("Mobile token operation failed due to authorization error: {}", ex.getMessage(), ex);
+        logger.warn("Mobile token operation failed due to authorization error", ex);
         return new ErrorResponse(ex.getCode(), ex.getMessage());
     }
 
@@ -136,7 +136,7 @@ public class DefaultExceptionHandler {
     @ExceptionHandler(MobileTokenConfigurationException.class)
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     public @ResponseBody ErrorResponse handleMobileTokenConfigurationException(MobileTokenConfigurationException ex) {
-        logger.warn("Mobile token back-end is incorrectly configured: {}", ex.getMessage(), ex);
+        logger.warn("Mobile token back-end is incorrectly configured", ex);
         return new ErrorResponse(ex.getCode(), ex.getMessage());
     }
 
@@ -185,7 +185,7 @@ public class DefaultExceptionHandler {
     @ExceptionHandler(NoResourceFoundException.class)
     @ResponseStatus(HttpStatus.NOT_FOUND)
     public @ResponseBody ErrorResponse handleNoResourceFoundException(final NoResourceFoundException e) {
-        logger.warn("Error occurred when calling an API: {}", e.getMessage(), e);
+        logger.warn("Error occurred when calling an API", e);
         return new ErrorResponse("ERROR_NOT_FOUND", "Resource not found.");
     }
 

--- a/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/impl/service/converter/MobileTokenConverter.java
+++ b/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/impl/service/converter/MobileTokenConverter.java
@@ -111,8 +111,6 @@ public class MobileTokenConverter {
 
             return operation;
         } catch (JacksonException e) {
-            logger.debug("Unable to parse JSON with operation template parameters: {}", e.getMessage());
-            logger.debug("Exception detail", e);
             throw new MobileTokenConfigurationException("ERR_CONFIG", "Invalid JSON structure for the configuration: " + e.getMessage());
         }
     }

--- a/enrollment-server/src/main/resources/application-dev.properties
+++ b/enrollment-server/src/main/resources/application-dev.properties
@@ -13,3 +13,4 @@ spring.security.user.password=${ENROLLMENT_SERVER_DEV_SECURITY_USER_PASSWORD:{no
 
 logging.level.com.wultra=DEBUG
 logging.level.com.wultra.core.audit=INFO
+logging.config=classpath:logback-dev.xml

--- a/enrollment-server/src/main/resources/logback-dev.xml
+++ b/enrollment-server/src/main/resources/logback-dev.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ PowerAuth Enrollment Server
+  ~ Copyright (C) 2026 Wultra s.r.o.
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as published
+  ~ by the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<configuration>
+    <conversionRule conversionWord="sa" converterClass="com.wultra.core.logging.logback.StructuredArgumentsConverter"/>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%sa%n</pattern>
+        </encoder>
+    </appender>
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/enrollment-server/src/test/resources/logback-test.xml
+++ b/enrollment-server/src/test/resources/logback-test.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ PowerAuth Enrollment Server
+  ~ Copyright (C) 2026 Wultra s.r.o.
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as published
+  ~ by the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<configuration>
+    <conversionRule conversionWord="sa" converterClass="com.wultra.core.logging.logback.StructuredArgumentsConverter"/>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%sa%n</pattern>
+        </encoder>
+    </appender>
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -191,6 +191,12 @@
             </dependency>
 
             <dependency>
+                <groupId>com.wultra.core</groupId>
+                <artifactId>logging-support</artifactId>
+                <version>${wultra-core.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>com.wultra.security</groupId>
                 <artifactId>powerauth-java-crypto</artifactId>
                 <version>${powerauth-crypto.version}</version>


### PR DESCRIPTION
## Summary

Implements structured log quality improvements (L6/L7/L8) for the enrollment-server, as defined in epic [#864](https://github.com/wultra/tasklist/issues/864).

Closes #1773

## Problem

Log statements across enrollment-server were inconsistent and did not follow the Wultra Observability standards:
- **L6**: Missing or incomplete `action`/`state` structured fields
- **L7**: Key-value pairs not using `StructuredArguments.kv()` — structured data invisible in JSON logs
- **L8**: Debug log statements retained in exception handlers where the exception is re-thrown (noise, duplicate logging)

Additionally, `kv()` fields were invisible in plain-text output during local development and tests.

## Solution

- Applied L6/L7/L8 fixes across all service and controller classes in `enrollment-server` and `enrollment-server-onboarding`
- Added `logback-dev.xml` for local development with `%sa` (structured arguments) pattern
- Added `logback-test.xml` for all test modules with `%sa` pattern
- Added `logging-support` (from [java-core#454](https://github.com/wultra/java-core/pull/454)) which provides the `StructuredArgumentsConverter` that renders `kv()` in plain-text output

> [!NOTE]
> This PR depends on [wultra/java-core#454](https://github.com/wultra/java-core/pull/454) being merged and released before the final build. Both use `2.2.0-SNAPSHOT` and are compatible in local dev.

## Changes

| Area | Change |
|---|---|
| 19+ Java service/controller files | L6/L7/L8 log quality fixes |
| `enrollment-server/pom.xml` | Added `logging-support` + `logstash-logback-encoder` deps |
| `enrollment-server-onboarding/pom.xml` | Added `logging-support` + `logstash-logback-encoder` deps |
| 5 sub-module `pom.xml` files | Added `logging-support` + `logstash-logback-encoder` as test deps |
| `logback-dev.xml` (×2) | New — dev logging config with `%sa` pattern |
| `logback-test.xml` (×7) | New/updated — test logging config with `%sa` pattern |
| `application-dev.properties` (×2) | Added `logging.config=classpath:logback-dev.xml` |