### PR TITLE
Fix #1817: Add mandatory fields for LCP event

### DIFF
--- a/docs/onboarding/Changelog.md
+++ b/docs/onboarding/Changelog.md
@@ -20,3 +20,9 @@
 
 - Removed `Serializable` from JPA entities. [(1425)](https://github.com/wultra/enrollment-server/issues/1425)
 - Remove property `enrollment-server-onboarding.identity-verification.enabledenrollment-server-onboarding.identity-verification.enabled` [(1788)](https://github.com/wultra/enrollment-server/issues/1788)
+
+
+### Fixed
+
+- Include `id` and `timestamp` in the outgoing process event request. [(1751)](https://github.com/wultra/enrollment-server/issues/1751)
+

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/OnboardingEventService.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/OnboardingEventService.java
@@ -39,10 +39,8 @@ import tools.jackson.core.JacksonException;
 import tools.jackson.databind.ObjectMapper;
 
 import java.time.LocalDate;
-import java.util.Base64;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
+import java.time.LocalDateTime;
+import java.util.*;
 
 import static com.wultra.app.onboardingserver.common.logging.StructuredLogging.*;
 
@@ -192,6 +190,8 @@ public class OnboardingEventService {
         return ProcessEventRequest.builder()
                 .processId(process.getId())
                 .processType(process.getProcessConfiguration().getProcessType())
+                .id(UUID.randomUUID().toString())
+                .timestamp(LocalDateTime.now())
                 .userId(identityVerification.getUserId())
                 .externalUserId(process.getExternalUserId())
                 .identityVerificationId(identityVerification.getId());

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/provider/model/request/ProcessEventRequest.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/provider/model/request/ProcessEventRequest.java
@@ -22,6 +22,8 @@ import com.wultra.app.onboardingserver.provider.OnboardingProvider;
 import com.wultra.core.annotations.PublicApi;
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 /**
  * Request object for {@link OnboardingProvider#processEvent(ProcessEventRequest)}.
  *
@@ -33,6 +35,18 @@ import lombok.*;
 @PublicApi
 @EqualsAndHashCode
 public final class ProcessEventRequest {
+
+    /**
+     * Unique identifier of the event.
+     */
+    @NonNull
+    private String id;
+
+    /**
+     * Timestamp when the event was created.
+     */
+    @NonNull
+    private LocalDateTime timestamp;
 
     @NonNull
     private String processId;

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/provider/rest/ProcessEventRequestDto.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/provider/rest/ProcessEventRequestDto.java
@@ -19,6 +19,8 @@ package com.wultra.app.onboardingserver.provider.rest;
 
 import lombok.Data;
 
+import java.time.LocalDateTime;
+
 /**
  * Request object for processing event.
  *
@@ -26,6 +28,10 @@ import lombok.Data;
  */
 @Data
 class ProcessEventRequestDto {
+
+    private String id;
+
+    private LocalDateTime timestamp;
 
     private String processId;
 

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/provider/rest/RestOnboardingProvider.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/provider/rest/RestOnboardingProvider.java
@@ -33,7 +33,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
@@ -233,8 +232,8 @@ public class RestOnboardingProvider implements OnboardingProvider {
 
     private static ProcessEventRequestDto convert(final ProcessEventRequest source) {
         final ProcessEventRequestDto target = new ProcessEventRequestDto();
-        target.setId(UUID.randomUUID().toString());
-        target.setTimestamp(LocalDateTime.now());
+        target.setId(source.getId());
+        target.setTimestamp(source.getTimestamp());
         target.setProcessId(source.getProcessId());
         target.setProcessType(source.getProcessType());
         target.setIdentityVerificationId(source.getIdentityVerificationId());

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/provider/rest/RestOnboardingProvider.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/provider/rest/RestOnboardingProvider.java
@@ -33,6 +33,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
@@ -232,6 +233,8 @@ public class RestOnboardingProvider implements OnboardingProvider {
 
     private static ProcessEventRequestDto convert(final ProcessEventRequest source) {
         final ProcessEventRequestDto target = new ProcessEventRequestDto();
+        target.setId(UUID.randomUUID().toString());
+        target.setTimestamp(LocalDateTime.now());
         target.setProcessId(source.getProcessId());
         target.setProcessType(source.getProcessType());
         target.setIdentityVerificationId(source.getIdentityVerificationId());

--- a/enrollment-server-onboarding/src/test/java/com/wultra/app/onboardingserver/provider/rest/ProcessEventRequestDtoSerializationTest.java
+++ b/enrollment-server-onboarding/src/test/java/com/wultra/app/onboardingserver/provider/rest/ProcessEventRequestDtoSerializationTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.json.JsonMapper;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
 
@@ -39,6 +40,8 @@ class ProcessEventRequestDtoSerializationTest {
     @Test
     void testSerializeProcessFinished() throws Exception {
         final var dto = new ProcessEventRequestDto();
+        dto.setId("790c5d2d-0a30-4850-9fc8-b3889563d833");
+        dto.setTimestamp(OffsetDateTime.parse("2026-06-17T10:46:15Z").toLocalDateTime());
         dto.setProcessId("8b2dfae4-d955-4d8f-a95b-2d9c5a4b0e26");
         dto.setProcessType("onboarding");
         dto.setIdentityVerificationId("d3827099-3b6c-4df9-887d-4eac402fc4f9");
@@ -60,6 +63,8 @@ class ProcessEventRequestDtoSerializationTest {
 
         final String expectedJson = """
                 {
+                  "id": "790c5d2d-0a30-4850-9fc8-b3889563d833",
+                  "timestamp": "2026-06-17T10:46:15",
                   "processId": "8b2dfae4-d955-4d8f-a95b-2d9c5a4b0e26",
                   "processType": "onboarding",
                   "identityVerificationId": "d3827099-3b6c-4df9-887d-4eac402fc4f9",

--- a/enrollment-server-onboarding/src/test/java/com/wultra/app/onboardingserver/provider/rest/RestOnboardingProviderTest.java
+++ b/enrollment-server-onboarding/src/test/java/com/wultra/app/onboardingserver/provider/rest/RestOnboardingProviderTest.java
@@ -40,6 +40,7 @@ import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.ResponseEntity;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -125,6 +126,8 @@ class RestOnboardingProviderTest {
     @Test
     void testProcessEvent_processFinished_correctRequestBody() throws OnboardingProviderException, RestClientException {
         final var request = ProcessEventRequest.builder()
+                .id("dummyId")
+                .timestamp(LocalDateTime.parse("2026-06-17T10:46:15"))
                 .processId("dummyProcessId")
                 .processType("dummyProcessType")
                 .userId("dummyUserId")
@@ -155,6 +158,8 @@ class RestOnboardingProviderTest {
         final ProcessEventRequestDto requestDto = processEventRequestDtoArgumentCaptor.getValue();
         assertEquals("dummyProcessId", requestDto.getProcessId());
         assertEquals("dummyProcessType", requestDto.getProcessType());
+        assertEquals("dummyId", requestDto.getId());
+        assertEquals(LocalDateTime.parse("2026-06-17T10:46:15"), requestDto.getTimestamp());
         assertEquals("dummyUserId", requestDto.getUserId());
         assertEquals("dummyExternalUserId", requestDto.getExternalUserId());
         assertEquals("dummyIdentityVerificationId", requestDto.getIdentityVerificationId());


### PR DESCRIPTION
# Functional description

Added field `id` and `timestamp` to all onboarding events