### PR TITLE
Fix #1853: [2.1.2] Fix failing checksum check for Liquibase migration

### DIFF
--- a/docs/db/changelog/changesets/enrollment-server-onboarding/2.0.x/20260116-add-processed-document-data-table.xml
+++ b/docs/db/changelog/changesets/enrollment-server-onboarding/2.0.x/20260116-add-processed-document-data-table.xml
@@ -64,7 +64,7 @@
     </changeSet>
 
     <changeSet id="6" logicalFilePath="enrollment-server-onboarding/2.0.x/20260116-add-processed-document-data-table.xml" author="Michal Rozehnal">
-        <validCheckSum>ANY</validCheckSum>
+        <validCheckSum>9:d4d9d5d4f6b825c46f301e0fdd12fd1c</validCheckSum>
         <preConditions>
             <not>
                 <indexExists tableName="es_document_verification" indexName="es_document_verification_upload_id_idx"/>

--- a/docs/db/changelog/changesets/enrollment-server-onboarding/2.0.x/20260116-add-processed-document-data-table.xml
+++ b/docs/db/changelog/changesets/enrollment-server-onboarding/2.0.x/20260116-add-processed-document-data-table.xml
@@ -64,6 +64,7 @@
     </changeSet>
 
     <changeSet id="6" logicalFilePath="enrollment-server-onboarding/2.0.x/20260116-add-processed-document-data-table.xml" author="Michal Rozehnal">
+        <validCheckSum>ANY</validCheckSum>
         <preConditions>
             <not>
                 <indexExists tableName="es_document_verification" indexName="es_document_verification_upload_id_idx"/>

--- a/docs/db/changelog/changesets/enrollment-server-onboarding/2.1.x/20260430-drop-duplicate-document-data-index.xml
+++ b/docs/db/changelog/changesets/enrollment-server-onboarding/2.1.x/20260430-drop-duplicate-document-data-index.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.33.xsd">
+
+    <changeSet id="1" logicalFilePath="enrollment-server-onboarding/2.1.x/20260430-drop-duplicate-document-data-index.xml" author="Michal Rozehnal">
+        <preConditions onFail="MARK_RAN">
+            <indexExists tableName="es_document_data" indexName="es_document_data_timestamp_created_idx"/>
+        </preConditions>
+        <comment>Drop duplicate index es_document_data_timestamp_created_idx (already covered by document_data_timestamp from 1.4.x)</comment>
+        <dropIndex tableName="es_document_data" indexName="es_document_data_timestamp_created_idx"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/docs/db/changelog/changesets/enrollment-server-onboarding/2.1.x/20260430-drop-duplicate-document-data-index.xml
+++ b/docs/db/changelog/changesets/enrollment-server-onboarding/2.1.x/20260430-drop-duplicate-document-data-index.xml
@@ -3,12 +3,15 @@
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.33.xsd">
 
-    <changeSet id="1" logicalFilePath="enrollment-server-onboarding/2.1.x/20260430-drop-duplicate-document-data-index.xml" author="Michal Rozehnal">
+    <changeSet id="1" logicalFilePath="enrollment-server-onboarding/2.1.x/20260430-drop-duplicate-document-data-index.xml" author="Michal Rozehnal"
+               runInTransaction="false">
         <preConditions onFail="MARK_RAN">
             <indexExists tableName="es_document_data" indexName="es_document_data_timestamp_created_idx"/>
         </preConditions>
         <comment>Drop duplicate index es_document_data_timestamp_created_idx (already covered by document_data_timestamp from 1.4.x)</comment>
-        <dropIndex tableName="es_document_data" indexName="es_document_data_timestamp_created_idx"/>
+        <sql dbms="postgresql">
+            DROP INDEX CONCURRENTLY IF EXISTS es_document_data_timestamp_created_idx
+        </sql>
     </changeSet>
 
 </databaseChangeLog>

--- a/docs/db/changelog/changesets/enrollment-server-onboarding/2.1.x/20260803-add-tag-2.1.2.xml
+++ b/docs/db/changelog/changesets/enrollment-server-onboarding/2.1.x/20260803-add-tag-2.1.2.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.33.xsd">
+
+    <changeSet id="1" logicalFilePath="enrollment-server-onboarding/2.1.x/20260803-add-tag-2.1.2.xml" author="Michal Rozehnal">
+        <tagDatabase tag="enrollment-server-onboarding/2.1.2"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/docs/db/changelog/changesets/enrollment-server-onboarding/2.1.x/db.changelog-version.xml
+++ b/docs/db/changelog/changesets/enrollment-server-onboarding/2.1.x/db.changelog-version.xml
@@ -6,5 +6,7 @@
     <include file="20260330-audit-subject-id.xml" relativeToChangelogFile="true" />
     <include file="20260423-document-result-anonymized-column.xml" relativeToChangelogFile="true" />
     <include file="20260424-add-tag-2.1.0.xml" relativeToChangelogFile="true" />
+    <include file="20260430-drop-duplicate-document-data-index.xml" relativeToChangelogFile="true" />
+    <include file="20260803-add-tag-2.1.2.xml" relativeToChangelogFile="true" />
 
 </databaseChangeLog>

--- a/docs/onboarding/PowerAuth-Enrollment-Onboarding-Server-2.1.0.md
+++ b/docs/onboarding/PowerAuth-Enrollment-Onboarding-Server-2.1.0.md
@@ -45,6 +45,14 @@ the table was never used in production and all these metadata are stored in `es_
 linked to `es_document_data` records via `upload_id` column.
 
 
+### Duplicate Index on `es_document_data`
+
+A duplicate index `es_document_data_timestamp_created_idx` on column `timestamp_created` of table `es_document_data` is dropped.
+This index was mistakenly introduced and is already covered by the existing `document_data_timestamp` index created in version `1.4.x`.
+
+This release version fixes liquibase checksum for changeset `enrollment-server-onboarding/2.0.x/20260116-add-processed-document-data-table.xml::6` by adding the `<validCheckSum>` declaration
+
+
 ### Selfie
 
 A new table `es_selfie` has been added to temporarily store selfie images of identity verification.

--- a/docs/sql/postgresql/onboarding/create-schema.sql
+++ b/docs/sql/postgresql/onboarding/create-schema.sql
@@ -363,3 +363,6 @@ ALTER TABLE es_document_result ALTER COLUMN  anonymized SET DEFAULT FALSE;
 -- Changeset enrollment-server-onboarding/2.1.x/20260423-document-result-anonymized-column.xml::3::Michal Rozehnal
 -- Add index on anonymized column in es_document_result table
 CREATE INDEX es_document_result_anonymized_idx ON es_document_result(anonymized);
+-- Changeset enrollment-server-onboarding/2.1.x/20260430-drop-duplicate-document-data-index.xml::1::Michal Rozehnal
+-- Drop duplicate index es_document_data_timestamp_created_idx (already covered by document_data_timestamp from 1.4.x)
+DROP INDEX IF EXISTS es_document_data_timestamp_created_idx;

--- a/docs/sql/postgresql/onboarding/create-schema.sql
+++ b/docs/sql/postgresql/onboarding/create-schema.sql
@@ -363,6 +363,3 @@ ALTER TABLE es_document_result ALTER COLUMN  anonymized SET DEFAULT FALSE;
 -- Changeset enrollment-server-onboarding/2.1.x/20260423-document-result-anonymized-column.xml::3::Michal Rozehnal
 -- Add index on anonymized column in es_document_result table
 CREATE INDEX es_document_result_anonymized_idx ON es_document_result(anonymized);
--- Changeset enrollment-server-onboarding/2.1.x/20260430-drop-duplicate-document-data-index.xml::1::Michal Rozehnal
--- Drop duplicate index es_document_data_timestamp_created_idx (already covered by document_data_timestamp from 1.4.x)
-DROP INDEX IF EXISTS es_document_data_timestamp_created_idx;

--- a/docs/sql/postgresql/onboarding/migration_1.10.0_2.1.0.sql
+++ b/docs/sql/postgresql/onboarding/migration_1.10.0_2.1.0.sql
@@ -137,4 +137,4 @@ CREATE INDEX es_document_result_anonymized_idx ON es_document_result(anonymized)
 
 -- Changeset enrollment-server-onboarding/2.1.x/20260430-drop-duplicate-document-data-index.xml::1::Michal Rozehnal
 -- Drop duplicate index es_document_data_timestamp_created_idx (already covered by document_data_timestamp from 1.4.x)
-DROP INDEX IF EXISTS es_document_data_timestamp_created_idx;
+DROP INDEX CONCURRENTLY IF EXISTS es_document_data_timestamp_created_idx;

--- a/docs/sql/postgresql/onboarding/migration_1.10.0_2.1.0.sql
+++ b/docs/sql/postgresql/onboarding/migration_1.10.0_2.1.0.sql
@@ -134,3 +134,7 @@ ALTER TABLE es_document_result ALTER COLUMN  anonymized SET DEFAULT FALSE;
 -- Changeset enrollment-server-onboarding/2.1.x/20260423-document-result-anonymized-column.xml::3::Michal Rozehnal
 -- Add index on anonymized column in es_document_result table
 CREATE INDEX es_document_result_anonymized_idx ON es_document_result(anonymized);
+
+-- Changeset enrollment-server-onboarding/2.1.x/20260430-drop-duplicate-document-data-index.xml::1::Michal Rozehnal
+-- Drop duplicate index es_document_data_timestamp_created_idx (already covered by document_data_timestamp from 1.4.x)
+DROP INDEX IF EXISTS es_document_data_timestamp_created_idx;


### PR DESCRIPTION
# Functional description

- Add liquibase `<validCheckSum>` for overriding already released and modified changeset
- Drop duplicated index `es_document_data_timestamp_created_idx` if exists