### PR TITLE
Fix #1819: Populate message field for structured (kv) logs

### DIFF
--- a/enrollment-server-onboarding-provider-innovatrics/src/main/java/com/wultra/app/onboardingserver/provider/innovatrics/InnovatricsLivenessController.java
+++ b/enrollment-server-onboarding-provider-innovatrics/src/main/java/com/wultra/app/onboardingserver/provider/innovatrics/InnovatricsLivenessController.java
@@ -79,7 +79,7 @@ class InnovatricsLivenessController {
             @Parameter(hidden = true) final EncryptionContext encryptionContext,
             @Parameter(hidden = true) final PowerAuthApiAuthentication apiAuthentication) throws IdentityVerificationException, PowerAuthAuthenticationException, PowerAuthEncryptionException, RemoteCommunicationException {
 
-        logger.info("", action("upload"), stateInitiated(), kv("activationId", extractActivationId(apiAuthentication)));
+        logger.info("Upload initiated", action("upload"), stateInitiated(), kv("activationId", extractActivationId(apiAuthentication)));
         if (apiAuthentication == null) {
             throw new PowerAuthTokenInvalidException("Unable to verify device registration when uploading liveness");
         }
@@ -89,7 +89,7 @@ class InnovatricsLivenessController {
         }
 
         innovatricsLivenessService.upload(requestData, encryptionContext);
-        logger.info("", action("upload"), stateSucceeded());
+        logger.info("Upload succeeded", action("upload"), stateSucceeded());
         return new Response();
     }
 

--- a/enrollment-server-onboarding-provider-microblink/src/main/java/com/wultra/app/onboardingserver/provider/microblink/MicroblinkDocumentVerificationProvider.java
+++ b/enrollment-server-onboarding-provider-microblink/src/main/java/com/wultra/app/onboardingserver/provider/microblink/MicroblinkDocumentVerificationProvider.java
@@ -112,7 +112,7 @@ public class MicroblinkDocumentVerificationProvider implements DocumentVerificat
 
     @Override
     public DocumentsSubmitResult checkDocumentUpload(OwnerId ownerId, DocumentVerificationEntity document) {
-        logger.info("", action("checkDocumentUpload"), kv("state", "unsupported"), kv("provider", "microblink"), kv("ownerId", ownerId));
+        logger.info("Check document upload not supported", action("checkDocumentUpload"), kv("state", "unsupported"), kv("provider", "microblink"), kv("ownerId", ownerId));
         throw new UnsupportedOperationException("Method checkDocumentUpload is not supported by Microblink provider.");
     }
 
@@ -122,7 +122,7 @@ public class MicroblinkDocumentVerificationProvider implements DocumentVerificat
                 .map(SubmittedDocument::getDocumentId)
                 .toList();
 
-        logger.info("", action("submitDocuments"), stateInitiated(), kv("provider", "microblink"), kv("ownerId", ownerId), kv("documentIds", documentIds));
+        logger.info("Submit documents initiated", action("submitDocuments"), stateInitiated(), kv("provider", "microblink"), kv("ownerId", ownerId), kv("documentIds", documentIds));
 
         final var documentsVerificationData = submittedDocuments.stream()
                 .map(MicroblinkDocumentVerificationProvider::buildDocumentVerificationData)
@@ -152,20 +152,20 @@ public class MicroblinkDocumentVerificationProvider implements DocumentVerificat
             result.setRejectReason("Rejected documents: " + rejectedDocuments);
         }
 
-        logger.info("", action("submitDocuments"), stateSucceeded(), kv("provider", "microblink"), kv("rejectReason", result.getRejectReason()));
+        logger.info("Submit documents succeeded", action("submitDocuments"), stateSucceeded(), kv("provider", "microblink"), kv("rejectReason", result.getRejectReason()));
         return result;
     }
 
     @Override
     public DocumentsVerificationResult getVerificationResult(OwnerId ownerId, String verificationId) {
-        logger.info("", action("getVerificationResult"), kv("state", "unsupported"), kv("provider", "microblink"), kv("ownerId", ownerId), kv("verificationId", verificationId));
+        logger.info("Get verification result not supported", action("getVerificationResult"), kv("state", "unsupported"), kv("provider", "microblink"), kv("ownerId", ownerId), kv("verificationId", verificationId));
         throw new UnsupportedOperationException("Method getVerificationResult is not supported by Microblink provider.");
     }
 
     @Override
     public Image getPhoto(String photoId) throws DocumentVerificationException {
         try {
-            logger.info("", action("getPhoto"), stateInitiated(), kv("provider", "microblink"), kv("photoId", photoId));
+            logger.info("Get photo initiated", action("getPhoto"), stateInitiated(), kv("provider", "microblink"), kv("photoId", photoId));
 
             final var photoDocumentData = processedDocumentDataRepository.findById(photoId)
                     .orElseThrow(() -> new DocumentVerificationException("Photo with id %s not found".formatted(photoId)));
@@ -175,32 +175,32 @@ public class MicroblinkDocumentVerificationProvider implements DocumentVerificat
                     .data(photoDocumentData.getData())
                     .build();
 
-            logger.info("", action("getPhoto"), stateSucceeded(), kv("provider", "microblink"));
+            logger.info("Get photo succeeded", action("getPhoto"), stateSucceeded(), kv("provider", "microblink"));
             return image;
         } catch (final DocumentVerificationException e) {
-            logger.info("", action("getPhoto"), stateFailed(), kv("provider", "microblink"));
+            logger.info("Get photo failed", action("getPhoto"), stateFailed(), kv("provider", "microblink"));
             throw e;
         }
     }
 
     @Override
     public void cleanupDocuments(OwnerId ownerId, List<String> uploadIds) {
-        logger.debug("", action("cleanupDocuments"), state("skipped"), kv("provider", "microblink"), kv("ownerId", ownerId), kv("uploadIds", uploadIds));
+        logger.debug("Cleanup documents skipped", action("cleanupDocuments"), state("skipped"), kv("provider", "microblink"), kv("ownerId", ownerId), kv("uploadIds", uploadIds));
     }
 
     @Override
     public List<String> parseRejectionReasons(DocumentResultEntity docResult) {
-        logger.info("", action("parseRejectionReasons"), stateInitiated(), kv("provider", "microblink"), kv("documentResultId", docResult.getId()));
+        logger.info("Parse rejection reasons initiated", action("parseRejectionReasons"), stateInitiated(), kv("provider", "microblink"), kv("documentResultId", docResult.getId()));
 
         final var result = List.of(docResult.getVerificationResult());
 
-        logger.info("", action("parseRejectionReasons"), stateSucceeded(), kv("provider", "microblink"), kv("rejectionReasons", String.join(",", result)));
+        logger.info("Parse rejection reasons succeeded", action("parseRejectionReasons"), stateSucceeded(), kv("provider", "microblink"), kv("rejectionReasons", String.join(",", result)));
         return result;
     }
 
     @Override
     public VerificationSdkInfo initVerificationSdk(OwnerId ownerId, Map<String, String> initAttributes) {
-        logger.info("", action("initVerificationSdk"), stateInitiated(), kv("provider", "microblink"), kv("ownerId", ownerId), kv("initAttributes", initAttributes));
+        logger.info("Init verification sdk initiated", action("initVerificationSdk"), stateInitiated(), kv("provider", "microblink"), kv("ownerId", ownerId), kv("initAttributes", initAttributes));
 
         final var origin = initAttributes.getOrDefault("origin", null);
         final var platform = initAttributes.getOrDefault("platform", null);
@@ -211,13 +211,13 @@ public class MicroblinkDocumentVerificationProvider implements DocumentVerificat
                 .map(it -> new VerificationSdkInfo(Map.of("license-key", it)))
                 .orElse(new VerificationSdkInfo());
 
-        logger.info("", action("initVerificationSdk"), stateSucceeded(), kv("provider", "microblink"), kv("sdkInfo", MicroblinkLogSanitizationUtils.sanitizeSdkInfo(sdkInfo)));
+        logger.info("Init verification sdk succeeded", action("initVerificationSdk"), stateSucceeded(), kv("provider", "microblink"), kv("sdkInfo", MicroblinkLogSanitizationUtils.sanitizeSdkInfo(sdkInfo)));
         return sdkInfo;
     }
 
     @Override
     public boolean shouldStoreSelfie() {
-        logger.info("", action("shouldStoreSelfie"), stateSucceeded(), kv("provider", "microblink"), kv("result", false));
+        logger.info("Should store selfie succeeded", action("shouldStoreSelfie"), stateSucceeded(), kv("provider", "microblink"), kv("result", false));
         return false;
     }
 
@@ -225,15 +225,15 @@ public class MicroblinkDocumentVerificationProvider implements DocumentVerificat
     public DocumentsVerificationResult verifyDocuments(OwnerId ownerId, List<String> uploadIds) {
         final var verificationId = UUID.randomUUID().toString();
 
-        logger.info("", action("verifyDocuments"), stateInitiated(), kv("provider", "microblink"), kv("ownerId", ownerId), kv("uploadIds", uploadIds), kv("verificationId", verificationId));
+        logger.info("Verify documents initiated", action("verifyDocuments"), stateInitiated(), kv("provider", "microblink"), kv("ownerId", ownerId), kv("uploadIds", uploadIds), kv("verificationId", verificationId));
 
         try {
             final var result = verifyDocuments(uploadIds, verificationId);
 
-            logger.info("", action("verifyDocuments"), stateSucceeded(), kv("provider", "microblink"), kv("result", result.getStatus()));
+            logger.info("Verify documents succeeded", action("verifyDocuments"), stateSucceeded(), kv("provider", "microblink"), kv("result", result.getStatus()));
             return result;
         } catch (final DocumentVerificationException | RuntimeException e) {
-            logger.warn("", action("verifyDocuments"), stateFailed(), kv("provider", "microblink"), e);
+            logger.warn("Verify documents failed", action("verifyDocuments"), stateFailed(), kv("provider", "microblink"), e);
 
             final var errorMessage = "Microblink provider exception: %s %s".formatted(e.getClass().getSimpleName(), e.getMessage());
 
@@ -313,11 +313,11 @@ public class MicroblinkDocumentVerificationProvider implements DocumentVerificat
             final DocumentVerificationData frontDocument,
             final DocumentVerificationData backDocument
     ) throws DocumentVerificationException, RemoteCommunicationException {
-        logger.info("", action("sendMicroblinkRequest"), stateInitiated(), kv("frontDocumentUploadId", frontDocument != null ? frontDocument.uploadId() : null), kv("backDocumentUploadId", backDocument != null ? backDocument.uploadId() : null));
+        logger.info("Send microblink request initiated", action("sendMicroblinkRequest"), stateInitiated(), kv("frontDocumentUploadId", frontDocument != null ? frontDocument.uploadId() : null), kv("backDocumentUploadId", backDocument != null ? backDocument.uploadId() : null));
 
         try {
             final var request = buildRequest(frontDocument, backDocument);
-            logger.debug("", action("sendMicroblinkRequest"), stateInitiated(), kv("requestBody", (Supplier<String>) () -> MicroblinkLogSanitizationUtils.sanitizeDocumentVerificationRequest(request)));
+            logger.debug("Send microblink request initiated", action("sendMicroblinkRequest"), stateInitiated(), kv("requestBody", (Supplier<String>) () -> MicroblinkLogSanitizationUtils.sanitizeDocumentVerificationRequest(request)));
 
             final var response = microblinkRestClient.post("/api/v2/docver", request, new ParameterizedTypeReference<String>() {});
             final var body = Optional.ofNullable(response)
@@ -327,7 +327,7 @@ public class MicroblinkDocumentVerificationProvider implements DocumentVerificat
             final var parsedResponse = parseMicroblinkResponse(body)
                     .orElseThrow(() -> new DocumentVerificationException("Failed to parse Microblink API response"));
 
-            logger.info("", action("sendMicroblinkRequest"), stateSucceeded(), kv("verificationResult", Optional.ofNullable(parsedResponse.getParsedResponseBody())
+            logger.info("Send microblink request succeeded", action("sendMicroblinkRequest"), stateSucceeded(), kv("verificationResult", Optional.ofNullable(parsedResponse.getParsedResponseBody())
                     .map(DocumentVerificationResponse::verification)
                     .map(DocumentVerificationResponse.Verification::result)
                     .orElse(null)), kv("microblinkTraceId", Optional.ofNullable(parsedResponse.getParsedResponseBody())
@@ -337,7 +337,7 @@ public class MicroblinkDocumentVerificationProvider implements DocumentVerificat
 
             return parsedResponse;
         } catch (final RestClientException e) {
-            logger.info("", action("sendMicroblinkRequest"), stateFailed(), kv("statusCode", e.getStatusCode()), kv("response", e.getResponse()));
+            logger.info("Send microblink request failed", action("sendMicroblinkRequest"), stateFailed(), kv("statusCode", e.getStatusCode()), kv("response", e.getResponse()));
 
             throw new RemoteCommunicationException(
                     "Failed REST API call to Microblink, statusCode=%s, responseBody='%s'".formatted(

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/controller/api/ConfigurationController.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/controller/api/ConfigurationController.java
@@ -73,7 +73,7 @@ public class ConfigurationController {
             @Parameter(hidden = true) final EncryptionContext encryptionContext) throws PowerAuthEncryptionException, InvalidRequestObjectException {
 
         final String processType = request.getRequestObject().processType();
-        logger.info("", action("fetchConfiguration"), stateInitiated(), kv("processType", processType));
+        logger.info("Fetch configuration initiated", action("fetchConfiguration"), stateInitiated(), kv("processType", processType));
 
         if (encryptionContext == null) {
             throw new PowerAuthEncryptionException("ECIES decryption failed");
@@ -86,8 +86,8 @@ public class ConfigurationController {
                 .otpResendPeriodSeconds(onboardingConfig.getOtpResendPeriod().getSeconds())
                 .build();
 
-        logger.info("", action("fetchConfiguration"), stateSucceeded());
-        logger.debug("", action("fetchConfiguration"), stateSucceeded(), kv("result", result));
+        logger.info("Fetch configuration succeeded", action("fetchConfiguration"), stateSucceeded());
+        logger.debug("Fetch configuration succeeded", action("fetchConfiguration"), stateSucceeded(), kv("result", result));
 
         return new ObjectResponse<>(result);
     }

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/controller/api/IdentityVerificationController.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/controller/api/IdentityVerificationController.java
@@ -93,9 +93,9 @@ public class IdentityVerificationController {
             final @Parameter(hidden = true) PowerAuthApiAuthentication apiAuthentication) throws PowerAuthAuthenticationException, IdentityVerificationException, OnboardingProcessException {
 
         final IdentityVerificationInitRequest requestObject = request.getRequestObject();
-        logger.info("", action("initializeIdentityVerification"), stateInitiated(), kv("processId", requestObject.getProcessId()));
+        logger.info("Initialize identity verification initiated", action("initializeIdentityVerification"), stateInitiated(), kv("processId", requestObject.getProcessId()));
         final var response = identityVerificationRestService.initializeIdentityVerification(requestObject, apiAuthentication);
-        logger.info("", action("initializeIdentityVerification"), stateSucceeded());
+        logger.info("Initialize identity verification succeeded", action("initializeIdentityVerification"), stateSucceeded());
         return response;
     }
 
@@ -118,9 +118,9 @@ public class IdentityVerificationController {
             final @Parameter(hidden = true) PowerAuthApiAuthentication apiAuthentication)
             throws PowerAuthAuthenticationException, RemoteCommunicationException, OnboardingProcessException {
 
-        logger.info("", action("checkIdentityVerificationStatus"), stateInitiated(), kv("activationId", extractActivationId(apiAuthentication)));
+        logger.info("Check identity verification status initiated", action("checkIdentityVerificationStatus"), stateInitiated(), kv("activationId", extractActivationId(apiAuthentication)));
         final var response = identityVerificationRestService.checkIdentityVerificationStatus(request.getRequestObject(), apiAuthentication);
-        logger.info("", action("checkIdentityVerificationStatus"), stateSucceeded(), kv("phase", response.getResponseObject().getIdentityVerificationPhase()), kv("status", response.getResponseObject().getIdentityVerificationStatus()));
+        logger.info("Check identity verification status succeeded", action("checkIdentityVerificationStatus"), stateSucceeded(), kv("phase", response.getResponseObject().getIdentityVerificationPhase()), kv("status", response.getResponseObject().getIdentityVerificationStatus()));
         return response;
     }
 
@@ -155,9 +155,9 @@ public class IdentityVerificationController {
             throws PowerAuthAuthenticationException, PowerAuthEncryptionException, DocumentSubmitException, OnboardingProcessException, IdentityVerificationLimitException, RemoteCommunicationException, IdentityVerificationException, OnboardingProcessLimitException {
 
         final DocumentSubmitRequest requestObject = request.getRequestObject();
-        logger.info("", action("submitDocuments"), stateInitiated(), kv("processId", requestObject.getProcessId()));
+        logger.info("Submit documents initiated", action("submitDocuments"), stateInitiated(), kv("processId", requestObject.getProcessId()));
         final Response response = identityVerificationRestService.submitDocuments(requestObject, encryptionContext, apiAuthentication);
-        logger.info("", action("submitDocuments"), stateSucceeded());
+        logger.info("Submit documents succeeded", action("submitDocuments"), stateSucceeded());
         return response;
     }
 
@@ -178,10 +178,10 @@ public class IdentityVerificationController {
             final @Parameter(hidden = true) PowerAuthApiAuthentication apiAuthentication) throws PowerAuthAuthenticationException, OnboardingProcessException {
 
         final DocumentStatusRequest requestObject = request.getRequestObject();
-        logger.info("", action("checkDocumentStatus"), stateInitiated(), kv("processId", requestObject.getProcessId()));
+        logger.info("Check document status initiated", action("checkDocumentStatus"), stateInitiated(), kv("processId", requestObject.getProcessId()));
         final var result = identityVerificationRestService.checkDocumentStatus(requestObject, apiAuthentication);
 
-        logger.info("", action("checkDocumentStatus"), stateSucceeded(), kv("statuses", collectDocumentStatuses(result)));
+        logger.info("Check document status succeeded", action("checkDocumentStatus"), stateSucceeded(), kv("statuses", collectDocumentStatuses(result)));
         return result;
     }
 
@@ -219,9 +219,9 @@ public class IdentityVerificationController {
             throws PowerAuthAuthenticationException, DocumentVerificationException, PowerAuthEncryptionException, OnboardingProcessException, RemoteCommunicationException {
 
         final DocumentVerificationSdkInitRequest requestObject = request.getRequestObject();
-        logger.info("", action("initVerificationSdk"), stateInitiated(), kv("processId", requestObject.getProcessId()));
+        logger.info("Init verification sdk initiated", action("initVerificationSdk"), stateInitiated(), kv("processId", requestObject.getProcessId()));
         final var response = identityVerificationRestService.initVerificationSdk(requestObject, encryptionContext, apiAuthentication);
-        logger.info("", action("initVerificationSdk"), stateSucceeded());
+        logger.info("Init verification sdk succeeded", action("initVerificationSdk"), stateSucceeded());
         return response;
     }
 
@@ -249,9 +249,9 @@ public class IdentityVerificationController {
             throws IdentityVerificationException, PowerAuthAuthenticationException, PowerAuthEncryptionException, OnboardingProcessException {
 
         final PresenceCheckInitRequest requestObject = request.getRequestObject();
-        logger.info("", action("initPresenceCheck"), stateInitiated(), kv("processId", requestObject.getProcessId()));
+        logger.info("Init presence check initiated", action("initPresenceCheck"), stateInitiated(), kv("processId", requestObject.getProcessId()));
         final var response = identityVerificationRestService.initPresenceCheck(requestObject, encryptionContext, apiAuthentication);
-        logger.info("", action("initPresenceCheck"), stateSucceeded());
+        logger.info("Init presence check succeeded", action("initPresenceCheck"), stateSucceeded());
         return response;
     }
 
@@ -272,9 +272,9 @@ public class IdentityVerificationController {
             final @Parameter(hidden = true) PowerAuthApiAuthentication apiAuthentication) throws IdentityVerificationException, PowerAuthAuthenticationException, OnboardingProcessException {
 
         final PresenceCheckSubmitRequest requestObject = request.getRequestObject();
-        logger.info("", action("submitPresenceCheck"), stateInitiated(), kv("processId", requestObject.getProcessId()));
+        logger.info("Submit presence check initiated", action("submitPresenceCheck"), stateInitiated(), kv("processId", requestObject.getProcessId()));
         final var response = identityVerificationRestService.submitPresenceCheck(requestObject, apiAuthentication);
-        logger.info("", action("submitPresenceCheck"), stateSucceeded());
+        logger.info("Submit presence check succeeded", action("submitPresenceCheck"), stateSucceeded());
         return response;
     }
 
@@ -294,9 +294,9 @@ public class IdentityVerificationController {
             final @Parameter(hidden = true) PowerAuthApiAuthentication apiAuthentication) throws IdentityVerificationException, OnboardingProcessException, PowerAuthTokenInvalidException {
 
         final IdentityVerificationOtpSendRequest requestObject = request.getRequestObject();
-        logger.info("", action("resendOtp"), stateInitiated(), kv("processId", requestObject.getProcessId()));
+        logger.info("Resend otp initiated", action("resendOtp"), stateInitiated(), kv("processId", requestObject.getProcessId()));
         final var response = identityVerificationRestService.resendOtp(requestObject, apiAuthentication);
-        logger.info("", action("resendOtp"), stateSucceeded());
+        logger.info("Resend otp succeeded", action("resendOtp"), stateSucceeded());
         return response;
     }
 
@@ -316,9 +316,9 @@ public class IdentityVerificationController {
             throws PowerAuthEncryptionException, OnboardingProcessException {
 
         final IdentityVerificationOtpVerifyRequest requestObject = request.getRequestObject();
-        logger.info("", action("verifyOtp"), stateInitiated(), kv("processId", requestObject.getProcessId()));
+        logger.info("Verify otp initiated", action("verifyOtp"), stateInitiated(), kv("processId", requestObject.getProcessId()));
         final var response = identityVerificationRestService.verifyOtp(requestObject, encryptionContext);
-        logger.info("", action("verifyOtp"), stateSucceeded());
+        logger.info("Verify otp succeeded", action("verifyOtp"), stateSucceeded());
         return response;
     }
 
@@ -344,9 +344,9 @@ public class IdentityVerificationController {
             throws PowerAuthAuthenticationException, DocumentVerificationException, PresenceCheckException, RemoteCommunicationException, OnboardingProcessException, IdentityVerificationException, OnboardingProcessLimitException {
 
         final IdentityVerificationCleanupRequest requestObject = request.getRequestObject();
-        logger.info("", action("cleanup"), stateInitiated(), kv("processId", requestObject.getProcessId()));
+        logger.info("Cleanup initiated", action("cleanup"), stateInitiated(), kv("processId", requestObject.getProcessId()));
         final Response response = identityVerificationRestService.cleanup(requestObject, apiAuthentication);
-        logger.info("", action("cleanup"), stateSucceeded());
+        logger.info("Cleanup succeeded", action("cleanup"), stateSucceeded());
         return response;
     }
 
@@ -371,9 +371,9 @@ public class IdentityVerificationController {
             final @Parameter(hidden = true) PowerAuthApiAuthentication apiAuthentication) throws OnboardingProcessException, PowerAuthTokenInvalidException {
 
         final OnboardingConsentTextRequest requestObject = request.getRequestObject();
-        logger.info("", action("fetchConsentText"), stateInitiated(), kv("processId", requestObject.getProcessId()));
+        logger.info("Fetch consent text initiated", action("fetchConsentText"), stateInitiated(), kv("processId", requestObject.getProcessId()));
         final var response = identityVerificationRestService.fetchConsentText(requestObject, apiAuthentication);
-        logger.info("", action("fetchConsentText"), stateSucceeded());
+        logger.info("Fetch consent text succeeded", action("fetchConsentText"), stateSucceeded());
         return response;
     }
 
@@ -396,9 +396,9 @@ public class IdentityVerificationController {
             final @Parameter(hidden = true) PowerAuthApiAuthentication apiAuthentication) throws OnboardingProcessException, PowerAuthAuthenticationException {
 
         final OnboardingConsentApprovalRequest requestObject = request.getRequestObject();
-        logger.info("", action("approveConsent"), stateInitiated(), kv("processId", requestObject.getProcessId()), kv("approved", requestObject.isApproved()));
+        logger.info("Approve consent initiated", action("approveConsent"), stateInitiated(), kv("processId", requestObject.getProcessId()), kv("approved", requestObject.isApproved()));
         final Response response = identityVerificationRestService.approveConsent(requestObject, apiAuthentication);
-        logger.info("", action("approveConsent"), stateSucceeded());
+        logger.info("Approve consent succeeded", action("approveConsent"), stateSucceeded());
         return response;
     }
 
@@ -423,9 +423,9 @@ public class IdentityVerificationController {
             @Parameter(hidden = true) @NotNull final PowerAuthApiAuthentication apiAuthentication) throws OnboardingProcessException, RemoteCommunicationException {
 
         final CreateTargetActivationRequest requestObject = request.getRequestObject();
-        logger.info("", action("createTargetActivation"), stateInitiated(), kv("processId", requestObject.processId()));
+        logger.info("Create target activation initiated", action("createTargetActivation"), stateInitiated(), kv("processId", requestObject.processId()));
         final CreateTargetActivationResponse response = identityVerificationTargetActivationService.createTargetActivation(requestObject, apiAuthentication);
-        logger.info("", action("createTargetActivation"), stateSucceeded());
+        logger.info("Create target activation succeeded", action("createTargetActivation"), stateSucceeded());
 
         return new ObjectResponse<>(response);
     }

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/controller/api/OnboardingController.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/controller/api/OnboardingController.java
@@ -85,7 +85,7 @@ public class OnboardingController {
             final HttpServletRequest servletRequest) throws OnboardingProcessException, OnboardingOtpDeliveryException, PowerAuthEncryptionException, TooManyProcessesException, InvalidRequestObjectException, RemoteCommunicationException {
 
         final OnboardingStartRequest requestObject = request.getRequestObject();
-        logger.info("", action("start"), stateInitiated(), kv("processType", requestObject.processType()));
+        logger.info("Start initiated", action("start"), stateInitiated(), kv("processType", requestObject.processType()));
         // Check if the request was correctly decrypted
         if (encryptionContext == null) {
             throw new PowerAuthEncryptionException("ECIES decryption failed during onboarding");
@@ -94,7 +94,7 @@ public class OnboardingController {
         final RequestContext requestContext = RequestContextConverter.convert(servletRequest);
 
         final OnboardingStartResponse response = onboardingService.startOnboarding(requestObject, requestContext, encryptionContext);
-        logger.info("", action("start"), stateSucceeded());
+        logger.info("Start succeeded", action("start"), stateSucceeded());
         return new ObjectResponse<>(response);
     }
 
@@ -116,14 +116,14 @@ public class OnboardingController {
             throws PowerAuthEncryptionException, OnboardingProcessException, OnboardingOtpDeliveryException {
 
         final OnboardingOtpResendRequest requestObject = request.getRequestObject();
-        logger.info("", action("resendOtp"), stateInitiated(), kv("processId", requestObject.getProcessId()));
+        logger.info("Resend otp initiated", action("resendOtp"), stateInitiated(), kv("processId", requestObject.getProcessId()));
         // Check if the request was correctly decrypted
         if (encryptionContext == null) {
             throw new PowerAuthEncryptionException("ECIES decryption failed while resending OTP code");
         }
 
         final Response response = onboardingService.resendOtp(requestObject);
-        logger.info("", action("resendOtp"), stateSucceeded());
+        logger.info("Resend otp succeeded", action("resendOtp"), stateSucceeded());
         return response;
     }
 
@@ -143,7 +143,7 @@ public class OnboardingController {
             @Parameter(hidden = true) final EncryptionContext encryptionContext) throws PowerAuthEncryptionException, OnboardingProcessException {
 
         final OnboardingStatusRequest requestObject = request.getRequestObject();
-        logger.info("", action("status"), stateInitiated(), kv("processId", requestObject.getProcessId()));
+        logger.info("Status initiated", action("status"), stateInitiated(), kv("processId", requestObject.getProcessId()));
         // Check if the request was correctly decrypted
         if (encryptionContext == null) {
             throw new PowerAuthEncryptionException("ECIES decryption failed while getting status");
@@ -151,7 +151,7 @@ public class OnboardingController {
 
         logger.debug("Onboarding process will not be locked, {}", requestObject.getProcessId(), kv("processId", requestObject.getProcessId()));
         final OnboardingStatusResponse response = onboardingService.getStatus(requestObject);
-        logger.info("", action("status"), stateSucceeded());
+        logger.info("Status succeeded", action("status"), stateSucceeded());
         return new ObjectResponse<>(response);
     }
 
@@ -171,14 +171,14 @@ public class OnboardingController {
             @Parameter(hidden = true) final EncryptionContext encryptionContext) throws PowerAuthEncryptionException, OnboardingProcessException {
 
         final OnboardingCleanupRequest requestObject = request.getRequestObject();
-        logger.info("", action("cleanup"), stateInitiated(), kv("processId", requestObject.getProcessId()));
+        logger.info("Cleanup initiated", action("cleanup"), stateInitiated(), kv("processId", requestObject.getProcessId()));
         // Check if the request was correctly decrypted
         if (encryptionContext == null) {
             throw new PowerAuthEncryptionException("ECIES decryption failed during cleanup");
         }
 
         final Response response = onboardingService.performCleanup(requestObject);
-        logger.info("", action("cleanup"), stateSucceeded());
+        logger.info("Cleanup succeeded", action("cleanup"), stateSucceeded());
         return response;
     }
 }

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/controller/api/PrivateClientController.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/controller/api/PrivateClientController.java
@@ -52,10 +52,10 @@ class PrivateClientController {
      */
     @PostMapping("approve")
     public AcknowledgeApproveClientResponse acknowledgeApproveClient(final @Valid @RequestBody AcknowledgeApproveClientRequest request) {
-        logger.info("", action("acknowledgeApproveClient"), stateInitiated(), kv("processId", request.processId()));
+        logger.info("Acknowledge approve client initiated", action("acknowledgeApproveClient"), stateInitiated(), kv("processId", request.processId()));
 
         if (request.approvalResult() == AcknowledgeApproveClientRequest.ApprovalResult.WAIT) {
-            logger.info("", action("acknowledgeApproveClient"), state("skipped"), kv("reason", "approvalResult is WAIT"));
+            logger.info("Acknowledge approve client skipped: approvalResult is WAIT", action("acknowledgeApproveClient"), state("skipped"), kv("reason", "approvalResult is WAIT"));
             return AcknowledgeApproveClientResponse.builder()
                     .result(AcknowledgeApproveClientResponse.Result.OK)
                     .build();
@@ -64,9 +64,9 @@ class PrivateClientController {
         final AcknowledgeApproveClientResponse response = acknowledgeService.acknowledgeApproveClient(request);
 
         if (response.result() == AcknowledgeApproveClientResponse.Result.OK) {
-            logger.info("", action("acknowledgeApproveClient"), stateSucceeded());
+            logger.info("Acknowledge approve client succeeded", action("acknowledgeApproveClient"), stateSucceeded());
         } else {
-            logger.info("", action("acknowledgeApproveClient"), stateFailed(), kv("reason", response.resultReason()));
+            logger.info("Acknowledge approve client failed", action("acknowledgeApproveClient"), stateFailed(), kv("reason", response.resultReason()));
         }
 
         return response;
@@ -74,10 +74,10 @@ class PrivateClientController {
 
     @PostMapping("evaluate")
     public AcknowledgeEvaluationClientResponse acknowledgeEvaluationClient(final @Valid @RequestBody AcknowledgeEvaluationClientRequest request) {
-        logger.info("", action("acknowledgeEvaluationClient"), stateInitiated(), kv("processId", request.processId()));
+        logger.info("Acknowledge evaluation client initiated", action("acknowledgeEvaluationClient"), stateInitiated(), kv("processId", request.processId()));
 
         if (request.evaluationResult() == AcknowledgeEvaluationClientRequest.EvaluationResult.WAIT) {
-            logger.info("", action("acknowledgeEvaluationClient"), state("skipped"), kv("reason", "evaluationResult is WAIT"));
+            logger.info("Acknowledge evaluation client skipped: evaluationResult is WAIT", action("acknowledgeEvaluationClient"), state("skipped"), kv("reason", "evaluationResult is WAIT"));
             return AcknowledgeEvaluationClientResponse.builder()
                     .result(AcknowledgeEvaluationClientResponse.Result.OK)
                     .build();
@@ -86,9 +86,9 @@ class PrivateClientController {
         final AcknowledgeEvaluationClientResponse response = acknowledgeService.acknowledgeEvaluationClient(request);
 
         if (response.result() == AcknowledgeEvaluationClientResponse.Result.OK) {
-            logger.info("", action("acknowledgeEvaluationClient"), stateSucceeded());
+            logger.info("Acknowledge evaluation client succeeded", action("acknowledgeEvaluationClient"), stateSucceeded());
         } else {
-            logger.info("", action("acknowledgeEvaluationClient"), stateFailed(), kv("reason", response.resultReason()));
+            logger.info("Acknowledge evaluation client failed", action("acknowledgeEvaluationClient"), stateFailed(), kv("reason", response.resultReason()));
         }
 
         return response;

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/controller/api/v2/IdentityVerificationV2Controller.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/controller/api/v2/IdentityVerificationV2Controller.java
@@ -99,15 +99,15 @@ class IdentityVerificationV2Controller {
     ) throws OnboardingProcessException, RemoteCommunicationException, IdentityVerificationLimitException, DocumentSubmitException, PowerAuthEncryptionException, IdentityVerificationException, OnboardingProcessLimitException, PowerAuthAuthenticationException {
 
         final DocumentSubmitV2Request requestObject = request.getRequestObject();
-        logger.info("", action("submitDocumentsV2"), stateInitiated(), kv("processId", requestObject.processId()));
+        logger.info("Submit documents v2 initiated", action("submitDocumentsV2"), stateInitiated(), kv("processId", requestObject.processId()));
 
         try {
             final var response = identityVerificationRestService.submitDocumentsV2(requestObject, encryptionContext, apiAuthentication);
 
-            logger.info("", action("submitDocumentsV2"), stateSucceeded());
+            logger.info("Submit documents v2 succeeded", action("submitDocumentsV2"), stateSucceeded());
             return response;
         } catch (final Exception e) {
-            logger.error("", action("submitDocumentsV2"), stateFailed());
+            logger.error("Submit documents v2 failed", action("submitDocumentsV2"), stateFailed());
             throw e;
         }
     }

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/ClientEvaluationService.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/ClientEvaluationService.java
@@ -161,14 +161,14 @@ public class ClientEvaluationService {
         final var maxAttempts = config.getClientEvaluationMaxFailedAttempts();
         final int attempt = attemptCounter.incrementAndGet();
 
-        logger.info("", action("callEvaluateClient"), stateInitiated(), kv("attempt", attempt), kv("maxAttempts", maxAttempts));
+        logger.info("Call evaluate client initiated", action("callEvaluateClient"), stateInitiated(), kv("attempt", attempt), kv("maxAttempts", maxAttempts));
 
         try {
             final EvaluateClientResponse response = onboardingProvider.evaluateClient(request);
-            logger.info("", action("callEvaluateClient"), stateSucceeded(), kv("evaluationResult", response.getEvaluationResult()), kv("resultReason", response.getResultReason()));
+            logger.info("Call evaluate client succeeded", action("callEvaluateClient"), stateSucceeded(), kv("evaluationResult", response.getEvaluationResult()), kv("resultReason", response.getResultReason()));
             return response;
         } catch (final Exception e) {
-            logger.warn("", action("callEvaluateClient"), stateFailed(), kv("attempt", attempt), kv("maxAttempts", maxAttempts));
+            logger.warn("Call evaluate client failed", action("callEvaluateClient"), stateFailed(), kv("attempt", attempt), kv("maxAttempts", maxAttempts));
             throw e;
         }
     }

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/OnboardingApprovalService.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/OnboardingApprovalService.java
@@ -106,17 +106,17 @@ public class OnboardingApprovalService {
                     .image(loadImage(identityVerification))
                     .build();
 
-            logger.info("", action("callApproveClient"), stateInitiated());
+            logger.info("Call approve client initiated", action("callApproveClient"), stateInitiated());
             final ApproveClientResponse response = onboardingProvider.approveClient(request);
             final ApproveClientResponse.ApprovalResult approvalResult = response.result();
             final String resultReason = response.resultReason();
-            logger.info("", action("callApproveClient"), stateSucceeded(), kv("approvalResult", approvalResult), kv("resultReason", resultReason));
+            logger.info("Call approve client succeeded", action("callApproveClient"), stateSucceeded(), kv("approvalResult", approvalResult), kv("resultReason", resultReason));
             persistRejectReason(response, identityVerification);
 
             auditService.audit(identityVerification, "Onboarding approval result: {}, resultReason: {}", approvalResult, resultReason);
             return convert(approvalResult);
         } catch (final OnboardingProviderException | OnboardingProcessException | RuntimeException e) {
-            logger.warn("", action("callApproveClient"), stateFailed(), e);
+            logger.warn("Call approve client failed", action("callApproveClient"), stateFailed(), e);
             auditService.audit(identityVerification, "Onboarding approval result: FAILED");
             return ApprovalResult.FAILED;
         }

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/OnboardingEventService.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/OnboardingEventService.java
@@ -218,13 +218,13 @@ public class OnboardingEventService {
 
     private void sendEvent(final ProcessEventRequest request) {
         try {
-            logger.info("", action("sendEvent"), stateInitiated(), kv("eventType", request.getType()), kv("processId", request.getProcessId()));
+            logger.info("Send event initiated", action("sendEvent"), stateInitiated(), kv("eventType", request.getType()), kv("processId", request.getProcessId()));
             final ProcessEventResponse response = onboardingProvider.processEvent(request);
             logger.debug("Got {} for processId={}", response, request.getProcessId());
-            logger.info("", action("sendEvent"), stateSucceeded(), kv("errorOccurred", response.isErrorOccurred()), kv("errorDetail", response.getErrorDetail()));
+            logger.info("Send event succeeded", action("sendEvent"), stateSucceeded(), kv("errorOccurred", response.isErrorOccurred()), kv("errorDetail", response.getErrorDetail()));
         } catch (OnboardingProviderException e) {
             // unsuccessful event publishing does not stop the process
-            logger.warn("", action("sendEvent"), stateFailed(), kv("exceptionMessage", e.getMessage()), e);
+            logger.warn("Send event failed", action("sendEvent"), stateFailed(), kv("exceptionMessage", e.getMessage()), e);
         }
     }
 

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/userdatastore/DefaultUserDataStoreService.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/userdatastore/DefaultUserDataStoreService.java
@@ -106,23 +106,23 @@ class DefaultUserDataStoreService implements UserDataStoreService {
     @Transactional(readOnly = true)
     @Override
     public List<DocumentCreateRequest> collectDocumentData(final String processId) {
-        logger.info("", action("collectDocumentData"), stateInitiated(), kv("processId", processId));
+        logger.info("Collect document data initiated", action("collectDocumentData"), stateInitiated(), kv("processId", processId));
 
         final var process = onboardingProcessRepository.findById(processId).orElse(null);
         if (process == null) {
-            logger.warn("", action("collectDocumentData"), stateFailed(), kv("reason", "process_not_found"), kv("processId", processId));
+            logger.warn("Collect document data failed: process_not_found", action("collectDocumentData"), stateFailed(), kv("reason", "process_not_found"), kv("processId", processId));
             return List.of();
         }
 
         final var identityVerification = identityVerificationRepository.findFirstByActivationIdOrderByTimestampCreatedDesc(process.getActivationId()).orElse(null);
         if (identityVerification == null) {
-            logger.warn("", action("collectDocumentData"), stateFailed(), kv("reason", "identity_not_found"), kv("processId", processId));
+            logger.warn("Collect document data failed: identity_not_found", action("collectDocumentData"), stateFailed(), kv("reason", "identity_not_found"), kv("processId", processId));
             return List.of();
         }
 
         final var documentVerifications = fetchDocumentVerifications(identityVerification, config.getDocumentType());
         if (documentVerifications.primaryDocuments() == null) {
-            logger.info("", action("collectDocumentData"), state("skipped"), kv("reason", "no_document_verification"), kv("processId", processId));
+            logger.info("Collect document data skipped: no_document_verification", action("collectDocumentData"), state("skipped"), kv("reason", "no_document_verification"), kv("processId", processId));
             return List.of();
         }
 
@@ -133,13 +133,13 @@ class DefaultUserDataStoreService implements UserDataStoreService {
             documentRequests.add(createDocumentRequest(process, entry));
         }
 
-        logger.info("", action("collectDocumentData"), kv("state", "finished"), kv("processId", processId), kv("count", documentRequests.size()));
+        logger.info("Collect document data finished", action("collectDocumentData"), kv("state", "finished"), kv("processId", processId), kv("count", documentRequests.size()));
         return documentRequests;
     }
 
     @Override
     public void storeDocumentData(final List<DocumentCreateRequest> requests) throws UserDataStoreClientException {
-        logger.info("", action("storeDocumentData"), stateInitiated(), kv("count", requests.size()));
+        logger.info("Store document data initiated", action("storeDocumentData"), stateInitiated(), kv("count", requests.size()));
 
         for (final var request : requests) {
             final AtomicInteger attemptCounter = new AtomicInteger();
@@ -149,7 +149,7 @@ class DefaultUserDataStoreService implements UserDataStoreService {
                 throw new UserDataStoreClientException("Too many attempts to create document", e);
             }
         }
-        logger.info("", action("storeDocumentData"), kv("state", "finished"));
+        logger.info("Store document data finished", action("storeDocumentData"), kv("state", "finished"));
     }
 
     private List<ProcessedDocumentDataEntity> fetchProcessedDocumentData(final Collection<DocumentVerificationEntity> documentVerifications) {
@@ -224,14 +224,14 @@ class DefaultUserDataStoreService implements UserDataStoreService {
     Void callCreateDocument(final DocumentCreateRequest request, final AtomicInteger attemptCounter) throws UserDataStoreClientException {
         final int maxAttempts = config.getMaxAttempts();
         final int attempt = attemptCounter.incrementAndGet();
-        logger.info("", action("callCreateDocument"), stateInitiated(), kv("userId", request.userId()), kv("externalId", request.externalId()), kv("documentType", request.documentType()), kv("dataType", request.dataType()), kv("attempt", attempt), kv("maxAttempts", maxAttempts));
+        logger.info("Call create document initiated", action("callCreateDocument"), stateInitiated(), kv("userId", request.userId()), kv("externalId", request.externalId()), kv("documentType", request.documentType()), kv("dataType", request.dataType()), kv("attempt", attempt), kv("maxAttempts", maxAttempts));
 
         try {
             final var response = userDataStoreClient.createDocument(request);
-            logger.info("", action("callCreateDocument"), stateSucceeded(), kv("documentId", response.id()), kv("photoIds", collectPhotoIds(response)));
+            logger.info("Call create document succeeded", action("callCreateDocument"), stateSucceeded(), kv("documentId", response.id()), kv("photoIds", collectPhotoIds(response)));
             return null;
         } catch (final UserDataStoreClientException e) {
-            logger.warn("", action("callCreateDocument"), stateFailed(), kv("attempt", attempt), kv("maxAttempts", maxAttempts));
+            logger.warn("Call create document failed", action("callCreateDocument"), stateFailed(), kv("attempt", attempt), kv("maxAttempts", maxAttempts));
             throw e;
         }
     }

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/userdatastore/NoOpUserDataStoreService.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/userdatastore/NoOpUserDataStoreService.java
@@ -34,6 +34,6 @@ class NoOpUserDataStoreService implements UserDataStoreService {
 
     @Override
     public void storeDocumentData(final List<DocumentCreateRequest> documentRequests) {
-        logger.info("", action("storeDocumentData"), state("skipped"));
+        logger.info("Store document data skipped", action("storeDocumentData"), state("skipped"));
     }
 }

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/statemachine/event/OnboardingCompletedAcceptedListener.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/statemachine/event/OnboardingCompletedAcceptedListener.java
@@ -49,15 +49,15 @@ public class OnboardingCompletedAcceptedListener {
     public void onOnboardingCompletedAccepted(final OnboardingCompletedAcceptedEvent event) {
         final var processId = event.getProcessId();
 
-        logger.info("", action("onOnboardingCompletedAccepted"), stateInitiated(), kv("processId", processId), kv("userId", event.getOwnerId().getUserId()), kv("activationId", event.getOwnerId().getActivationId()));
+        logger.info("On onboarding completed accepted initiated", action("onOnboardingCompletedAccepted"), stateInitiated(), kv("processId", processId), kv("userId", event.getOwnerId().getUserId()), kv("activationId", event.getOwnerId().getActivationId()));
 
         try {
             final var documentData = userDataStoreService.collectDocumentData(processId);
             userDataStoreService.storeDocumentData(documentData);
 
-            logger.info("", action("onOnboardingCompletedAccepted"), stateSucceeded(), kv("storedDocumentCount", documentData.size()));
+            logger.info("On onboarding completed accepted succeeded", action("onOnboardingCompletedAccepted"), stateSucceeded(), kv("storedDocumentCount", documentData.size()));
         } catch (final UserDataStoreClientException | RuntimeException e) {
-            logger.warn("", action("onOnboardingCompletedAccepted"), stateFailed(), e);
+            logger.warn("On onboarding completed accepted failed", action("onOnboardingCompletedAccepted"), stateFailed(), e);
         }
     }
 }

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/statemachine/service/StateMachineService.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/statemachine/service/StateMachineService.java
@@ -90,7 +90,7 @@ public class StateMachineService {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     boolean changeMachineState(final IdentityVerificationEntity identityVerification) {
         final var processId = identityVerification.getProcessId();
-        logger.info("", action("changeMachineState"), stateInitiated(), kv("processId", processId));
+        logger.info("Change machine state initiated", action("changeMachineState"), stateInitiated(), kv("processId", processId));
 
         final var ownerId = new OwnerId();
         ownerId.setActivationId(identityVerification.getActivationId());
@@ -99,14 +99,14 @@ public class StateMachineService {
         try {
             lockAndVerifyProcess(processId);
             processStateMachineEventInternal(ownerId, processId, OnboardingEvent.EVENT_NEXT_STATE);
-            logger.info("", action("changeMachineState"), stateSucceeded());
+            logger.info("Change machine state succeeded", action("changeMachineState"), stateSucceeded());
             return true;
         } catch (IdentityVerificationException e) {
-            logger.warn("", action("changeMachineState"), stateFailed(), kv("errorMessage", "Unable to change state for process"), e);
+            logger.warn("Change machine state failed", action("changeMachineState"), stateFailed(), kv("errorMessage", "Unable to change state for process"), e);
         } catch (final OnboardingProcessException e) {
-            logger.warn("", action("changeMachineState"), stateFailed(), kv("errorMessage", "Process not found"), e);
+            logger.warn("Change machine state failed", action("changeMachineState"), stateFailed(), kv("errorMessage", "Process not found"), e);
         } catch (final RuntimeException e) {
-            logger.warn("", action("changeMachineState"), stateFailed(), kv("errorMessage", "Exception when changing state of process"), e);
+            logger.warn("Change machine state failed", action("changeMachineState"), stateFailed(), kv("errorMessage", "Exception when changing state of process"), e);
         }
 
         return false;

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/cleaning/PersonalDataCleaningTask.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/task/cleaning/PersonalDataCleaningTask.java
@@ -45,10 +45,10 @@ public class PersonalDataCleaningTask {
 	@Scheduled(fixedDelayString = "PT10M", initialDelayString = "PT20S")
 	@SchedulerLock(name = SchedulerLockNames.CLEANUP_SELFIES_LOCK, lockAtMostFor = "5m")
 	public void cleanupSelfies() {
-		logger.info("", action("cleanupSelfies"), stateInitiated());
+		logger.info("Cleanup selfies initiated", action("cleanupSelfies"), stateInitiated());
 		LockAssert.assertLocked();
 		final int count = cleaningService.cleanSelfies();
-		logger.info("", action("cleanupSelfies"), stateSucceeded(), kv("count", count));
+		logger.info("Cleanup selfies succeeded", action("cleanupSelfies"), stateSucceeded(), kv("count", count));
 	}
 
 	/**
@@ -58,9 +58,9 @@ public class PersonalDataCleaningTask {
 	@SchedulerLock(name = SchedulerLockNames.DOCUMENT_DATA_LOCK, lockAtMostFor = "5m")
 	public void cleanupDocumentData() {
 		LockAssert.assertLocked();
-		logger.debug("", action("cleanupDocumentData"), stateInitiated());
+		logger.debug("Cleanup document data initiated", action("cleanupDocumentData"), stateInitiated());
 		final var count = cleaningService.cleanupDocumentData();
-		logger.debug("", action("cleanupDocumentData"), stateSucceeded(), kv("cleanedRecords", count));
+		logger.debug("Cleanup document data succeeded", action("cleanupDocumentData"), stateSucceeded(), kv("cleanedRecords", count));
 	}
 
 	/**
@@ -70,9 +70,9 @@ public class PersonalDataCleaningTask {
 	@SchedulerLock(name = SchedulerLockNames.DOCUMENT_RESULT_PERSONAL_DATA_LOCK, lockAtMostFor = "5m")
 	public void cleanupDocumentResultPersonalData() {
 		LockAssert.assertLocked();
-		logger.debug("", action("cleanupDocumentResultPersonalData"), stateInitiated());
+		logger.debug("Cleanup document result personal data initiated", action("cleanupDocumentResultPersonalData"), stateInitiated());
 		final var count = cleaningService.cleanupDocumentResultPersonalData();
-		logger.debug("", action("cleanupDocumentResultPersonalData"), stateSucceeded(), kv("cleanedRecords", count));
+		logger.debug("Cleanup document result personal data succeeded", action("cleanupDocumentResultPersonalData"), stateSucceeded(), kv("cleanedRecords", count));
 	}
 
 	/**
@@ -82,9 +82,9 @@ public class PersonalDataCleaningTask {
 	@SchedulerLock(name = SchedulerLockNames.PROCESSED_DOCUMENT_DATA_LOCK, lockAtMostFor = "5m")
 	public void cleanupProcessedDocumentData() {
 		LockAssert.assertLocked();
-		logger.debug("", action("cleanupProcessedDocumentData"), stateInitiated());
+		logger.debug("Cleanup processed document data initiated", action("cleanupProcessedDocumentData"), stateInitiated());
 		final var count = cleaningService.cleanupProcessedDocumentData();
-		logger.debug("", action("cleanupProcessedDocumentData"), stateSucceeded(), kv("cleanedRecords", count));
+		logger.debug("Cleanup processed document data succeeded", action("cleanupProcessedDocumentData"), stateSucceeded(), kv("cleanedRecords", count));
 	}
 }
 

--- a/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/controller/api/ActivationCodeController.java
+++ b/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/controller/api/ActivationCodeController.java
@@ -101,7 +101,7 @@ public class ActivationCodeController {
             @Parameter(hidden = true) final PowerAuthApiAuthentication apiAuthentication) throws PowerAuthAuthenticationException, InvalidRequestObjectException, ActivationCodeException, PowerAuthEncryptionException {
 
         final ActivationCodeRequest requestObject = request.getRequestObject();
-        logger.info("", action("requestActivationCode"), stateInitiated(), kv("applicationId", requestObject.getApplicationId()));
+        logger.info("Request activation code initiated", action("requestActivationCode"), stateInitiated(), kv("applicationId", requestObject.getApplicationId()));
         // Check if the authentication object is present
         if (apiAuthentication == null) {
             logger.error("Unable to verify device registration when fetching activation code");
@@ -115,7 +115,7 @@ public class ActivationCodeController {
         }
 
         final ActivationCodeResponse response = activationCodeService.requestActivationCode(requestObject, apiAuthentication);
-        logger.info("", action("requestActivationCode"), stateSucceeded());
+        logger.info("Request activation code succeeded", action("requestActivationCode"), stateSucceeded());
         return new ObjectResponse<>(response);
     }
 }

--- a/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/controller/api/ApplicationConfigurationController.java
+++ b/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/controller/api/ApplicationConfigurationController.java
@@ -73,10 +73,10 @@ public class ApplicationConfigurationController {
             @NotNull @EncryptedRequestBody @Valid final OidcApplicationConfigurationRequest request,
             @Parameter(hidden = true) final EncryptionContext encryptionContext) throws PowerAuthEncryptionException, PowerAuthApplicationConfigurationException {
 
-        logger.info("", action("fetchOidcConfiguration"), stateInitiated(), kv("providerId", request != null ? request.getProviderId() : null));
+        logger.info("Fetch oidc configuration initiated", action("fetchOidcConfiguration"), stateInitiated(), kv("providerId", request != null ? request.getProviderId() : null));
 
         if (encryptionContext == null) {
-            logger.error("", action("fetchOidcConfiguration"), stateFailed(), kv("reason", "encryptionFailed"));
+            logger.error("Fetch oidc configuration failed: encryptionFailed", action("fetchOidcConfiguration"), stateFailed(), kv("reason", "encryptionFailed"));
             throw new PowerAuthEncryptionException("Encryption failed");
         }
 
@@ -85,7 +85,7 @@ public class ApplicationConfigurationController {
                 .applicationKey(encryptionContext.getApplicationKey())
                 .build());
         final OidcApplicationConfigurationResponse result = convert(oidcApplicationConfiguration);
-        logger.info("", action("fetchOidcConfiguration"), stateSucceeded());
+        logger.info("Fetch oidc configuration succeeded", action("fetchOidcConfiguration"), stateSucceeded());
         return new ObjectResponse<>(result);
     }
 

--- a/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/controller/api/InboxController.java
+++ b/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/controller/api/InboxController.java
@@ -74,18 +74,18 @@ public class InboxController {
             PowerAuthCodeType.POSSESSION_KNOWLEDGE
     })
     public ObjectResponse<GetInboxCountResponse> countUnreadMessages(@Parameter(hidden = true) PowerAuthApiAuthentication apiAuthentication) throws InboxException, PowerAuthAuthenticationException {
-        logger.info("", action("countUnreadMessages"), stateInitiated(), kv("activationId", extractActivationId(apiAuthentication)));
+        logger.info("Count unread messages initiated", action("countUnreadMessages"), stateInitiated(), kv("activationId", extractActivationId(apiAuthentication)));
         checkApiAuthentication(apiAuthentication);
         final String userId = apiAuthentication.getUserId();
         final String appId = apiAuthentication.getApplicationId();
         final GetInboxCountResponse response = new GetInboxCountResponse();
         try {
             final ObjectResponse<GetInboxMessageCountResponse> pushResponse = pushClient.fetchMessageCountForUser(userId, appId);
-            logger.info("", action("countUnreadMessages"), stateSucceeded());
+            logger.info("Count unread messages succeeded", action("countUnreadMessages"), stateSucceeded());
             response.setCountUnread(pushResponse.getResponseObject().getCountUnread());
             return new ObjectResponse<>(response);
         } catch (PushServerClientException ex) {
-            logger.warn("", action("countUnreadMessages"), stateFailed());
+            logger.warn("Count unread messages failed", action("countUnreadMessages"), stateFailed());
             throw new InboxException("Push server REST API call failed, error: " + ex.getMessage(), ex);
         }
     }
@@ -97,7 +97,7 @@ public class InboxController {
             PowerAuthCodeType.POSSESSION_KNOWLEDGE
     })
     public ObjectResponse<GetInboxListResponse> fetchMessageList(@RequestBody ObjectRequest<GetInboxListRequest> objectRequest, @Parameter(hidden = true) PowerAuthApiAuthentication apiAuthentication) throws InboxException, PowerAuthAuthenticationException {
-        logger.info("", action("fetchMessageList"), stateInitiated(), kv("activationId", extractActivationId(apiAuthentication)));
+        logger.info("Fetch message list initiated", action("fetchMessageList"), stateInitiated(), kv("activationId", extractActivationId(apiAuthentication)));
         checkApiAuthentication(apiAuthentication);
         final String userId = apiAuthentication.getUserId();
         final String appId = apiAuthentication.getApplicationId();
@@ -108,12 +108,12 @@ public class InboxController {
         try {
             final ObjectResponse<ListOfInboxMessages> pushResponse = pushClient.fetchMessageListForUser(
                     userId, Collections.singletonList(appId), onlyUnread, page, size);
-            logger.info("", action("fetchMessageList"), stateSucceeded());
+            logger.info("Fetch message list succeeded", action("fetchMessageList"), stateSucceeded());
             final GetInboxListResponse response = new GetInboxListResponse();
             pushResponse.getResponseObject().forEach(message -> response.add(convertMessageInList(message)));
             return new PagedResponse<>(response, page, size);
         } catch (PushServerClientException ex) {
-            logger.warn("", action("fetchMessageList"), stateFailed());
+            logger.warn("Fetch message list failed", action("fetchMessageList"), stateFailed());
             throw new InboxException("Push server REST API call failed, error: " + ex.getMessage(), ex);
         }
     }
@@ -129,18 +129,18 @@ public class InboxController {
             @Parameter(hidden = true) final PowerAuthApiAuthentication apiAuthentication) throws InboxException, PowerAuthAuthenticationException {
 
         final GetInboxDetailRequest request = objectRequest.getRequestObject();
-        logger.info("", action("fetchMessageDetail"), stateInitiated(), kv("activationId", extractActivationId(apiAuthentication)), kv("messageId", request.getId()));
+        logger.info("Fetch message detail initiated", action("fetchMessageDetail"), stateInitiated(), kv("activationId", extractActivationId(apiAuthentication)), kv("messageId", request.getId()));
         checkApiAuthentication(apiAuthentication);
         final String userId = apiAuthentication.getUserId();
         final String appId = apiAuthentication.getApplicationId();
 
         try {
             final GetInboxMessageDetailResponse messageDetail = fetchInboxMessageDetail(userId, appId, request.getId());
-            logger.info("", action("fetchMessageDetail"), stateSucceeded());
+            logger.info("Fetch message detail succeeded", action("fetchMessageDetail"), stateSucceeded());
             final GetInboxDetailResponse response = convertMessageDetail(messageDetail);
             return new ObjectResponse<>(response);
         } catch (PushServerClientException ex) {
-            logger.warn("", action("fetchMessageDetail"), stateFailed());
+            logger.warn("Fetch message detail failed", action("fetchMessageDetail"), stateFailed());
             throw new InboxException("Push server REST API call failed, error: " + ex.getMessage(), ex);
         }
     }
@@ -156,7 +156,7 @@ public class InboxController {
             @Parameter(hidden = true) final PowerAuthApiAuthentication apiAuthentication) throws InboxException, PowerAuthAuthenticationException {
 
         final InboxReadRequest request = objectRequest.getRequestObject();
-        logger.info("", action("readMessage"), stateInitiated(), kv("activationId", extractActivationId(apiAuthentication)), kv("messageId", request.getId()));
+        logger.info("Read message initiated", action("readMessage"), stateInitiated(), kv("activationId", extractActivationId(apiAuthentication)), kv("messageId", request.getId()));
         checkApiAuthentication(apiAuthentication);
         final String userId = apiAuthentication.getUserId();
         final String appId = apiAuthentication.getApplicationId();
@@ -165,13 +165,13 @@ public class InboxController {
             final GetInboxMessageDetailResponse messageDetail = fetchInboxMessageDetail(userId, appId, request.getId());
             if (!messageDetail.isRead()) {
                 pushClient.readMessage(request.getId());
-                logger.info("", action("readMessage"), stateSucceeded());
+                logger.info("Read message succeeded", action("readMessage"), stateSucceeded());
             } else {
-                logger.info("", action("readMessage"), state("skipped"), kv("reason", "message is already marked as read"));
+                logger.info("Read message skipped: message is already marked as read", action("readMessage"), state("skipped"), kv("reason", "message is already marked as read"));
             }
             return new Response();
         } catch (PushServerClientException ex) {
-            logger.warn("", action("readMessage"), stateFailed());
+            logger.warn("Read message failed", action("readMessage"), stateFailed());
             throw new InboxException("Push server REST API call failed, error: " + ex.getMessage(), ex);
         }
     }
@@ -183,16 +183,16 @@ public class InboxController {
             PowerAuthCodeType.POSSESSION_KNOWLEDGE
     })
     public Response readAllMessages(@Parameter(hidden = true) PowerAuthApiAuthentication apiAuthentication) throws InboxException, PowerAuthAuthenticationException {
-        logger.info("", action("readAllMessages"), stateInitiated(), kv("activationId", extractActivationId(apiAuthentication)));
+        logger.info("Read all messages initiated", action("readAllMessages"), stateInitiated(), kv("activationId", extractActivationId(apiAuthentication)));
         checkApiAuthentication(apiAuthentication);
         final String userId = apiAuthentication.getUserId();
         final String appId = apiAuthentication.getApplicationId();
         try {
             pushClient.readAllMessages(userId, appId);
-            logger.info("", action("readAllMessages"), stateSucceeded());
+            logger.info("Read all messages succeeded", action("readAllMessages"), stateSucceeded());
             return new Response();
         } catch (PushServerClientException ex) {
-            logger.warn("", action("readAllMessages"), stateFailed());
+            logger.warn("Read all messages failed", action("readAllMessages"), stateFailed());
             throw new InboxException("Push server REST API call failed, error: " + ex.getMessage(), ex);
         }
     }

--- a/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/controller/api/MobileTokenController.java
+++ b/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/controller/api/MobileTokenController.java
@@ -108,7 +108,7 @@ public class MobileTokenController {
             PowerAuthCodeType.POSSESSION_KNOWLEDGE
     })
     public ObjectResponse<OperationListResponse> operationList(@Parameter(hidden = true) PowerAuthApiAuthentication auth, @Parameter(hidden = true) Locale locale) throws MobileTokenException, MobileTokenConfigurationException, RemoteCommunicationException {
-        logger.info("", action("operationList"), stateInitiated(), kv("activationId", extractActivationId(auth)));
+        logger.info("Operation list initiated", action("operationList"), stateInitiated(), kv("activationId", extractActivationId(auth)));
         validateApiAuthentication(auth);
 
         try {
@@ -117,22 +117,22 @@ public class MobileTokenController {
             final String activationId = auth.getActivationContext().getActivationId();
             final String language = locale.getLanguage();
             final OperationListResponse listResponse = mobileTokenService.operationListForUser(userId, applicationId, language, activationId, true);
-            logger.info("", action("operationList"), stateSucceeded());
+            logger.info("Operation list succeeded", action("operationList"), stateSucceeded());
             final Date currentTimestamp = new Date();
             return new MobileTokenResponse<>(listResponse, currentTimestamp);
         } catch (PowerAuthClientException e) {
             final String errorCode = e.getPowerAuthError().map(PowerAuthError::getCode).orElse("ERROR_CODE_MISSING");
             switch (errorCode) {
                 case APPLICATION_NOT_FOUND -> {
-                    logger.warn("", action("operationList"), stateFailed(), kv("reason", "applicationNotFound"));
+                    logger.warn("Operation list failed: applicationNotFound", action("operationList"), stateFailed(), kv("reason", "applicationNotFound"));
                     throw new MobileTokenException(ErrorCode.INVALID_APPLICATION, "No application was found with the provided identifier.", e);
                 }
                 case INVALID_REQUEST -> {
-                    logger.warn("", action("operationList"), stateFailed(), kv("reason", "validation"));
+                    logger.warn("Operation list failed: validation", action("operationList"), stateFailed(), kv("reason", "validation"));
                     throw new MobileTokenException(ErrorCode.INVALID_REQUEST, "Request validation error: %s".formatted(e.getMessage()), e);
                 }
                 default -> {
-                    logger.warn("", action("operationList"), stateFailed(), kv("reason", "powerAuthConnection"));
+                    logger.warn("Operation list failed: powerAuthConnection", action("operationList"), stateFailed(), kv("reason", "powerAuthConnection"));
                     throw new RemoteCommunicationException("Unable to call upstream service.", e);
                 }
             }
@@ -160,14 +160,14 @@ public class MobileTokenController {
             @Parameter(hidden = true) final Locale locale) throws MobileTokenException, MobileTokenConfigurationException, RemoteCommunicationException {
 
         final String operationId = request.getRequestObject().getId();
-        logger.info("", action("fetchOperationDetail"), stateInitiated(), kv("activationId", extractActivationId(auth)), kv("operationId", operationId));
+        logger.info("Fetch operation detail initiated", action("fetchOperationDetail"), stateInitiated(), kv("activationId", extractActivationId(auth)), kv("operationId", operationId));
         validateApiAuthentication(auth);
 
         try {
             final String language = locale.getLanguage();
                 final String userId = auth.getUserId();
                 final Operation response = mobileTokenService.fetchOperationDetail(operationId, language, userId);
-                logger.info("", action("fetchOperationDetail"), stateSucceeded());
+                logger.info("Fetch operation detail succeeded", action("fetchOperationDetail"), stateSucceeded());
                 final Date currentTimestamp = new Date();
                 return new MobileTokenResponse<>(response, currentTimestamp);
 
@@ -175,15 +175,15 @@ public class MobileTokenController {
             final String errorCode = e.getPowerAuthError().map(PowerAuthError::getCode).orElse("ERROR_CODE_MISSING");
             switch (errorCode) {
                 case OPERATION_NOT_FOUND -> {
-                    logger.warn("", action("fetchOperationDetail"), stateFailed(), kv("reason", "operationNotFound"));
+                    logger.warn("Fetch operation detail failed: operationNotFound", action("fetchOperationDetail"), stateFailed(), kv("reason", "operationNotFound"));
                     throw new MobileTokenException(ErrorCode.INVALID_OPERATION, "No operation was found with the provided identifier.", e);
                 }
                 case INVALID_REQUEST -> {
-                    logger.warn("", action("fetchOperationDetail"), stateFailed(), kv("reason", "validation"));
+                    logger.warn("Fetch operation detail failed: validation", action("fetchOperationDetail"), stateFailed(), kv("reason", "validation"));
                     throw new MobileTokenException(ErrorCode.INVALID_REQUEST, "Request validation error: %s".formatted(e.getMessage()), e);
                 }
                 default -> {
-                    logger.warn("", action("fetchOperationDetail"), stateFailed(), kv("reason", "powerAuthConnection"));
+                    logger.warn("Fetch operation detail failed: powerAuthConnection", action("fetchOperationDetail"), stateFailed(), kv("reason", "powerAuthConnection"));
                     throw new RemoteCommunicationException("Unable to call upstream service.", e);
                 }
             }
@@ -211,14 +211,14 @@ public class MobileTokenController {
             @Parameter(hidden = true) final Locale locale) throws MobileTokenException, MobileTokenConfigurationException, RemoteCommunicationException {
 
         final String operationId = request.getRequestObject().getId();
-        logger.info("", action("claimOperation"), stateInitiated(), kv("activationId", extractActivationId(auth)), kv("operationId", operationId));
+        logger.info("Claim operation initiated", action("claimOperation"), stateInitiated(), kv("activationId", extractActivationId(auth)), kv("operationId", operationId));
         validateApiAuthentication(auth);
 
         try {
             final String language = locale.getLanguage();
                 final String userId = auth.getUserId();
                 final Operation response = mobileTokenService.claimOperation(operationId, language, userId);
-                logger.info("", action("claimOperation"), stateSucceeded());
+                logger.info("Claim operation succeeded", action("claimOperation"), stateSucceeded());
                 final Date currentTimestamp = new Date();
                 return new MobileTokenResponse<>(response, currentTimestamp);
 
@@ -226,15 +226,15 @@ public class MobileTokenController {
             final String errorCode = e.getPowerAuthError().map(PowerAuthError::getCode).orElse("ERROR_CODE_MISSING");
             switch (errorCode) {
                 case OPERATION_NOT_FOUND -> {
-                    logger.warn("", action("claimOperation"), stateFailed(), kv("reason", "operationNotFound"));
+                    logger.warn("Claim operation failed: operationNotFound", action("claimOperation"), stateFailed(), kv("reason", "operationNotFound"));
                     throw new MobileTokenException(ErrorCode.INVALID_OPERATION, "No operation was found with the provided identifier.", e);
                 }
                 case INVALID_REQUEST -> {
-                    logger.warn("", action("claimOperation"), stateFailed(), kv("reason", "validation"));
+                    logger.warn("Claim operation failed: validation", action("claimOperation"), stateFailed(), kv("reason", "validation"));
                     throw new MobileTokenException(ErrorCode.INVALID_REQUEST, "Request validation error: %s".formatted(e.getMessage()), e);
                 }
                 default -> {
-                    logger.warn("", action("claimOperation"), stateFailed(), kv("reason", "powerAuthConnection"));
+                    logger.warn("Claim operation failed: powerAuthConnection", action("claimOperation"), stateFailed(), kv("reason", "powerAuthConnection"));
                     throw new RemoteCommunicationException("Unable to call upstream service.", e);
                 }
             }
@@ -256,7 +256,7 @@ public class MobileTokenController {
             PowerAuthCodeType.POSSESSION_KNOWLEDGE
     })
     public ObjectResponse<OperationListResponse> operationListAll(@Parameter(hidden = true) PowerAuthApiAuthentication auth, @Parameter(hidden = true) Locale locale) throws MobileTokenException, MobileTokenConfigurationException, RemoteCommunicationException {
-        logger.info("", action("operationListAll"), stateInitiated(), kv("activationId", extractActivationId(auth)));
+        logger.info("Operation list all initiated", action("operationListAll"), stateInitiated(), kv("activationId", extractActivationId(auth)));
         validateApiAuthentication(auth);
 
         try {
@@ -265,21 +265,21 @@ public class MobileTokenController {
             final String activationId = auth.getActivationContext().getActivationId();
             final String language = locale.getLanguage();
             final OperationListResponse listResponse = mobileTokenService.operationListForUser(userId, applicationId, language, activationId, false);
-            logger.info("", action("operationListAll"), stateSucceeded());
+            logger.info("Operation list all succeeded", action("operationListAll"), stateSucceeded());
             return new ObjectResponse<>(listResponse);
         } catch (PowerAuthClientException e) {
             final String errorCode = e.getPowerAuthError().map(PowerAuthError::getCode).orElse("ERROR_CODE_MISSING");
             switch (errorCode) {
                 case APPLICATION_NOT_FOUND -> {
-                    logger.warn("", action("operationListAll"), stateFailed(), kv("reason", "applicationNotFound"));
+                    logger.warn("Operation list all failed: applicationNotFound", action("operationListAll"), stateFailed(), kv("reason", "applicationNotFound"));
                     throw new MobileTokenException(ErrorCode.INVALID_APPLICATION, "No application was found with the provided identifier.", e);
                 }
                 case INVALID_REQUEST -> {
-                    logger.warn("", action("operationListAll"), stateFailed(), kv("reason", "validation"));
+                    logger.warn("Operation list all failed: validation", action("operationListAll"), stateFailed(), kv("reason", "validation"));
                     throw new MobileTokenException(ErrorCode.INVALID_REQUEST, "Request validation error: %s".formatted(e.getMessage()), e);
                 }
                 default -> {
-                    logger.warn("", action("operationListAll"), stateFailed(), kv("reason", "powerAuthConnection"));
+                    logger.warn("Operation list all failed: powerAuthConnection", action("operationListAll"), stateFailed(), kv("reason", "powerAuthConnection"));
                     throw new RemoteCommunicationException("Unable to call upstream service.", e);
                 }
             }
@@ -308,7 +308,7 @@ public class MobileTokenController {
 
         final OperationApproveRequest requestObject = request.getRequestObject();
         final String operationId = requestObject.getId();
-        logger.info("", action("operationApprove"), stateInitiated(), kv("activationId", extractActivationId(auth)), kv("operationId", operationId));
+        logger.info("Operation approve initiated", action("operationApprove"), stateInitiated(), kv("activationId", extractActivationId(auth)), kv("operationId", operationId));
 
         try {
             final String data = requestObject.getData();
@@ -339,7 +339,7 @@ public class MobileTokenController {
                         .build();
 
                 final Response response = mobileTokenService.operationApprove(serviceRequest);
-                logger.info("", action("operationApprove"), stateSucceeded());
+                logger.info("Operation approve succeeded", action("operationApprove"), stateSucceeded());
                 return response;
             } else {
                 // make sure to fail operation as well, to increase the failed number
@@ -351,19 +351,19 @@ public class MobileTokenController {
             final String errorCode = e.getPowerAuthError().map(PowerAuthError::getCode).orElse("ERROR_CODE_MISSING");
             switch (errorCode) {
                 case APPLICATION_NOT_FOUND -> {
-                    logger.warn("", action("operationApprove"), stateFailed(), kv("reason", "applicationNotFound"));
+                    logger.warn("Operation approve failed: applicationNotFound", action("operationApprove"), stateFailed(), kv("reason", "applicationNotFound"));
                     throw new MobileTokenException(ErrorCode.INVALID_APPLICATION, "No application was found with the provided identifier.", e);
                 }
                 case OPERATION_NOT_FOUND, OPERATION_APPROVE_FAILURE, OPERATION_INVALID_STATE -> {
-                    logger.warn("", action("operationApprove"), stateFailed(), kv("reason", "operationNotFoundOrInvalidState"));
+                    logger.warn("Operation approve failed: operationNotFoundOrInvalidState", action("operationApprove"), stateFailed(), kv("reason", "operationNotFoundOrInvalidState"));
                     throw new MobileTokenException(ErrorCode.INVALID_OPERATION, "Operation not found or is in an unexpected state.", e);
                 }
                 case INVALID_REQUEST -> {
-                    logger.warn("", action("operationApprove"), stateFailed(), kv("reason", "validation"));
+                    logger.warn("Operation approve failed: validation", action("operationApprove"), stateFailed(), kv("reason", "validation"));
                     throw new MobileTokenException(ErrorCode.INVALID_REQUEST, "Request validation error: %s".formatted(e.getMessage()), e);
                 }
                 default -> {
-                    logger.warn("", action("operationApprove"), stateFailed(), kv("reason", "powerAuthConnection"));
+                    logger.warn("Operation approve failed: powerAuthConnection", action("operationApprove"), stateFailed(), kv("reason", "powerAuthConnection"));
                     throw new RemoteCommunicationException("Unable to call upstream service.", e);
                 }
             }
@@ -399,7 +399,7 @@ public class MobileTokenController {
 
         final OperationRejectRequest requestObject = request.getRequestObject();
         final String operationId = requestObject.getId();
-        logger.info("", action("operationReject"), stateInitiated(), kv("activationId", extractActivationId(auth)), kv("operationId", operationId));
+        logger.info("Operation reject initiated", action("operationReject"), stateInitiated(), kv("activationId", extractActivationId(auth)), kv("operationId", operationId));
 
         try {
             if (auth != null && auth.getUserId() != null) {
@@ -413,7 +413,7 @@ public class MobileTokenController {
                         .requestContext(RequestContextConverter.convert(servletRequest))
                         .mobileTokenData(requestObject.getMobileTokenData())
                         .build());
-                logger.info("", action("operationReject"), stateSucceeded());
+                logger.info("Operation reject succeeded", action("operationReject"), stateSucceeded());
                 return result;
             } else {
                 throw new MobileTokenAuthException();
@@ -422,19 +422,19 @@ public class MobileTokenController {
             final String errorCode = e.getPowerAuthError().map(PowerAuthError::getCode).orElse("ERROR_CODE_MISSING");
             switch (errorCode) {
                 case APPLICATION_NOT_FOUND -> {
-                    logger.warn("", action("operationReject"), stateFailed(), kv("reason", "applicationNotFound"));
+                    logger.warn("Operation reject failed: applicationNotFound", action("operationReject"), stateFailed(), kv("reason", "applicationNotFound"));
                     throw new MobileTokenException(ErrorCode.INVALID_APPLICATION, "No application was found with the provided identifier: %s".formatted(auth.getApplicationId()), e);
                 }
                 case OPERATION_NOT_FOUND, OPERATION_REJECT_FAILURE -> {
-                    logger.warn("", action("operationReject"), stateFailed(), kv("reason", "operationNotFoundOrInvalidState"));
+                    logger.warn("Operation reject failed: operationNotFoundOrInvalidState", action("operationReject"), stateFailed(), kv("reason", "operationNotFoundOrInvalidState"));
                     throw new MobileTokenException(ErrorCode.INVALID_OPERATION, "Operation not found or is in an unexpected state", e);
                 }
                 case INVALID_REQUEST -> {
-                    logger.warn("", action("operationReject"), stateFailed(), kv("reason", "validation"));
+                    logger.warn("Operation reject failed: validation", action("operationReject"), stateFailed(), kv("reason", "validation"));
                     throw new MobileTokenException(ErrorCode.INVALID_REQUEST, "Request validation error: %s".formatted(e.getMessage()), e);
                 }
                 default -> {
-                    logger.warn("", action("operationReject"), stateFailed(), kv("reason", "powerAuthConnection"));
+                    logger.warn("Operation reject failed: powerAuthConnection", action("operationReject"), stateFailed(), kv("reason", "powerAuthConnection"));
                     throw new RemoteCommunicationException("Unable to call upstream service.", e);
                 }
             }

--- a/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/controller/api/PushRegistrationController.java
+++ b/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/controller/api/PushRegistrationController.java
@@ -71,9 +71,9 @@ public class PushRegistrationController {
     public Response registerDeviceDefault(@RequestBody ObjectRequest<PushRegisterRequest> request, @Parameter(hidden = true) PowerAuthApiAuthentication apiAuthentication) throws PowerAuthAuthenticationException, InvalidRequestObjectException, PushRegistrationFailedException {
         validateApiAuthentication(apiAuthentication);
 
-        logger.info("", action("registerDeviceDefault"), stateInitiated(), kv("userId", apiAuthentication.getUserId()));
+        logger.info("Register device default initiated", action("registerDeviceDefault"), stateInitiated(), kv("userId", apiAuthentication.getUserId()));
         final Response response = pushRegistrationService.registerDevice(request, apiAuthentication);
-        logger.info("", action("registerDeviceDefault"), stateSucceeded());
+        logger.info("Register device default succeeded", action("registerDeviceDefault"), stateSucceeded());
         return response;
     }
 
@@ -96,9 +96,9 @@ public class PushRegistrationController {
     public Response registerDeviceToken(@RequestBody ObjectRequest<PushRegisterRequest> request, @Parameter(hidden = true) PowerAuthApiAuthentication apiAuthentication) throws PowerAuthAuthenticationException, InvalidRequestObjectException, PushRegistrationFailedException {
         validateApiAuthentication(apiAuthentication);
 
-        logger.info("", action("registerDeviceToken"), stateInitiated(), kv("userId", apiAuthentication.getUserId()));
+        logger.info("Register device token initiated", action("registerDeviceToken"), stateInitiated(), kv("userId", apiAuthentication.getUserId()));
         final Response response = pushRegistrationService.registerDevice(request, apiAuthentication);
-        logger.info("", action("registerDeviceToken"), stateSucceeded());
+        logger.info("Register device token succeeded", action("registerDeviceToken"), stateSucceeded());
         return response;
     }
 

--- a/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/controller/api/admin/AdminController.java
+++ b/enrollment-server/src/main/java/com/wultra/app/enrollmentserver/controller/api/admin/AdminController.java
@@ -55,10 +55,10 @@ public class AdminController {
 
     @GetMapping("/template")
     public ObjectResponse<TemplateListResponse> templates() {
-        logger.info("", action("templates"), stateInitiated());
+        logger.info("Templates initiated", action("templates"), stateInitiated());
         final TemplateListResponse response = new TemplateListResponse();
         response.addAll(convert(operationTemplateService.findAll()));
-        logger.info("", action("templates"), stateSucceeded());
+        logger.info("Templates succeeded", action("templates"), stateSucceeded());
         return new ObjectResponse<>(response);
     }
 


### PR DESCRIPTION
🤖

## Summary
Fixes #1819 (part of epic wultra/tasklist#992).

Structured log calls were logging an **empty message string**, e.g.:
```java
logger.info("", action("operationList"), stateInitiated(), kv("activationId", id));
```
Because the Logstash encoder is configured with `<omitEmptyFields>true</omitEmptyFields>`, the empty `message` field was dropped and indexed as `null` in Elasticsearch. Old-style logs (with a real message) were unaffected.

## Change
Add a concise, human-readable message to every structured log call, derived deterministically from the existing structured arguments — `action` + `state` (+ `reason` on failure/skip). All structured arguments (`action(...)`, `state...()`, `kv(...)`) are left **unchanged**, so existing Elastic dashboards/queries keyed on those fields keep working.

Example:
```java
logger.warn("Operation list failed: validation", action("operationList"), stateFailed(), kv("reason", "validation"));
```

Message templates by state: `initiated`→"… initiated", `succeeded`→"… succeeded", `finished`→"… finished", `failed`/`skipped`→"… failed/skipped: <reason>", `unsupported`→"… not supported".

## Scope
165 call sites across 21 files in `enrollment-server`, `enrollment-server-onboarding`, and the microblink/innovatrics provider modules. No logback/encoder config change (`omitEmptyFields=true` stays).

The other two components from the epic — `liveness-check-proxy` and `user-data-store` — are tracked by their own bug issues in their repositories.

## Validation
- `BUILD SUCCESS` (compile, JDK 25).
- No tests assert on log output.
