### PR TITLE
Fix #1832: Fix issues found by Coverity scan

### DIFF
--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/IdentityVerificationRestService.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/IdentityVerificationRestService.java
@@ -422,7 +422,7 @@ public class IdentityVerificationRestService {
         StateMachine<OnboardingState, OnboardingEvent> stateMachine = stateMachineService.processStateMachineEvent(ownerId, processId, OnboardingEvent.PRESENCE_CHECK_INIT);
 
         @SuppressWarnings("unchecked")
-        final Class<ObjectResponse<PresenceCheckInitResponse>> presenceCheckInitResponseClass = (Class<ObjectResponse<PresenceCheckInitResponse>>) new ObjectResponse<PresenceCheckInitResponse>().getClass();
+        final Class<ObjectResponse<PresenceCheckInitResponse>> presenceCheckInitResponseClass = (Class<ObjectResponse<PresenceCheckInitResponse>>) (Class<?>) ObjectResponse.class;
         return createResponseEntity(stateMachine, presenceCheckInitResponseClass);
     }
 

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/OnboardingEventService.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/OnboardingEventService.java
@@ -315,14 +315,14 @@ public class OnboardingEventService {
                 .build();
     }
 
-    private List<DocumentVerificationFinishedEventData.Image> buildImages(final DocumentVerificationEntity doc) {
+    private List<DocumentVerificationFinishedEventData.DocumentImage> buildImages(final DocumentVerificationEntity doc) {
         final List<ProcessedDocumentDataEntity> entities =
                 processedDocumentDataRepository.findAllByDocumentVerificationIds(Set.of(doc.getId()));
         if (entities.isEmpty()) {
             return List.of();
         }
         return entities.stream()
-                .map(it -> DocumentVerificationFinishedEventData.Image.builder()
+                .map(it -> DocumentVerificationFinishedEventData.DocumentImage.builder()
                         .type(it.getDataType().name())
                         .data(Base64.getEncoder().encodeToString(it.getData()))
                         .build())

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/userdatastore/DefaultUserDataStoreService.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/userdatastore/DefaultUserDataStoreService.java
@@ -192,7 +192,7 @@ class DefaultUserDataStoreService implements UserDataStoreService {
                 .build();
     }
 
-    private DocumentsWrapper fetchDocumentVerifications(final IdentityVerificationEntity idVerification, UserDataStoreConfigProperties.DocumentType documentType) {
+    private DocumentsWrapper fetchDocumentVerifications(final IdentityVerificationEntity idVerification, UserDataStoreConfigProperties.DocumentTypeFilter documentType) {
         final Map<DocumentType, List<DocumentVerificationEntity>> documentVerifications = documentVerificationRepository.findAcceptedWithPhoto(idVerification).stream()
                 .collect(Collectors.groupingBy(
                         DocumentVerificationEntity::getType,

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/userdatastore/UserDataStoreConfigProperties.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/impl/service/userdatastore/UserDataStoreConfigProperties.java
@@ -45,7 +45,7 @@ class UserDataStoreConfigProperties {
      * Type of documents to store.
      */
     @NotNull
-    private DocumentType documentType;
+    private DocumentTypeFilter documentType;
 
     /**
      * Whether to store extracted data from documents.
@@ -65,7 +65,7 @@ class UserDataStoreConfigProperties {
     /**
      * Document type filtering.
      */
-    enum DocumentType {
+    enum DocumentTypeFilter {
 
         /**
          * Store only documents with trusted images.

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/provider/model/request/DocumentVerificationFinishedEventData.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/provider/model/request/DocumentVerificationFinishedEventData.java
@@ -53,7 +53,7 @@ public record DocumentVerificationFinishedEventData(
             String type,
             String country,
             DocumentData data,
-            List<Image> images,
+            List<DocumentImage> images,
             Object rawData
     ) {}
 
@@ -75,7 +75,7 @@ public record DocumentVerificationFinishedEventData(
 
     @Builder
     @PublicApi
-    public record Image(
+    public record DocumentImage(
             @NonNull String type,
             @NonNull String data
     ) {}

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/provider/rest/DocumentVerificationFinishedEventDataDto.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/provider/rest/DocumentVerificationFinishedEventDataDto.java
@@ -46,7 +46,7 @@ record DocumentVerificationFinishedEventDataDto(DocumentVerification documentVer
             String type,
             String country,
             DocumentData data,
-            List<Image> images,
+            List<DocumentImage> images,
             Object rawData
     ) {}
 
@@ -66,7 +66,7 @@ record DocumentVerificationFinishedEventDataDto(DocumentVerification documentVer
     ) {}
 
     @Builder
-    public record Image(
+    public record DocumentImage(
             String type,
             String data
     ) {}

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/provider/rest/ProcessFinishedEventDataDto.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/provider/rest/ProcessFinishedEventDataDto.java
@@ -27,10 +27,10 @@ import java.util.Map;
  * @author Lubos Racansky, lubos.racansky@wultra.com
  */
 @Builder
-record ProcessFinishedEventDataDto(Process process) implements EventDataDto {
+record ProcessFinishedEventDataDto(ProcessInfo process) implements EventDataDto {
 
     @Builder
-    public record Process(
+    public record ProcessInfo(
             String status,
             String errorDetail,
             DeviceData deviceData

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/provider/rest/RestOnboardingProvider.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/provider/rest/RestOnboardingProvider.java
@@ -268,7 +268,7 @@ public class RestOnboardingProvider implements OnboardingProvider {
 
     private static ProcessFinishedEventDataDto convert(final ProcessFinishedEventData source) {
         return ProcessFinishedEventDataDto.builder()
-                .process(ProcessFinishedEventDataDto.Process.builder()
+                .process(ProcessFinishedEventDataDto.ProcessInfo.builder()
                         .status(source.status().name())
                         .errorDetail(source.errorDetail())
                         .deviceData(convert(source.deviceData()))
@@ -339,10 +339,10 @@ public class RestOnboardingProvider implements OnboardingProvider {
                 .build();
     }
 
-    private static DocumentVerificationFinishedEventDataDto.Image convert(
-            final DocumentVerificationFinishedEventData.Image source) {
+    private static DocumentVerificationFinishedEventDataDto.DocumentImage convert(
+            final DocumentVerificationFinishedEventData.DocumentImage source) {
 
-        return DocumentVerificationFinishedEventDataDto.Image.builder()
+        return DocumentVerificationFinishedEventDataDto.DocumentImage.builder()
                 .type(source.type())
                 .data(source.data())
                 .build();

--- a/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/statemachine/event/OnboardingCompletedAcceptedEvent.java
+++ b/enrollment-server-onboarding/src/main/java/com/wultra/app/onboardingserver/statemachine/event/OnboardingCompletedAcceptedEvent.java
@@ -29,7 +29,7 @@ import org.springframework.context.ApplicationEvent;
 @Getter
 public class OnboardingCompletedAcceptedEvent extends ApplicationEvent {
 
-    private final OwnerId ownerId;
+    private final transient OwnerId ownerId;
     private final String processId;
 
     /**

--- a/enrollment-server-onboarding/src/test/java/com/wultra/app/onboardingserver/provider/rest/ProcessEventRequestDtoSerializationTest.java
+++ b/enrollment-server-onboarding/src/test/java/com/wultra/app/onboardingserver/provider/rest/ProcessEventRequestDtoSerializationTest.java
@@ -49,7 +49,7 @@ class ProcessEventRequestDtoSerializationTest {
         dto.setExternalUserId("629199e8-aa0d-4fc0-911c-089d53e0f608");
         dto.setType(EventTypeDto.PROCESS_FINISHED);
         dto.setEventData(ProcessFinishedEventDataDto.builder()
-                .process(ProcessFinishedEventDataDto.Process.builder()
+                .process(ProcessFinishedEventDataDto.ProcessInfo.builder()
                         .status("FINISHED")
                         .errorDetail(null)
                         .deviceData(ProcessFinishedEventDataDto.DeviceData.builder()
@@ -116,7 +116,7 @@ class ProcessEventRequestDtoSerializationTest {
                                         .dateOfBirth("1980-01-01")
                                         .documentNumber("AB123456")
                                         .build())
-                                .images(List.of(DocumentVerificationFinishedEventDataDto.Image.builder()
+                                .images(List.of(DocumentVerificationFinishedEventDataDto.DocumentImage.builder()
                                         .type("FACE")
                                         .data("base64data")
                                         .build()))

--- a/enrollment-server-onboarding/src/test/java/com/wultra/app/onboardingserver/provider/rest/RestOnboardingProviderTest.java
+++ b/enrollment-server-onboarding/src/test/java/com/wultra/app/onboardingserver/provider/rest/RestOnboardingProviderTest.java
@@ -166,7 +166,7 @@ class RestOnboardingProviderTest {
         assertEquals(EventTypeDto.PROCESS_FINISHED, requestDto.getType());
 
         final var expected = ProcessFinishedEventDataDto.builder()
-                .process(ProcessFinishedEventDataDto.Process.builder()
+                .process(ProcessFinishedEventDataDto.ProcessInfo.builder()
                         .status("FINISHED")
                         .errorDetail(null)
                         .deviceData(ProcessFinishedEventDataDto.DeviceData.builder()


### PR DESCRIPTION
Fixes 6 Coverity scan findings in the `enrollment-server-onboarding` module: four inner types (`Process`, two `Image`s, `DocumentType`) were renamed to avoid shadowing JDK identifiers (`java.lang.Process`, `java.awt.Image`, and `DocumentType`); the non-serializable `ownerId` field in `OnboardingCompletedAcceptedEvent` was marked `transient` to resolve a bad-serializable-field warning; and an unnecessary object instantiation used solely to call `.getClass()` in `IdentityVerificationRestService` was replaced with a direct `.class` reference. All 226 tests pass.