### PR TITLE
Fix #1781: Configure annotationProcessorPaths for Lombok

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -312,6 +312,19 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <excludedGroups>external-service</excludedGroups>


### PR DESCRIPTION
## Summary

Fixes Lombok annotation processing on Java 25 by explicitly registering Lombok via `annotationProcessorPaths` in `maven-compiler-plugin`.

Closes #1781

## Problem

Lombok 1.18.x relies on implicit annotation processor discovery which breaks on Java 25 — the `logger` field (and other generated members) are not visible to `javac`, causing:

```
cannot find symbol
  symbol: variable logger
```

CI (Java 21) is unaffected; the issue only manifests locally when using Java 25.

## Solution

Add explicit `annotationProcessorPaths` configuration to `maven-compiler-plugin` in the root `pom.xml`. This bypasses the implicit APT discovery and works correctly on Java 25.

The existing `provided` Lombok dependency is retained — it is still needed to make Lombok annotations (`import lombok.*`) available on the compile classpath.

## Changes

| File | Change |
|---|---|
| `pom.xml` | Added `maven-compiler-plugin` with `annotationProcessorPaths` for Lombok |