### PR TITLE
Make `ProcessEventRequest#externalUserId` nullable

### DIFF
--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/provider/model/request/ProcessEventRequest.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/provider/model/request/ProcessEventRequest.java
@@ -46,8 +46,8 @@ public final class ProcessEventRequest {
     /**
      * User ID in the external system, which is used by the provider.
      * It can be the same as {@code userId} or different, depending on the provider implementation.
+     * It is {@code null} at the early phases of the process.
      */
-    @NonNull
     private String externalUserId;
 
     @NonNull


### PR DESCRIPTION
A follow-up to #1751